### PR TITLE
style(ui): DS conformance — settings/resell/proactive/materials

### DIFF
--- a/app/templates/htmx/partials/materials/add_modal.html
+++ b/app/templates/htmx/partials/materials/add_modal.html
@@ -63,7 +63,7 @@
         </div>
       </div>
     </div>
-    <p class="mt-4 text-xs text-gray-400">Only the MPN is required — anything left blank is filled by enrichment, never guessed.</p>
+    <p class="mt-4 text-secondary">Only the MPN is required — anything left blank is filled by enrichment, never guessed.</p>
     <div class="mt-6 flex justify-end gap-3 pt-4 border-t border-gray-100">
       <button type="button" @click="$dispatch('close-modal')"
               class="btn-secondary">Cancel</button>

--- a/app/templates/htmx/partials/materials/crosses_section.html
+++ b/app/templates/htmx/partials/materials/crosses_section.html
@@ -54,7 +54,7 @@
             hx-post="/v2/partials/materials/{{ card.id }}/find-crosses"
               hx-target="#crosses-section"
               hx-swap="outerHTML"
-              class="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-md hover:bg-brand-100 transition-colors">
+              class="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 transition-colors">
         <svg class="h-3 w-3 htmx-indicator animate-spin" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>

--- a/app/templates/htmx/partials/materials/detail.html
+++ b/app/templates/htmx/partials/materials/detail.html
@@ -47,7 +47,7 @@
       <div class="text-right space-y-1.5 ml-6 flex-shrink-0">
         <p class="text-sm text-gray-600">Searches: <span class="figure-accent">{{ card.search_count or 0 }}</span></p>
         {% if card.last_searched_at %}
-        <p class="text-xs text-gray-400">Last: {{ card.last_searched_at.strftime('%b %d, %Y') }}</p>
+        <p class="text-secondary">Last: {{ card.last_searched_at.strftime('%b %d, %Y') }}</p>
         {% endif %}
         {# Enrichment-status badge — polls itself while the card is queued (HTTP 286
            stops the poll once the worker lands a terminal status). #}
@@ -129,16 +129,16 @@
 
       {# Display mode #}
       <div x-show="!editing" x-cloak class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-        <div><span class="text-gray-400 text-xs font-medium block mb-0.5">Category</span> <span class="font-medium text-gray-900">{{ card.category or "--" }}</span></div>
-        <div><span class="text-gray-400 text-xs font-medium block mb-0.5">Package</span> <span class="font-medium text-gray-900">{{ card.package_type or "--" }}</span></div>
-        <div><span class="text-gray-400 text-xs font-medium block mb-0.5">Pin Count</span> <span class="font-medium text-gray-900">{{ card.pin_count or "--" }}</span></div>
-        <div><span class="text-gray-400 text-xs font-medium block mb-0.5">Lifecycle</span> <span class="font-medium text-gray-900">{{ card.lifecycle_status or "--" }}</span></div>
+        <div><span class="text-secondary font-medium block mb-0.5">Category</span> <span class="font-medium text-gray-900">{{ card.category or "--" }}</span></div>
+        <div><span class="text-secondary font-medium block mb-0.5">Package</span> <span class="font-medium text-gray-900">{{ card.package_type or "--" }}</span></div>
+        <div><span class="text-secondary font-medium block mb-0.5">Pin Count</span> <span class="font-medium text-gray-900">{{ card.pin_count or "--" }}</span></div>
+        <div><span class="text-secondary font-medium block mb-0.5">Lifecycle</span> <span class="font-medium text-gray-900">{{ card.lifecycle_status or "--" }}</span></div>
         {% if card.specs_summary %}
-        <div class="col-span-full"><span class="text-gray-400 text-xs font-medium block mb-0.5">Specs</span> <span class="font-medium text-gray-900">{{ card.specs_summary }}</span></div>
+        <div class="col-span-full"><span class="text-secondary font-medium block mb-0.5">Specs</span> <span class="font-medium text-gray-900">{{ card.specs_summary }}</span></div>
         {% endif %}
         {% if card.datasheet_url %}
         <div class="col-span-full">
-          <span class="text-gray-400 text-xs font-medium block mb-0.5">Datasheet</span>
+          <span class="text-secondary font-medium block mb-0.5">Datasheet</span>
           <a href="{{ card.datasheet_url }}" target="_blank" rel="noopener"
              class="inline-flex items-center gap-1 text-accent-600 hover:text-accent-700 font-medium">
             <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/app/templates/htmx/partials/materials/filters/_macros.html
+++ b/app/templates/htmx/partials/materials/filters/_macros.html
@@ -105,7 +105,7 @@
            min="{{ range_data.min }}" max="{{ range_data.max }}" step="any">
   </div>
   {% else %}
-  <p class="text-xs text-gray-400 italic">No data available</p>
+  <p class="text-secondary italic">No data available</p>
   {% endif %}
 </div>
 {% endmacro %}

--- a/app/templates/htmx/partials/materials/filters/global.html
+++ b/app/templates/htmx/partials/materials/filters/global.html
@@ -13,7 +13,7 @@
   ('obsolete', 'Obsolete'), ('ltb', 'LTB')
 ] %}
 <div class="mb-3">
-  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Lifecycle</h4>
+  <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Lifecycle</h4>
   <div class="space-y-0.5">
     {% for value, label in lifecycle_opts %}
     {% if lc_counts.get(value, 0) > 0 %}
@@ -35,7 +35,7 @@
   ('compliant', 'Compliant'), ('non-compliant', 'Non-compliant'), ('exempt', 'Exempt')
 ] %}
 <div class="mb-3">
-  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">RoHS</h4>
+  <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">RoHS</h4>
   <div class="space-y-0.5">
     {% for value, label in rohs_opts %}
     {% if rohs_counts.get(value, 0) > 0 %}
@@ -60,7 +60,7 @@
 ] %}
 {% if condition_counts %}
 <div class="mb-3">
-  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Condition</h4>
+  <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Condition</h4>
   <div class="space-y-0.5">
     {% for value, label in condition_opts %}
     {% if condition_counts.get(value, 0) > 0 %}
@@ -81,7 +81,7 @@
 {# Has-datasheet boolean toggle — datasheet_url IS NOT NULL #}
 {% if ds_count > 0 %}
 <div class="mb-3">
-  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Datasheet</h4>
+  <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Datasheet</h4>
   <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
     <input aria-label="Only parts with a datasheet" type="checkbox"
            :checked="hasDatasheet"

--- a/app/templates/htmx/partials/materials/filters/manufacturers.html
+++ b/app/templates/htmx/partials/materials/filters/manufacturers.html
@@ -5,7 +5,7 @@
 #}
 {% if manufacturer_options %}
 <div class="mb-3" x-data="{mfgSearch: '', mfgExpanded: false}">
-  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Brand</h4>
+  <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Brand</h4>
   <input aria-label="Search manufacturers" type="text" x-model="mfgSearch"
          @focus="mfgExpanded = true"
          placeholder="Search manufacturers..."

--- a/app/templates/htmx/partials/materials/filters/subfilters.html
+++ b/app/templates/htmx/partials/materials/filters/subfilters.html
@@ -55,6 +55,6 @@
 {% else %}
 <div class="border-t border-gray-100 pt-3 mt-3">
   {{ coverage_line() }}
-  <p class="text-xs text-gray-400 italic">No filters available for this category</p>
+  <p class="text-secondary italic">No filters available for this category</p>
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/materials/filters/tree.html
+++ b/app/templates/htmx/partials/materials/filters/tree.html
@@ -24,7 +24,7 @@
               :aria-current="commodity === '{{ sub }}' ? 'true' : undefined"
               class="w-full text-left px-3 py-1.5 text-sm rounded-r flex items-center justify-between transition-colors">
         <span>{{ display_names.get(sub, sub) }}</span>
-        <span class="text-xs text-gray-400">({{ count }})</span>
+        <span class="text-secondary">({{ count }})</span>
       </button>
       {% endif %}
       {% endfor %}
@@ -32,7 +32,7 @@
   </div>
   {% endfor %}
   {# Type-to-find found nothing — don't leave a blank tree with no signal. #}
-  <p x-show="categorySearch && !anyCategoryMatches" x-cloak class="px-3 py-2 text-xs text-gray-400 italic">
+  <p x-show="categorySearch && !anyCategoryMatches" x-cloak class="px-3 py-2 text-secondary italic">
     No categories match “<span x-text="categorySearch"></span>”.
   </p>
 </div>

--- a/app/templates/htmx/partials/materials/insights.html
+++ b/app/templates/htmx/partials/materials/insights.html
@@ -15,13 +15,13 @@
   <div class="grid grid-cols-2 gap-3 mb-4 text-sm">
     {% if material.manufacturer %}
     <div class="bg-gray-50 rounded-lg p-3 border border-gray-100">
-      <p class="text-xs text-gray-400 font-medium mb-0.5">Manufacturer</p>
+      <p class="text-secondary font-medium mb-0.5">Manufacturer</p>
       <p class="text-gray-900 font-medium">{{ material.manufacturer }}</p>
     </div>
     {% endif %}
     {% if material.search_count %}
     <div class="bg-gray-50 rounded-lg p-3 border border-gray-100">
-      <p class="text-xs text-gray-400 font-medium mb-0.5">Search Count</p>
+      <p class="text-secondary font-medium mb-0.5">Search Count</p>
       <p class="text-gray-900 font-medium">{{ material.search_count }}</p>
     </div>
     {% endif %}

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -207,13 +207,13 @@
     {# Coverage-aware nudge: parametric facets only exist on spec-enriched cards, so a
        zero here mostly means "not yet spec-enriched", not "no such parts". #}
     <p class="text-sm font-medium text-gray-600">No matches — but most parts here haven't been spec-enriched yet. Try clearing parametric filters.</p>
-    <p class="text-xs text-gray-400 mt-1">
+    <p class="text-secondary mt-1">
       Only {{ "{:,}".format(spec_coverage.with_specs) }} of {{ "{:,}".format(spec_coverage.total) }}
       {% if commodity_display %}{{ commodity_display }} {% endif %}parts have filterable specs so far
     </p>
     {% else %}
     <p class="text-sm font-medium text-gray-600">No results match your filters</p>
-    <p class="text-xs text-gray-400 mt-1">Try removing a filter or broadening your search</p>
+    <p class="text-secondary mt-1">Try removing a filter or broadening your search</p>
     {% endif %}
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -51,14 +51,14 @@
           </div>
         </template>
         <template x-if="activeFilterCount === 0">
-          <span class="text-xs font-semibold text-gray-400 uppercase tracking-widest">Filters</span>
+          <span class="font-semibold text-secondary uppercase tracking-widest">Filters</span>
         </template>
       </div>
 
       {# ── Recents (re-entry accelerator) ─────────────────────────────#}
       <template x-if="recentCommodities.length > 0">
         <div class="mb-3">
-          <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Recent</h4>
+          <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Recent</h4>
           <div class="flex flex-wrap gap-1">
             <template x-for="rc in recentCommodities" :key="rc">
               <button @click="selectCommodity(rc)"
@@ -71,14 +71,14 @@
       </template>
 
       {# ── Category (the entry point) ─────────────────────────────────#}
-      <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Category</h4>
+      <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Category</h4>
       <input type="text" x-model="categorySearch" placeholder="Jump to category…"
              aria-label="Filter categories"
              class="w-full mb-1 px-2 py-1 text-[13px] border border-gray-200 rounded focus:ring-1 focus:ring-accent-500 focus:border-accent-500">
       <button @click="selectCommodity(null)" x-show="!categorySearch"
               :class="!commodity ? 'bg-accent-100 text-accent-800 font-semibold border-l-[3px] border-accent-500' : 'text-gray-600 hover:bg-gray-50 border-l-[3px] border-transparent'"
               class="w-full text-left px-3 py-1.5 text-sm rounded-r transition-colors mb-1">
-        All Materials <span class="text-xs text-gray-400">({{ total_materials }})</span>
+        All Materials <span class="text-secondary">({{ total_materials }})</span>
       </button>
       <span id="mfr-filter-spinner" class="htmx-indicator text-xs text-gray-400">Loading...</span>
       <div hx-get="/v2/partials/materials/filters/tree"
@@ -172,7 +172,7 @@
             </label>
           </div>
           <div class="mb-3">
-            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Part type</h4>
+            <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Part type</h4>
             <div class="flex flex-wrap gap-1">
               {# Vocabulary lives on the component (INTERNAL_MODES) — single front-end source of truth. #}
               <template x-for="opt in INTERNAL_MODES" :key="'int-' + opt[0]">
@@ -185,7 +185,7 @@
             </div>
           </div>
           <div class="mb-3">
-            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Searched within</h4>
+            <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Searched within</h4>
             <div class="flex flex-wrap gap-1">
               {# Vocabulary lives on the component (SEARCH_BUCKETS) — single front-end source of truth. #}
               <template x-for="opt in SEARCH_BUCKETS" :key="'sw-' + opt[0]">
@@ -198,7 +198,7 @@
             </div>
           </div>
           <div class="mb-3">
-            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Min searches</h4>
+            <h4 class="font-semibold text-secondary uppercase tracking-widest mb-1.5">Min searches</h4>
             <input type="number" min="0" step="1" placeholder="0"
                    :value="minSearches || ''"
                    @input.debounce.600ms="setMinSearches($event.target.value)"

--- a/app/templates/htmx/partials/proactive/_macros.html
+++ b/app/templates/htmx/partials/proactive/_macros.html
@@ -44,6 +44,6 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="{{ icon_path }}"/>
       </svg>
       <p class="mt-3 text-sm font-medium text-gray-600">{{ title }}</p>
-      <p class="mt-1 text-xs text-gray-400">{{ subtitle }}</p>
+      <p class="mt-1 text-secondary">{{ subtitle }}</p>
       {% if caller is defined %}{{ caller() }}{% endif %}
     </div>{% endmacro %}

--- a/app/templates/htmx/partials/proactive/_match_row.html
+++ b/app/templates/htmx/partials/proactive/_match_row.html
@@ -20,10 +20,10 @@
   <td>
     <p class="text-sm font-medium text-gray-900 font-mono">{{ match.mpn | default('--') }}</p>
     {% if match.manufacturer %}
-    <p class="text-xs text-gray-400 mt-0.5">{{ match.manufacturer }}</p>
+    <p class="text-secondary mt-0.5">{{ match.manufacturer }}</p>
     {% endif %}
     {% if match.customer_purchase_count %}
-    <span class="inline-flex items-center gap-0.5 text-xs text-gray-400 mt-0.5"
+    <span class="inline-flex items-center gap-0.5 text-secondary mt-0.5"
           title="Customer bought {{ match.customer_purchase_count }}x{% if match.customer_last_purchased_at %}, last {{ match.customer_last_purchased_at }}{% endif %}">
       <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
       {{ match.customer_purchase_count }}&times;

--- a/app/templates/htmx/partials/proactive/prepare.html
+++ b/app/templates/htmx/partials/proactive/prepare.html
@@ -68,7 +68,7 @@
             <td>
               <span class="text-sm font-medium text-gray-900 font-mono">{{ m.mpn }}</span>
               {% if m.manufacturer %}
-              <span class="text-xs text-gray-400 ml-1">{{ m.manufacturer }}</span>
+              <span class="text-secondary ml-1">{{ m.manufacturer }}</span>
               {% endif %}
             </td>
             <td class="text-sm text-gray-700">{{ m.vendor_name }}</td>

--- a/app/templates/htmx/partials/resell/_build_bid.html
+++ b/app/templates/htmx/partials/resell/_build_bid.html
@@ -71,7 +71,7 @@
             </td>
             <td>
               <span class="font-mono font-medium text-gray-900">{{ item.part_number }}</span>
-              {% if item.manufacturer %}<span class="block text-xs text-gray-400">{{ item.manufacturer }}</span>{% endif %}
+              {% if item.manufacturer %}<span class="block text-secondary">{{ item.manufacturer }}</span>{% endif %}
             </td>
             <td class="text-right tabular-nums">{{ "{:,}".format(item.quantity) }}</td>
             <td>{{ item.condition or '—' }}</td>
@@ -108,7 +108,7 @@
     <div class="flex items-start justify-between gap-3">
       <div>
         <p class="text-base font-semibold text-gray-900">{{ summary.bid_number }}</p>
-        <p class="text-xs text-gray-400 mt-0.5">{{ summary.line_count }} line{{ 's' if summary.line_count != 1 }} · rev {{ summary.revision }} · {{ summary.status }}</p>
+        <p class="text-secondary mt-0.5">{{ summary.line_count }} line{{ 's' if summary.line_count != 1 }} · rev {{ summary.revision }} · {{ summary.status }}</p>
       </div>
       <a href="/api/resell/{{ el.id }}/bid/{{ bid.id }}/pdf"
          class="btn-secondary btn-sm">
@@ -133,7 +133,7 @@
           <tr>
             <td>
               <span class="font-mono font-medium text-gray-900">{{ li.part_number or '—' }}</span>
-              {% if li.manufacturer %}<span class="block text-xs text-gray-400">{{ li.manufacturer }}</span>{% endif %}
+              {% if li.manufacturer %}<span class="block text-secondary">{{ li.manufacturer }}</span>{% endif %}
             </td>
             <td>{{ li.condition or '—' }}</td>
             <td class="text-right tabular-nums">{{ "{:,}".format(li.quantity) }}</td>
@@ -150,7 +150,7 @@
     </div>
 
     <div class="mt-3 text-right text-sm">
-      <span class="text-gray-400 uppercase tracking-wide text-xs mr-2">Total bid</span>
+      <span class="uppercase tracking-wide text-secondary mr-2">Total bid</span>
       <span class="font-semibold text-gray-900 tabular-nums">${{ "{:,.2f}".format(summary.subtotal) }}</span>
     </div>
   </div>

--- a/app/templates/htmx/partials/resell/_lines.html
+++ b/app/templates/htmx/partials/resell/_lines.html
@@ -47,7 +47,7 @@
   <div id="import-area" class="rounded-lg border border-dashed border-line-base bg-gray-50 p-3"
        x-data="{ uploading: false }">
     <div class="flex items-center justify-between gap-2">
-      <p class="text-xs text-gray-500">Add parts — drop a file, or add one line.</p>
+      <p class="text-secondary">Add parts — drop a file, or add one line.</p>
       <button @click="$dispatch('open-modal')"
               hx-get="/v2/partials/resell/{{ el.id }}/add-line-form"
               hx-target="#modal-content"
@@ -90,7 +90,7 @@
         <p class="text-base font-semibold text-gray-900 font-mono">{{ item.part_number }}</p>
         {% set desc = item|part_description %}
         {% if desc %}<p class="text-sm text-gray-500 mt-0.5">{{ desc }}</p>{% endif %}
-        {% if item.manufacturer %}<p class="text-xs text-gray-400 mt-0.5">{{ item.manufacturer }}</p>{% endif %}
+        {% if item.manufacturer %}<p class="text-secondary mt-0.5">{{ item.manufacturer }}</p>{% endif %}
       </div>
       <div class="inline-flex items-center gap-1.5 flex-shrink-0">
         {{ _status_pill(item) }}
@@ -98,11 +98,11 @@
       </div>
     </div>
     <div class="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
-      <div><span class="block text-xs text-gray-400 uppercase tracking-wide">Qty</span><span class="font-medium tabular-nums">{{ "{:,}".format(item.quantity) }}</span></div>
-      <div><span class="block text-xs text-gray-400 uppercase tracking-wide">Condition</span><span class="font-medium">{{ item.condition or '—' }}</span></div>
-      <div><span class="block text-xs text-gray-400 uppercase tracking-wide">Date code</span><span class="font-medium">{{ item.date_code or '—' }}</span></div>
+      <div><span class="block text-secondary uppercase tracking-wide">Qty</span><span class="font-medium tabular-nums">{{ "{:,}".format(item.quantity) }}</span></div>
+      <div><span class="block text-secondary uppercase tracking-wide">Condition</span><span class="font-medium">{{ item.condition or '—' }}</span></div>
+      <div><span class="block text-secondary uppercase tracking-wide">Date code</span><span class="font-medium">{{ item.date_code or '—' }}</span></div>
       <div>
-        <span class="block text-xs text-gray-400 uppercase tracking-wide">Best offer</span>
+        <span class="block text-secondary uppercase tracking-wide">Best offer</span>
         {# Owner-only: a non-owner broker must never see the current best COMPETING
            price (matches the Offers-tab / compare 403 boundary). #}
         {% if is_owner and item.best_offer_unit_price is not none %}
@@ -130,7 +130,7 @@
         <tr>
           <td>
             <span class="font-mono font-medium text-gray-900">{{ item.part_number }}</span>
-            {% if item.manufacturer %}<span class="block text-xs text-gray-400">{{ item.manufacturer }}</span>{% endif %}
+            {% if item.manufacturer %}<span class="block text-secondary">{{ item.manufacturer }}</span>{% endif %}
           </td>
           <td class="text-right tabular-nums">{{ "{:,}".format(item.quantity) }}</td>
           <td>{{ item.condition or '—' }}</td>

--- a/app/templates/htmx/partials/resell/_lists.html
+++ b/app/templates/htmx/partials/resell/_lists.html
@@ -52,9 +52,9 @@
         <div class="min-w-0 flex-1">
           <p class="text-sm font-semibold text-gray-900 truncate">{{ el.title }}</p>
           {% if c.customer_name %}
-          <p class="text-xs text-gray-500 truncate mt-0.5">{{ c.customer_name }}</p>
+          <p class="text-secondary truncate mt-0.5">{{ c.customer_name }}</p>
           {% else %}
-          <p class="text-xs text-gray-400 truncate mt-0.5 italic">Anonymized posting</p>
+          <p class="text-secondary truncate mt-0.5 italic">Anonymized posting</p>
           {% endif %}
         </div>
         {{ status_badge(el.status, status_map={
@@ -67,7 +67,7 @@
           'expired': 'bg-gray-50 text-gray-400 border-gray-200'
         }) }}
       </div>
-      <div class="mt-1.5 flex items-center gap-3 text-xs text-gray-500">
+      <div class="mt-1.5 flex items-center gap-3 text-secondary">
         <span class="inline-flex items-center gap-1.5" title="Offer coverage: {{ c.coverage_filled }} of {{ c.coverage_total }} lines have an offer">
           {{ coverage_meter(c.coverage_filled, c.coverage_total) }}
           <span class="tabular-nums">{{ c.coverage_filled }}/{{ c.coverage_total }}</span>

--- a/app/templates/htmx/partials/resell/_offers.html
+++ b/app/templates/htmx/partials/resell/_offers.html
@@ -35,7 +35,7 @@
             class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Unaward</button>
   </div>
   {%- elif item.status == 'awarded' -%}
-  <span class="text-xs text-gray-400 whitespace-nowrap">Not selected</span>
+  <span class="text-secondary whitespace-nowrap">Not selected</span>
   {%- elif offer.status in ['open', 'late'] -%}
   <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/award"
           hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
@@ -54,7 +54,7 @@
     <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
   </svg>
   <p class="text-sm font-medium text-gray-600">Offers are private to the list owner</p>
-  <p class="text-xs text-gray-400 mt-1">Use “Submit offer” to send yours — the owner sees it, other brokers do not.</p>
+  <p class="text-secondary mt-1">Use “Submit offer” to send yours — the owner sees it, other brokers do not.</p>
 </div>
 
 {% else %}
@@ -72,10 +72,10 @@
           Take-all
         </span>
         <p class="mt-1.5 text-sm font-semibold text-gray-900">{{ _broker_label(offer, is_owner) }}</p>
-        {% if offer.notes %}<p class="text-xs text-gray-500 mt-0.5">{{ offer.notes }}</p>{% endif %}
+        {% if offer.notes %}<p class="text-secondary mt-0.5">{{ offer.notes }}</p>{% endif %}
       </div>
       <div class="text-right">
-        <span class="block text-xs text-gray-400 uppercase tracking-wide">Lump price</span>
+        <span class="block text-secondary uppercase tracking-wide">Lump price</span>
         {% if offer.take_all_total_price is not none %}
         <span class="text-lg font-bold text-violet-700 tabular-nums">${{ "{:,.2f}".format(offer.take_all_total_price|float) }}</span>
         {% else %}<span class="text-sm text-gray-400 italic">Price TBD</span>{% endif %}
@@ -91,7 +91,7 @@
               data-loading-disable
               class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Unaward</button>
       {% elif take_all_blocked %}
-      <span class="text-xs text-gray-500">Some lines already awarded — unaward them first</span>
+      <span class="text-secondary">Some lines already awarded — unaward them first</span>
       {% elif offer.status in ['open', 'late'] %}
       <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/award"
               hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"

--- a/app/templates/htmx/partials/resell/_outreach.html
+++ b/app/templates/htmx/partials/resell/_outreach.html
@@ -35,7 +35,7 @@
   <div class="mx-auto max-w-sm text-center text-sm text-gray-500 py-10">
     <svg class="mx-auto mb-3 h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
     <p class="font-medium text-gray-600">This list hasn't been offered to anyone yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Use "Offer to buyers" to send or log your first touch.</p>
+    <p class="text-secondary mt-1">Use "Offer to buyers" to send or log your first touch.</p>
   </div>
 
   {% else %}

--- a/app/templates/htmx/partials/resell/_reply_viewer.html
+++ b/app/templates/htmx/partials/resell/_reply_viewer.html
@@ -37,10 +37,10 @@
           </div>
           <div>
             <span class="text-sm font-medium text-gray-900">{{ vr.vendor_name or 'Unknown sender' }}</span>
-            {% if vr.vendor_email %}<span class="text-xs text-gray-400 ml-1">&lt;{{ vr.vendor_email }}&gt;</span>{% endif %}
+            {% if vr.vendor_email %}<span class="text-secondary ml-1">&lt;{{ vr.vendor_email }}&gt;</span>{% endif %}
           </div>
         </div>
-        <span class="text-xs text-gray-400">{{ vr.received_at | fmtdate }}</span>
+        <span class="text-secondary">{{ vr.received_at | fmtdate }}</span>
       </div>
       {% if vr.subject %}<p class="text-xs font-medium text-gray-600 mb-1.5">{{ vr.subject }}</p>{% endif %}
       <div class="text-sm text-gray-700 prose prose-sm max-w-none">
@@ -54,7 +54,7 @@
      Honest note, not a silent blank — the convert form below still works off the thread. #}
   <div class="rounded-lg border border-dashed border-brand-200 p-5 text-center text-sm text-gray-500">
     <p class="font-medium text-gray-600">This buyer replied, but no message body was captured.</p>
-    <p class="text-xs text-gray-400 mt-1">You can still record their offer below.</p>
+    <p class="text-secondary mt-1">You can still record their offer below.</p>
   </div>
   {% endif %}
 
@@ -68,7 +68,7 @@
               class="text-xs font-medium text-accent-600 hover:text-accent-700"
               x-text="showConvert ? 'Hide' : 'Add offer'"></button>
     </div>
-    <p class="text-xs text-gray-400 mt-0.5">Read the reply, then record the buyer's price and quantity as a tracked offer.</p>
+    <p class="text-secondary mt-0.5">Read the reply, then record the buyer's price and quantity as a tracked offer.</p>
 
     <form x-show="showConvert" x-cloak
           hx-post="/api/resell/{{ el.id }}/outreach/{{ outreach.id }}/offer"

--- a/app/templates/htmx/partials/resell/create_modal.html
+++ b/app/templates/htmx/partials/resell/create_modal.html
@@ -23,7 +23,7 @@
         <option value="">Select company…</option>
         {% for c in companies %}<option value="{{ c.id }}">{{ c.name }}</option>{% endfor %}
       </select>
-      <p class="text-xs text-gray-400 mt-1">The customer is owner-only — never shown to brokers.</p>
+      <p class="text-secondary mt-1">The customer is owner-only — never shown to brokers.</p>
     </div>
     <div>
       <label class="form-label">Notes</label>

--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -16,7 +16,7 @@
   {# ── Slim header ──────────────────────────────────────────────── #}
   <div class="px-5 py-3 border-b border-line-base bg-white flex-shrink-0">
     {# Breadcrumb #}
-    <nav class="text-xs text-gray-400 mb-1" aria-label="Breadcrumb">
+    <nav class="text-secondary mb-1" aria-label="Breadcrumb">
       <a hx-get="/v2/partials/resell/workspace?lens=mine"
          hx-target="#main-content" hx-push-url="/v2/resell"
          class="hover:text-brand-500">Resell</a>
@@ -29,7 +29,7 @@
         <h1 class="text-xl font-bold text-gray-900 truncate">{{ el.title }}</h1>
         {# Metadata chips — refreshed in place by the award/unaward OOB response, so the
            id'd flex container is the swap target (chip content lives in _header_chips). #}
-        <div id="resell-chips-{{ el.id }}" class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+        <div id="resell-chips-{{ el.id }}" class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-secondary">
           {% include "htmx/partials/resell/_header_chips.html" %}
         </div>
       </div>

--- a/app/templates/htmx/partials/resell/import_preview.html
+++ b/app/templates/htmx/partials/resell/import_preview.html
@@ -51,7 +51,7 @@
     </table>
   </div>
   {% if valid_count > preview_rows|length %}
-  <p class="text-xs text-gray-400">Showing {{ preview_rows|length }} of {{ valid_count }} valid rows</p>
+  <p class="text-secondary">Showing {{ preview_rows|length }} of {{ valid_count }} valid rows</p>
   {% endif %}
   {% endif %}
 

--- a/app/templates/htmx/partials/resell/offer_buyers_modal.html
+++ b/app/templates/htmx/partials/resell/offer_buyers_modal.html
@@ -73,7 +73,7 @@
 
     {# ── Suggested buyers (ranked) ─────────────────────────────────── #}
     <div>
-      <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+      <label class="block font-medium text-secondary uppercase tracking-wider mb-2">
         Suggested buyers ({{ suggestions|length }})
       </label>
 
@@ -96,7 +96,7 @@
               <span class="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-indigo-50 text-indigo-700">{{ reason.get(b.rank_reason, b.rank_reason) }}</span>
             </div>
             {# One-glance scorecard chips: last bid · win-rate · last contacted. #}
-            <div class="mt-0.5 flex items-center gap-3 text-xs text-gray-400 flex-wrap">
+            <div class="mt-0.5 flex items-center gap-3 text-secondary flex-wrap">
               {% if b.last_bid is not none %}<span>last bid ${{ "{:,.4f}".format(b.last_bid|float) }}</span>{% endif %}
               {% if b.win_rate is not none %}<span>{{ (b.win_rate * 100)|round|int }}% win</span>{% endif %}
               {% if b.last_offered_at %}<span>offered {{ b.last_offered_at.strftime('%b %d') }}</span>
@@ -136,13 +136,13 @@
                placeholder="Add a buyer by name…" autocomplete="off" aria-label="Add a buyer by name"
                class="input w-full">
         <div x-show="searchOpen" x-cloak
-             class="absolute z-50 left-0 right-0 mt-1 max-h-40 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg">
+             class="absolute z-50 left-0 right-0 mt-1 max-h-40 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-float">
           <template x-for="r in results" :key="r.type + '-' + r.id">
             <button type="button" @click="pick(r)"
                     class="w-full text-left px-3 py-1.5 text-sm text-gray-700 hover:bg-brand-50 hover:text-brand-700 truncate"
                     x-text="r.name"></button>
           </template>
-          <div x-show="results.length === 0" x-cloak class="px-3 py-1.5 text-xs text-gray-400 italic">No matches</div>
+          <div x-show="results.length === 0" x-cloak class="px-3 py-1.5 text-secondary italic">No matches</div>
         </div>
       </div>
       {# Added chips. #}
@@ -158,7 +158,7 @@
 
     {# ── Scope ─────────────────────────────────────────────────────── #}
     <div>
-      <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Scope</label>
+      <label class="block font-medium text-secondary uppercase tracking-wider mb-1">Scope</label>
       <div class="flex rounded-lg border border-line-base overflow-hidden text-sm">
         <button type="button" @click="scope = 'whole_list'"
                 :class="scope === 'whole_list' ? 'bg-accent-500 text-white' : 'bg-white text-gray-600 hover:bg-accent-50'"
@@ -173,7 +173,7 @@
 
     {# ── Channel ───────────────────────────────────────────────────── #}
     <div>
-      <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Channel</label>
+      <label class="block font-medium text-secondary uppercase tracking-wider mb-1">Channel</label>
       <div class="flex flex-wrap gap-2 text-sm">
         {% for ch in channels %}
         <button type="button" @click="channel = '{{ ch }}'"
@@ -181,8 +181,8 @@
                 class="px-3 py-1.5 rounded-full border font-medium transition-colors capitalize">{{ ch }}</button>
         {% endfor %}
       </div>
-      <p class="mt-1 text-xs text-gray-400" x-show="channel === 'email'" x-cloak>Sends a real email to each buyer with a contact on file.</p>
-      <p class="mt-1 text-xs text-gray-400" x-show="channel !== 'email'" x-cloak>Logs the touch on the timeline — no email is sent.</p>
+      <p class="mt-1 text-secondary" x-show="channel === 'email'" x-cloak>Sends a real email to each buyer with a contact on file.</p>
+      <p class="mt-1 text-secondary" x-show="channel !== 'email'" x-cloak>Logs the touch on the timeline — no email is sent.</p>
     </div>
 
     {# ── Email compose (email channel only) ────────────────────────── #}

--- a/app/templates/htmx/partials/resell/offer_compare.html
+++ b/app/templates/htmx/partials/resell/offer_compare.html
@@ -33,7 +33,7 @@
             class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Unaward</button>
   </div>
   {%- elif item.status == 'awarded' -%}
-  <span class="text-xs text-gray-400 whitespace-nowrap">Not selected</span>
+  <span class="text-secondary whitespace-nowrap">Not selected</span>
   {%- elif offer.status in ['open', 'late'] -%}
   <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/award"
           hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
@@ -96,7 +96,7 @@
   {# Price-spread bar — one dot per priced offer, best in emerald. #}
   {% if priced|length > 1 and max_price and max_price > min_price %}
   <div class="mt-3 px-1">
-    <div class="flex items-center gap-2 text-xs text-gray-400">
+    <div class="flex items-center gap-2 text-secondary">
       <span class="font-mono tabular-nums">${{ "{:,.4f}".format(min_price) }}</span>
       <div class="flex-1 relative h-4 flex items-center">
         <div class="absolute inset-x-0 h-1 bg-gradient-to-r from-emerald-200 via-amber-200 to-rose-200 rounded-full"></div>
@@ -113,7 +113,7 @@
   </div>
   {% endif %}
 
-  <p class="mt-3 text-xs text-gray-400">Best price is highlighted for planning — pick on terms, lead, and reputation, not price alone.</p>
+  <p class="mt-3 text-secondary">Best price is highlighted for planning — pick on terms, lead, and reputation, not price alone.</p>
   {% else %}
   <div class="text-center py-8 text-sm text-gray-500">No offers on this line yet.</div>
   {% endif %}

--- a/app/templates/htmx/partials/resell/offer_form.html
+++ b/app/templates/htmx/partials/resell/offer_form.html
@@ -63,7 +63,7 @@
         <label class="form-label">Lump price for the whole list</label>
         <input type="number" name="take_all_total_price" step="0.01" min="0" class="input" placeholder="optional — leave blank for price TBD">
       </div>
-      <p class="text-xs text-gray-400">A take-all offer binds every line, all-or-nothing — it pins above the lines as the headline.</p>
+      <p class="text-secondary">A take-all offer binds every line, all-or-nothing — it pins above the lines as the headline.</p>
     </div>
 
     <div>

--- a/app/templates/htmx/partials/settings/_connector_macros.html
+++ b/app/templates/htmx/partials/settings/_connector_macros.html
@@ -120,7 +120,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
     {% endfor %}
     <div class="flex items-center gap-2 pt-1">
       {{ save_button(s, label) }}
-      <span class="text-xs text-gray-400">Saved keys are encrypted; we never show the full key again</span>
+      <span class="text-secondary">Saved keys are encrypted; we never show the full key again</span>
     </div>
   </div>
 {% endmacro %}
@@ -128,7 +128,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
 {# ── Consented Graph scopes / keyless note ───────────────────────────── #}
 {% macro scopes_block(s) %}
   {% if s.keyless_note %}
-  <p class="text-xs text-gray-500">{{ s.keyless_note }}</p>
+  <p class="text-secondary">{{ s.keyless_note }}</p>
   {% endif %}
 {% endmacro %}
 
@@ -147,7 +147,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
     <div class="min-w-0">
       <p class="text-sm font-medium text-gray-700 truncate">{{ s.display_name }}</p>
       {% if s.description %}
-      <p class="text-xs text-gray-400 truncate">{{ s.description }}</p>
+      <p class="text-secondary truncate">{{ s.description }}</p>
       {% endif %}
     </div>
   </div>
@@ -161,7 +161,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
       <div class="min-w-0">
         <p class="text-sm font-medium text-gray-900 truncate">{{ s.display_name }}</p>
         {% if s.description %}
-        <p class="text-xs text-gray-500 truncate">{{ s.description }}</p>
+        <p class="text-secondary truncate">{{ s.description }}</p>
         {% endif %}
       </div>
     </div>
@@ -215,7 +215,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
         <span class="text-sm text-amber-700">Connection expired — reconnect.</span>
         <a href="/auth/clay/connect" class="btn-md">Reconnect</a>
       {% else %}
-        <p class="text-xs text-gray-500 flex-1">Connect your Clay workspace to turn on enrichment</p>
+        <p class="text-secondary flex-1">Connect your Clay workspace to turn on enrichment</p>
         <a href="/auth/clay/connect" class="btn-md">Connect Clay</a>
       {% endif %}
     </div>
@@ -230,7 +230,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
       {% else %}
         <span class="text-sm text-gray-500">Not connected.</span>
       {% endif %}
-      <span class="text-xs text-gray-400">An admin manages this connection.</span>
+      <span class="text-secondary">An admin manages this connection.</span>
     </div>
     {% endif %}
 
@@ -239,7 +239,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
 
   {% elif s.control_type == 'key' %}
     {% if s.state == 'needs_setup' %}
-    <p class="text-xs text-gray-500">Add your {{ s.display_name }} API key to turn this on</p>
+    <p class="text-secondary">Add your {{ s.display_name }} API key to turn this on</p>
     {% endif %}
     <div class="space-y-2">
       {% for ev, field in s.creds.items() %}
@@ -247,7 +247,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
       {% endfor %}
       <div class="flex items-center gap-2 pt-1">
         {{ save_button(s, 'Save key') }}
-        <span class="text-xs text-gray-400">Saved keys are encrypted; we never show the full key again</span>
+        <span class="text-secondary">Saved keys are encrypted; we never show the full key again</span>
       </div>
     </div>
 
@@ -256,7 +256,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
        worker verdict when the source is switched on (worker_active / worker_down); an
        operator-disabled source reads 'Off' and shows no worker note. #}
     {% if s.state in ('worker_active', 'worker_down') %}{{ worker_detail(s) }}{% endif %}
-    <p class="text-xs text-gray-500">A background worker signs in to {{ s.display_name }} and searches for you. Update the login it uses below.</p>
+    <p class="text-secondary">A background worker signs in to {{ s.display_name }} and searches for you. Update the login it uses below.</p>
     <div class="space-y-2">
       {% for ev, field in s.creds.items() %}
         {{ key_field(s, ev, field) }}

--- a/app/templates/htmx/partials/settings/_mailbox_sync_card.html
+++ b/app/templates/htmx/partials/settings/_mailbox_sync_card.html
@@ -46,12 +46,12 @@
   {# Disconnected empty state #}
   <div class="mt-3 rounded-md border border-dashed border-gray-300 bg-gray-50 p-4 text-center">
     <p class="text-sm font-medium text-gray-700">Mailbox not connected</p>
-    <p class="mt-1 text-xs text-gray-500">Sign in with Microsoft 365 to let AvailAI read replies and keep your requisitions up to date.</p>
+    <p class="mt-1 text-secondary">Sign in with Microsoft 365 to let AvailAI read replies and keep your requisitions up to date.</p>
     {% if inbox_status.error_reason %}
     <p class="mt-2 text-xs text-rose-600">{{ inbox_status.error_reason }}</p>
     {% endif %}
     <a href="/auth/login"
-       class="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent-600 rounded-lg hover:bg-accent-700">
+       class="mt-3 btn-primary btn-sm">
       Connect Microsoft 365
     </a>
   </div>

--- a/app/templates/htmx/partials/settings/connectors.html
+++ b/app/templates/htmx/partials/settings/connectors.html
@@ -46,7 +46,7 @@
       </button>
       {# Test-all aggregate result — OOB-swapped here after the sweep so it's visible
          even when the cards that changed are far down a long page. #}
-      <div id="test-all-summary" class="text-xs text-gray-500" aria-live="polite"></div>
+      <div id="test-all-summary" class="text-secondary" aria-live="polite"></div>
     </div>
   </div>
 
@@ -57,7 +57,7 @@
             d="M13 10V3L4 14h7v7l9-11h-7z"/>
     </svg>
     <p class="text-sm text-gray-600 mt-3">No connectors yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Data providers appear here once they're configured for your workspace.</p>
+    <p class="text-secondary mt-1">Data providers appear here once they're configured for your workspace.</p>
   </div>
   {% endif %}
 
@@ -74,7 +74,7 @@
         </svg>
         <span class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ group.label }}</span>
       </span>
-      <span class="text-xs text-gray-500">
+      <span class="text-secondary">
         {{ g_live }} live{% if g_needs %} · {{ g_needs }} need setup{% endif %}
       </span>
     </button>

--- a/app/templates/htmx/partials/settings/profile.html
+++ b/app/templates/htmx/partials/settings/profile.html
@@ -88,7 +88,7 @@
       {# Click-to-call extension. Saving posts the current name + this extension. #}
       <form hx-post="/api/user/profile" hx-swap="none">
         <label class="block text-sm font-medium text-gray-600 mb-1.5">Click-to-call (8x8 phone)</label>
-        <p class="text-xs text-gray-500 mb-2">Your 8x8 desk extension. We use it so you can call a contact in one click.</p>
+        <p class="text-secondary mb-2">Your 8x8 desk extension. We use it so you can call a contact in one click.</p>
         <input type="hidden" name="name" :value="name">
         <div class="flex items-center gap-2">
           <input type="text" name="extension" x-model="extension"

--- a/app/templates/htmx/partials/settings/system.html
+++ b/app/templates/htmx/partials/settings/system.html
@@ -33,7 +33,7 @@
             <p class="text-sm font-medium text-gray-900">{{ item.label }}</p>
             <p class="text-xs text-gray-600 mt-0.5">{{ item.help }}</p>
             {% if item.restart %}
-            <p class="text-xs text-gray-400 mt-1">Applies after the next restart.</p>
+            <p class="text-secondary mt-1">Applies after the next restart.</p>
             {% endif %}
           </div>
           <label class="relative inline-flex items-center cursor-pointer ml-4 shrink-0">
@@ -63,7 +63,7 @@
               <p class="text-sm font-medium text-gray-900">{{ item.label }}</p>
               <p class="text-xs text-gray-600 mt-0.5">{{ item.help }}</p>
               {% if item.restart %}
-              <p class="text-xs text-gray-400 mt-1">Applies after the next restart.</p>
+              <p class="text-secondary mt-1">Applies after the next restart.</p>
               {% endif %}
             </div>
             <form class="flex items-center gap-2 shrink-0"

--- a/app/templates/htmx/partials/settings/user_access_panel.html
+++ b/app/templates/htmx/partials/settings/user_access_panel.html
@@ -27,7 +27,7 @@
     {# ── Sections ────────────────────────────────────────────────────── #}
     {% macro access_section(title, rows) %}
     <div class="px-5 py-4">
-      <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">{{ title }}</h4>
+      <h4 class="font-semibold uppercase tracking-wide text-secondary mb-2">{{ title }}</h4>
       <div class="divide-y divide-gray-100">
         {% for row in rows %}
         <div class="flex items-center justify-between gap-3 py-2">

--- a/tests/test_connectors_settings.py
+++ b/tests/test_connectors_settings.py
@@ -464,7 +464,7 @@ def test_connectors_empty_state_when_no_sources(empty_admin_client):
     html = empty_admin_client.get("/v2/partials/settings/connectors").text
     assert "No connectors" in html, "Expected empty-state heading when no sources exist"
     assert "text-sm text-gray-600" in html, "Expected house-style empty-state heading class"
-    assert "text-xs text-gray-400" in html, "Expected house-style empty-state hint class"
+    assert "text-secondary" in html, "Expected house-style empty-state hint class"
 
 
 def test_connectors_tab_not_empty_state_when_sources_exist(admin_client):


### PR DESCRIPTION
## What

Safe, mechanical **design-system conformance** pass across the Settings, Resell, Proactive, and Materials partials. Hand-rolled markup is replaced with the app's **existing** canonical classes so the same visual outcome is produced consistently, plus the documented contrast floor. No redesign, no rearranged features, no new classes/colors/spacing, no layout/behavior changes.

## Changes (presentation classes only)

- **Contrast floor (rule 1):** reader-facing caption / label / help / empty-state copy at `text-xs text-gray-400`/`text-gray-500` → **`.text-secondary`** (the documented gray-600 floor; the CSS itself notes "secondary uses gray-600 (not gray-500)"). Applied only where `text-xs` was already explicit, so it is size-preserving. Icons/SVG strokes, spinners, disabled states, badge color-pairs, interactive idle-with-hover controls, table headers, `—`/`TBD` placeholders, and non-`text-xs` sizes were left untouched.
- **Primary CTA (rule 4):** Settings mailbox "Connect Microsoft 365" was rendered in `bg-accent-600` (the hover shade at rest) → **`.btn-primary .btn-sm`** (rests at accent-500, the canonical primary).
- **Floating popover (rule 5):** Resell offer-buyers autocomplete dropdown `shadow-lg` → **`shadow-float`**.
- **Radius tier (rule 9):** Materials "Find crosses" button `rounded-md` → **`rounded-lg`**.
- Updated one connectors empty-state test assertion to the new house-style token (`text-secondary`).

## Deliberately skipped (noted, not guessed)

- **Legacy tables → `.data-table` (rule 7):** the four `min-w-full divide-y` tables (`settings/ops_group`, `settings/users`, `settings/users_audit`, `resell/offer_compare`) would change header background (gray-50→white), border, weight, and padding — a visual change, not a no-op. Left as-is.
- **Empty-state partial swap (rule 8):** inline "No X" states carry custom icons/subtitles the shared `empty_state.html` doesn't reproduce; converting would alter the visual. Left as-is.
- **`text-[11px]`/`text-sm` gray captions & gray-400 tertiary tier:** no size-preserving canonical gray class exists (`.text-secondary` = 12px; `.text-tertiary` = brand-400 blue), so bumping would resize or change hue. Left as-is.

## Tests

- `tests/test_static_analysis.py`, `test_template_ui_integrity.py`, `test_template_env.py`, `test_template_attr_quoting_fixes.py` — pass.
- Settings/Resell/Proactive/Materials render + route families — **404 passed**.
- `pre-commit run --files` on all changed files — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF