### PR TITLE
Design-system conformance: Quotes + Offers + Buy-Plans

### DIFF
--- a/app/templates/htmx/partials/buy_plans/_detail_action_banner.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_action_banner.html
@@ -29,9 +29,9 @@
 
   {# Buyer: lines awaiting PO assigned to them #}
   {% if show_buyer_banner %}
-  <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center gap-3">
-    <span class="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">{{ my_awaiting_lines|length }}</span>
-    <span class="text-sm text-blue-800">
+  <div class="mb-4 bg-accent-50 border border-accent-200 rounded-lg px-4 py-3 flex items-center gap-3">
+    <span class="flex-shrink-0 w-6 h-6 rounded-full bg-accent-600 text-white text-xs font-bold flex items-center justify-center">{{ my_awaiting_lines|length }}</span>
+    <span class="text-sm text-accent-800">
       PO{{ 's' if my_awaiting_lines|length != 1 }} need{{ '' if my_awaiting_lines|length != 1 else 's' }} to be cut.
       {% for l in my_awaiting_lines[:5] %}{{ l.requirement.primary_mpn if l.requirement else 'Line ' ~ l.id }}{% if not loop.last %}, {% endif %}{% endfor %}{% if my_awaiting_lines|length > 5 %} +{{ my_awaiting_lines|length - 5 }} more{% endif %}
     </span>
@@ -41,10 +41,10 @@
   {# Manager/Admin: plan pending approval #}
   {# Finding #4: raw bg-emerald-600/bg-rose-600 banner buttons → .btn family #}
   {% if show_approval_banner %}
-  <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+  <div class="mb-4 bg-accent-50 border border-accent-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
     <div class="flex items-center gap-3">
-      <span class="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">!</span>
-      <span class="text-sm text-blue-800">This plan needs your approval. ${{ '{:,.2f}'.format(total_cost) }} total. <span class="text-blue-600">Approving also signs off the sales order.</span></span>
+      <span class="flex-shrink-0 w-6 h-6 rounded-full bg-accent-600 text-white text-xs font-bold flex items-center justify-center">!</span>
+      <span class="text-sm text-accent-800">This plan needs your approval. ${{ '{:,.2f}'.format(total_cost) }} total. <span class="text-accent-600">Approving also signs off the sales order.</span></span>
     </div>
     <div class="flex gap-2 flex-shrink-0">
       <button @click="modalType = 'approve'; showModal = true"
@@ -61,18 +61,18 @@
 
   {# PO approvers: POs pending verification #}
   {% if show_verify_banner %}
-  <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center gap-3">
-    <span class="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">{{ pending_verify_lines|length }}</span>
-    <span class="text-sm text-blue-800">{{ pending_verify_lines|length }} PO{{ 's' if pending_verify_lines|length != 1 }} need{{ '' if pending_verify_lines|length != 1 else 's' }} verification.</span>
+  <div class="mb-4 bg-accent-50 border border-accent-200 rounded-lg px-4 py-3 flex items-center gap-3">
+    <span class="flex-shrink-0 w-6 h-6 rounded-full bg-accent-600 text-white text-xs font-bold flex items-center justify-center">{{ pending_verify_lines|length }}</span>
+    <span class="text-sm text-accent-800">{{ pending_verify_lines|length }} PO{{ 's' if pending_verify_lines|length != 1 }} need{{ '' if pending_verify_lines|length != 1 else 's' }} verification.</span>
   </div>
   {% endif %}
 
   {# Submitter: plan was rejected #}
   {% if show_rejected_banner %}
-  <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+  <div class="mb-4 bg-rose-50 border border-rose-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
     <div class="flex items-center gap-3">
       <span class="flex-shrink-0 w-6 h-6 rounded-full bg-rose-500 text-white text-xs font-bold flex items-center justify-center">!</span>
-      <span class="text-sm text-blue-800">Plan was rejected. Review notes and resubmit.</span>
+      <span class="text-sm text-rose-800">Plan was rejected. Review notes and resubmit.</span>
     </div>
     <button @click="modalType = 'submit'; showModal = true"
             class="flex-shrink-0 btn btn-primary btn-sm">
@@ -83,12 +83,12 @@
 
   {# Submitter: draft ready to submit #}
   {% if show_draft_banner %}
-  <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+  <div class="mb-4 bg-accent-50 border border-accent-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
     <div class="flex items-center gap-3">
-      <span class="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">
+      <span class="flex-shrink-0 w-6 h-6 rounded-full bg-accent-600 text-white text-xs font-bold flex items-center justify-center">
         <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
       </span>
-      <span class="text-sm text-blue-800">Ready to submit. Add SO# to proceed.</span>
+      <span class="text-sm text-accent-800">Ready to submit. Add SO# to proceed.</span>
     </div>
     <button @click="modalType = 'submit'; showModal = true"
             class="flex-shrink-0 btn btn-primary btn-sm">
@@ -99,10 +99,10 @@
 
   {# Buyer: PO approved, goods inbound — mark received to complete (SP-3) #}
   {% if show_inbound_banner %}
-  <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+  <div class="mb-4 bg-emerald-50 border border-emerald-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
     <div class="flex items-center gap-3">
-      <span class="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">!</span>
-      <span class="text-sm text-blue-800">Purchase Order approved — goods are inbound. Mark received to complete the deal.</span>
+      <span class="flex-shrink-0 w-6 h-6 rounded-full bg-emerald-600 text-white text-xs font-bold flex items-center justify-center">!</span>
+      <span class="text-sm text-emerald-800">Purchase Order approved — goods are inbound. Mark received to complete the deal.</span>
     </div>
     <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/receive"
             hx-target="#main-content" hx-swap="innerHTML"

--- a/app/templates/htmx/partials/buy_plans/_detail_lines.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_lines.html
@@ -30,7 +30,7 @@
   {# Finding #1: convert to data-table, drop per-cell px-4 py-3 and per-th font-medium text-gray-500 uppercase #}
   <div class="bg-white rounded-lg shadow-sm overflow-hidden border border-line-base mb-6">
     <div class="px-4 py-3 bg-gray-50 border-b border-line-base">
-      <h2 class="text-lg font-semibold text-gray-900">Line Items
+      <h2 class="h2">Line Items
         <span class="ml-1 text-sm font-normal text-gray-600">({{ lines|length }})</span>
       </h2>
     </div>
@@ -65,7 +65,7 @@
               {% if line.buyer %}
               <div class="flex items-center gap-1.5 mt-0.5">
                 {{ user_avatar(line.buyer) }}
-                <span class="text-xs text-gray-400">{{ line.buyer.name }}</span>
+                <span class="text-secondary">{{ line.buyer.name }}</span>
               </div>
               {% endif %}
             </td>
@@ -177,7 +177,7 @@
                     </label>
                     <div x-show="escalate" x-cloak class="pl-4 space-y-0.5">
                       {% for o in other_cut %}
-                      <label class="flex items-center gap-1.5 text-xs text-gray-500">
+                      <label class="flex items-center gap-1.5 text-secondary">
                         <input type="checkbox" name="also_line_ids" value="{{ o.id }}" checked>
                         <span class="font-mono">{{ o.requirement.primary_mpn if o.requirement else ('line ' ~ o.id) }}</span>
                       </label>
@@ -220,7 +220,7 @@
                     </label>
                     <div x-show="escalate" x-cloak class="pl-4 space-y-0.5">
                       {% for o in other_recv %}
-                      <label class="flex items-center gap-1.5 text-xs text-gray-500">
+                      <label class="flex items-center gap-1.5 text-secondary">
                         <input type="checkbox" name="also_line_ids" value="{{ o.id }}" checked>
                         <span class="font-mono">{{ o.requirement.primary_mpn if o.requirement else ('line ' ~ o.id) }}</span>
                       </label>

--- a/app/templates/htmx/partials/buy_plans/_detail_sidebar.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_sidebar.html
@@ -20,14 +20,14 @@
     <button @click="showAi = !showAi" class="w-full px-4 py-2 flex items-center justify-between gap-3 text-left hover:bg-gray-50 transition-colors">
       <div class="flex items-center gap-2 min-w-0">
         <svg class="w-4 h-4 flex-shrink-0 text-brand-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
-        <span class="text-sm font-semibold text-gray-700 flex-shrink-0">AI Insights</span>
+        <span class="h3 flex-shrink-0">AI Insights</span>
         {% if flag_count > 0 %}
         <span class="inline-flex items-center justify-center w-5 h-5 flex-shrink-0 rounded-full bg-amber-100 text-amber-700 text-xs font-bold">{{ flag_count }}</span>
         {% endif %}
         {# State the actual top issue at first glance — the verbatim flag reason, not just a count. #}
         {% if top_flag and top_flag.message %}
         <span class="text-xs truncate
-                     {% if top_flag.severity == 'critical' %}text-rose-600{% elif top_flag.severity == 'warning' %}text-amber-700{% else %}text-gray-500{% endif %}"
+                     {% if top_flag.severity == 'critical' %}text-rose-600{% elif top_flag.severity == 'warning' %}text-amber-700{% else %}text-gray-600{% endif %}"
               title="{{ top_flag.message }}">{{ top_flag.message }}</span>
         {% endif %}
       </div>
@@ -69,26 +69,26 @@
     <button @click="showNotes = !showNotes" class="w-full px-4 py-2 flex items-center justify-between text-left hover:bg-gray-50 transition-colors">
       <div class="flex items-center gap-2">
         <svg class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
-        <span class="text-sm font-semibold text-gray-700">Notes</span>
+        <span class="h3">Notes</span>
       </div>
       {{ collapse_chevron("showNotes") }}
     </button>
     <div x-show="showNotes" x-cloak x-collapse class="px-4 pb-4 space-y-3">
       {% if bp.salesperson_notes %}
       <div>
-        <div class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Salesperson Notes</div>
+        <div class="text-secondary font-medium uppercase tracking-wider mb-1">Salesperson Notes</div>
         <p class="text-sm text-gray-600 leading-relaxed">{{ bp.salesperson_notes }}</p>
       </div>
       {% endif %}
       {% if bp.approval_notes %}
       <div>
-        <div class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Approval Notes</div>
+        <div class="text-secondary font-medium uppercase tracking-wider mb-1">Approval Notes</div>
         <p class="text-sm text-gray-600 leading-relaxed">{{ bp.approval_notes }}</p>
       </div>
       {% endif %}
       {% if bp.case_report %}
       <div>
-        <div class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Case Report</div>
+        <div class="text-secondary font-medium uppercase tracking-wider mb-1">Case Report</div>
         <pre class="text-xs text-gray-600 whitespace-pre-wrap font-mono bg-gray-50 rounded p-3 leading-relaxed">{{ bp.case_report }}</pre>
       </div>
       {% endif %}
@@ -101,7 +101,7 @@
     <button @click="showSo = !showSo" class="w-full px-4 py-2 flex items-center justify-between text-left hover:bg-gray-50 transition-colors">
       <div class="flex items-center gap-2">
         <svg class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
-        <span class="text-sm font-semibold text-gray-700">SO Verification</span>
+        <span class="h3">SO Verification</span>
         {% if bp.so_status == 'approved' %}
         <svg class="w-4 h-4 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
         {% else %}

--- a/app/templates/htmx/partials/buy_plans/_macros.html
+++ b/app/templates/htmx/partials/buy_plans/_macros.html
@@ -23,5 +23,5 @@ Usage:
    The dismiss button shared by every buy-plan modal footer. Closes the
    modal without submitting. #}
 {% macro modal_cancel_btn() -%}
-<button @click="showModal = false" class="px-4 py-2 text-sm text-gray-700 border border-brand-200 rounded-md hover:bg-gray-50 transition-colors">Cancel</button>
+<button @click="showModal = false" class="btn btn-secondary">Cancel</button>
 {%- endmacro %}

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -66,8 +66,8 @@
         <span class="{% if margin >= 30 %}text-emerald-700{% elif margin >= 15 %}text-amber-700{% else %}text-rose-700{% endif %} font-semibold text-sm">
           {{ '{:.1f}'.format(margin) }}%
         </span>
-        <span class="text-xs text-gray-400">{{ lines|length }} line{{ 's' if lines|length != 1 }}</span>
-        <span class="text-xs text-gray-400">{{ unique_vendors|length }} vendor{{ 's' if unique_vendors|length != 1 }}</span>
+        <span class="text-secondary">{{ lines|length }} line{{ 's' if lines|length != 1 }}</span>
+        <span class="text-secondary">{{ unique_vendors|length }} vendor{{ 's' if unique_vendors|length != 1 }}</span>
         {# Quality Plan front door — get-or-create this buy plan's QP and open its native
            view. Always shown (independent of the action banner) so the owner can always
            reach the QP. #}
@@ -160,7 +160,7 @@
       {# Submit modal #}
       <template x-if="modalType === 'submit'" x-cloak>
         <div x-data="{ so: '', cpo: '', notes: '' }">
-          <h3 class="text-lg font-semibold text-gray-900 mb-4">Submit Buy Plan</h3>
+          <h3 class="h2 mb-4">Submit Buy Plan</h3>
           <div class="space-y-3">
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">SO# <span class="text-rose-500">*</span></label>
@@ -202,7 +202,7 @@
          (issue_type, note) match buy_plan_flag_issue_partial. #}
       <template x-if="modalType === 'issue'" x-cloak>
         <div x-data="{ issue_type: 'sold_out', note: '' }">
-          <h3 class="text-lg font-semibold text-gray-900 mb-4">Flag an Issue</h3>
+          <h3 class="h2 mb-4">Flag an Issue</h3>
           <div class="space-y-3">
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">What's wrong?</label>
@@ -237,7 +237,7 @@
       {# Approve modal #}
       <template x-if="modalType === 'approve'" x-cloak>
         <div x-data="{ notes: '' }">
-          <h3 class="text-lg font-semibold text-gray-900 mb-4">Approve Buy Plan</h3>
+          <h3 class="h2 mb-4">Approve Buy Plan</h3>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Notes (optional)</label>
             <textarea x-model="notes" rows="3" class="input w-full"></textarea>
@@ -259,7 +259,7 @@
       {# Reject modal #}
       <template x-if="modalType === 'reject'" x-cloak>
         <div x-data="{ notes: '' }">
-          <h3 class="text-lg font-semibold text-gray-900 mb-4">Reject Buy Plan</h3>
+          <h3 class="h2 mb-4">Reject Buy Plan</h3>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Reason <span class="text-rose-500">*</span></label>
             <textarea x-model="notes" rows="3" required
@@ -288,7 +288,7 @@
       {% if can_halt %}
       <template x-if="modalType === 'halt'" x-cloak>
         <div x-data="{ reason: '' }">
-          <h3 class="text-lg font-semibold text-gray-900 mb-4">Halt Buy Plan</h3>
+          <h3 class="h2 mb-4">Halt Buy Plan</h3>
           <p class="text-sm text-gray-600 mb-3">This stops everything. The plan can be reset to draft and resubmitted later.</p>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Reason</label>
@@ -314,7 +314,7 @@
       {# Cancel modal #}
       <template x-if="modalType === 'cancel'" x-cloak>
         <div x-data="{ reason: '' }">
-          <h3 class="text-lg font-semibold text-gray-900 mb-4">Cancel Buy Plan</h3>
+          <h3 class="h2 mb-4">Cancel Buy Plan</h3>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Reason</label>
             <textarea x-model="reason" rows="2"

--- a/app/templates/htmx/partials/offers/_qualification_fields.html
+++ b/app/templates/htmx/partials/offers/_qualification_fields.html
@@ -63,7 +63,7 @@
 
   {# Standardized note preview (read-only, auto-composed by JS) + meter #}
   <div x-show="condition" x-cloak class="text-xs">
-    <div class="text-gray-400 mb-0.5">Standardized note (auto)</div>
+    <div class="text-secondary mb-0.5">Standardized note (auto)</div>
     <div class="rounded bg-white border border-gray-200 px-2 py-1 text-gray-700" x-text="noteText() || '—'"></div>
     <div class="mt-1 text-gray-600" x-show="meterTotal() > 0">
       Qualified <span x-text="meterFilled()"></span>/<span x-text="meterTotal()"></span>

--- a/app/templates/htmx/partials/offers/changelog.html
+++ b/app/templates/htmx/partials/offers/changelog.html
@@ -24,10 +24,10 @@
         </svg>
         <span class="text-gray-700">{{ c.new_value or '(empty)' }}</span>
         {% if c.old_value %}
-        <span class="text-xs text-gray-400 ml-1">(was: {{ c.old_value }})</span>
+        <span class="text-secondary ml-1">(was: {{ c.old_value }})</span>
         {% endif %}
       </div>
-      <div class="text-xs text-gray-400 whitespace-nowrap flex-shrink-0">
+      <div class="text-secondary whitespace-nowrap flex-shrink-0">
         {{ c.user.name if c.user else 'System' }}
         {% if c.created_at %} &middot; {{ c.created_at.strftime('%b %d %H:%M') }}{% endif %}
       </div>

--- a/app/templates/htmx/partials/offers/review_queue.html
+++ b/app/templates/htmx/partials/offers/review_queue.html
@@ -43,28 +43,28 @@
           {# Details grid #}
           <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-2 text-sm mb-2">
             <div>
-              <span class="text-xs text-gray-400 font-medium">Qty</span>
+              <span class="text-secondary font-medium">Qty</span>
               <p class="text-gray-900 font-mono">{{ "{:,}".format(o.qty_available) if o.qty_available else '--' }}</p>
             </div>
             <div>
-              <span class="text-xs text-gray-400 font-medium">Price</span>
+              <span class="text-secondary font-medium">Price</span>
               <p class="{{ 'text-emerald-700 font-medium font-mono' if o.unit_price else 'text-gray-400' }}">
                 {{ "${:,.4f}".format(o.unit_price) if o.unit_price else 'RFQ' }}
               </p>
             </div>
             <div>
-              <span class="text-xs text-gray-400 font-medium">Lead Time</span>
+              <span class="text-secondary font-medium">Lead Time</span>
               <p class="text-gray-900">{{ o.lead_time or '--' }}</p>
             </div>
             <div>
-              <span class="text-xs text-gray-400 font-medium">Source</span>
+              <span class="text-secondary font-medium">Source</span>
               <p class="text-gray-900">{{ o.source or '--' }}</p>
             </div>
           </div>
 
           {# Requisition + date #}
           {% if o.requisition_id %}
-          <div class="flex items-center gap-2 text-xs text-gray-400">
+          <div class="flex items-center gap-2 text-secondary">
             <a hx-get="/v2/partials/requisitions/{{ o.requisition_id }}"
                hx-target="#main-content"
                hx-push-url="/v2/requisitions/{{ o.requisition_id }}"
@@ -120,7 +120,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>
     <p class="mt-3 text-sm font-medium text-gray-600">No offers pending review</p>
-    <p class="text-xs text-gray-400 mt-1">AI-parsed offers with medium confidence appear here for human verification.</p>
+    <p class="text-secondary mt-1">AI-parsed offers with medium confidence appear here for human verification.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -76,15 +76,15 @@
       {# Summary stats #}
       <div class="flex gap-4 sm:gap-6">
         <div class="text-center">
-          <p class="text-xs text-gray-400 uppercase tracking-wider mb-1">Subtotal</p>
+          <p class="text-secondary uppercase tracking-wider mb-1">Subtotal</p>
           <p class="text-lg font-semibold text-gray-900">${{ '{:,.2f}'.format(quote.subtotal|float) if quote.subtotal else '0.00' }}</p>
         </div>
         <div class="text-center">
-          <p class="text-xs text-gray-400 uppercase tracking-wider mb-1">Cost</p>
+          <p class="text-secondary uppercase tracking-wider mb-1">Cost</p>
           <p class="text-lg font-semibold text-gray-900">${{ '{:,.2f}'.format(quote.total_cost|float) if quote.total_cost else '0.00' }}</p>
         </div>
         <div class="text-center">
-          <p class="text-xs text-gray-400 uppercase tracking-wider mb-1">Margin</p>
+          <p class="text-secondary uppercase tracking-wider mb-1">Margin</p>
           {% set margin = quote.total_margin_pct|float if quote.total_margin_pct else 0 %}
           <p class="text-lg font-semibold {{ margin_text_color(margin) }}">
             {{ '{:.1f}'.format(margin) }}%
@@ -129,7 +129,7 @@
             hx-target="#main-content"
             hx-vals='{"result": "won"}'
             data-loading-disable
-            class="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-md hover:bg-emerald-700 flex items-center gap-1.5 transition-colors">
+            class="btn btn-lg bg-emerald-600 text-white hover:bg-emerald-700 inline-flex items-center gap-1.5">
       {{ loading_spinner("h-4 w-4 spinner") }}
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
       Mark Won
@@ -138,7 +138,7 @@
             hx-target="#main-content"
             hx-vals='{"result": "lost"}'
             data-loading-disable
-            class="px-4 py-2 bg-rose-600 text-white text-sm font-medium rounded-md hover:bg-rose-700 flex items-center gap-1.5 transition-colors">
+            class="btn btn-lg bg-rose-600 text-white hover:bg-rose-700 inline-flex items-center gap-1.5">
       {{ loading_spinner("h-4 w-4 spinner") }}
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
       Mark Lost
@@ -150,7 +150,7 @@
             hx-target="#main-content"
             hx-confirm="Build a buy plan from this quote?"
             data-loading-disable
-            class="px-4 py-2 bg-emerald-600 text-white text-sm font-medium rounded-md hover:bg-emerald-700 flex items-center gap-1.5 transition-colors">
+            class="btn btn-lg bg-emerald-600 text-white hover:bg-emerald-700 inline-flex items-center gap-1.5">
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
       Build Buy Plan
     </button>
@@ -195,13 +195,13 @@
             hx-target="#main-content"
             hx-confirm="Create a new revision of this quote?"
             data-loading-disable
-            class="px-4 py-2 bg-white border border-brand-200 text-brand-700 text-sm font-medium rounded-md hover:bg-brand-50 flex items-center gap-1.5 transition-colors">
+            class="btn btn-secondary btn-lg inline-flex items-center gap-1.5">
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
       Revise
     </button>
 
     <button @click="showMarkup = !showMarkup"
-            class="px-4 py-2 bg-white border border-brand-200 text-brand-700 text-sm font-medium rounded-md hover:bg-brand-50 flex items-center gap-1.5 transition-colors">
+            class="btn btn-secondary btn-lg inline-flex items-center gap-1.5">
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/></svg>
       Apply Markup
     </button>
@@ -219,13 +219,13 @@
         window.dispatchEvent(new CustomEvent('toast', {detail: {message: 'Table copied to clipboard', type: 'success'}}));
       });
     "
-            class="px-4 py-2 bg-white border border-brand-200 text-brand-700 text-sm font-medium rounded-md hover:bg-brand-50 flex items-center gap-1.5 transition-colors">
+            class="btn btn-secondary btn-lg inline-flex items-center gap-1.5">
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/></svg>
       Copy Table
     </button>
 
     <a href="/api/quotes/{{ quote.id }}/pdf" target="_blank" rel="noopener noreferrer"
-       class="px-4 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50 flex items-center gap-1.5 transition-colors">
+       class="btn btn-secondary btn-lg inline-flex items-center gap-1.5">
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
       Download PDF
     </a>
@@ -254,23 +254,23 @@
     <form hx-post="/v2/partials/quotes/{{ quote.id }}/apply-markup" hx-target="#main-content" class="flex flex-wrap items-center gap-3">
       <label class="text-sm font-medium text-gray-700">Markup %:</label>
       <input type="number" name="markup_pct" step="0.1" value="25"
-             class="w-24 px-3 py-1.5 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+             class="w-24 px-3 py-1.5 border border-brand-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
       <button type="submit" data-loading-disable
               class="btn-primary btn-sm">
         {{ loading_spinner("h-3 w-3 mr-1 spinner inline") }}
         Apply to All Lines
       </button>
-      <p class="text-xs text-gray-400">Sets sell price = cost + markup % on every line item.</p>
+      <p class="text-secondary">Sets sell price = cost + markup % on every line item.</p>
     </form>
   </div>
 
   {# Line items table #}
   <div class="bg-white rounded-lg shadow border border-brand-200 overflow-hidden mb-6">
     <div class="px-4 py-3 bg-gray-50 border-b border-brand-200 flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-gray-900">Line Items
+      <h2 class="h2">Line Items
         <span class="ml-1 text-sm font-normal text-gray-600">({{ lines|length }})</span>
       </h2>
-      <span class="text-xs text-gray-400">Double-click a row to edit</span>
+      <span class="text-secondary">Double-click a row to edit</span>
     </div>
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-gray-200">
@@ -316,27 +316,27 @@
         <div>
           <label class="block text-xs text-gray-600 mb-1">MPN</label>
           <input type="text" name="mpn" required placeholder="LM317T"
-                 class="w-32 px-2 py-1.5 text-sm border border-brand-200 rounded-md font-mono focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                 class="w-32 px-2 py-1.5 text-sm border border-brand-200 rounded-lg font-mono focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
           <label class="block text-xs text-gray-600 mb-1">Manufacturer</label>
           <input type="text" name="manufacturer" placeholder="TI"
-                 class="w-28 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                 class="w-28 px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
           <label class="block text-xs text-gray-600 mb-1">Qty</label>
           <input type="number" name="qty" value="1" min="1"
-                 class="w-20 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                 class="w-20 px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
           <label class="block text-xs text-gray-600 mb-1">Cost</label>
           <input type="number" name="cost_price" step="0.0001" placeholder="0.5000"
-                 class="w-24 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                 class="w-24 px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
           <label class="block text-xs text-gray-600 mb-1">Sell</label>
           <input type="number" name="sell_price" step="0.0001" placeholder="0.7500"
-                 class="w-24 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                 class="w-24 px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <button type="submit" data-loading-disable
                 class="btn-primary btn-sm">
@@ -364,7 +364,7 @@
         {% for line in lines %}
         {% if line.mpn %}
         <div class="border-b border-gray-100 last:border-b-0">
-          <div class="px-4 py-2 bg-gray-50 text-xs font-medium text-gray-500 uppercase">
+          <div class="px-4 py-2 bg-gray-50 text-secondary font-medium uppercase">
             {{ line.mpn }}
           </div>
           <div hx-get="/v2/partials/pricing-history/{{ line.mpn }}"
@@ -384,7 +384,7 @@
   {# Offer gallery #}
   {% if offers %}
   <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+    <h2 class="h2 mb-4 flex items-center gap-2">
       <svg class="w-5 h-5 text-brand-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
       </svg>

--- a/app/templates/htmx/partials/quotes/edit_form.html
+++ b/app/templates/htmx/partials/quotes/edit_form.html
@@ -27,33 +27,33 @@
 
     <div class='grid grid-cols-2 gap-2'>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Payment Terms</label>
+        <label class='form-label'>Payment Terms</label>
         <input type='text' name='payment_terms' list='payment-terms' maxlength='100'
                value='{{ quote.payment_terms or "" }}' placeholder='e.g. Net 30'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Shipping Terms</label>
+        <label class='form-label'>Shipping Terms</label>
         <input type='text' name='shipping_terms' list='shipping-terms' maxlength='100'
                value='{{ quote.shipping_terms or "" }}' placeholder='e.g. FOB Origin'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Valid Until <span class="text-rose-500">*</span></label>
+      <label class='form-label'>Valid Until <span class="text-rose-500">*</span></label>
       <input type='date' name='valid_until' required
              value='{{ valid_until_date.isoformat() }}' min='{{ min_valid_until.isoformat() }}'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
-      <p class='mt-1 text-xs text-gray-400'>
+             class='input'>
+      <p class='mt-1 text-secondary'>
         How long the quote stays valid. Counted from the send date once sent, or from today while it's a draft.
       </p>
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Internal Notes</label>
+      <label class='form-label'>Internal Notes</label>
       <textarea name='notes' rows='3'
-                class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>{{ quote.notes or "" }}</textarea>
+                class='input'>{{ quote.notes or "" }}</textarea>
     </div>
 
     <div class='flex justify-end gap-2 pt-1'>

--- a/app/templates/htmx/partials/quotes/line_row.html
+++ b/app/templates/htmx/partials/quotes/line_row.html
@@ -19,35 +19,35 @@
           data-loading-disable
           class="flex flex-wrap gap-2 items-end">
         <div>
-          <label class="block text-xs text-gray-400 mb-0.5">MPN</label>
+          <label class="block text-secondary mb-0.5">MPN</label>
           <input type="text" name="mpn" value="{{ line.mpn }}"
                  class="w-28 px-2 py-1 text-sm border border-brand-200 rounded font-mono focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-400 mb-0.5">Mfr</label>
+          <label class="block text-secondary mb-0.5">Mfr</label>
           <input type="text" name="manufacturer" value="{{ line.manufacturer or '' }}"
                  class="w-24 px-2 py-1 text-sm border border-brand-200 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-400 mb-0.5">Qty</label>
+          <label class="block text-secondary mb-0.5">Qty</label>
           <input type="number" name="qty" value="{{ line.qty or 0 }}"
                  class="w-20 px-2 py-1 text-sm border border-brand-200 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-400 mb-0.5">Cost</label>
+          <label class="block text-secondary mb-0.5">Cost</label>
           <input type="number" name="cost_price" value="{{ '{:.4f}'.format(line.cost_price|float) if line.cost_price else '' }}"
                  step="0.0001"
                  class="w-24 px-2 py-1 text-sm border border-brand-200 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-400 mb-0.5">Sell</label>
+          <label class="block text-secondary mb-0.5">Sell</label>
           <input type="number" name="sell_price" value="{{ '{:.4f}'.format(line.sell_price|float) if line.sell_price else '' }}"
                  step="0.0001"
                  class="w-24 px-2 py-1 text-sm border border-brand-200 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div class="flex gap-1">
-          <button type="submit" class="px-3 py-1 text-xs bg-brand-500 text-white rounded-md hover:bg-brand-600 font-medium transition-colors">Save</button>
-          <button type="button" @click="editing = false" class="px-3 py-1 text-xs text-gray-600 border border-gray-300 rounded-md hover:bg-gray-100 transition-colors">Cancel</button>
+          <button type="submit" class="btn btn-primary btn-sm">Save</button>
+          <button type="button" @click="editing = false" class="btn btn-secondary btn-sm">Cancel</button>
         </div>
       </form>
   </td>


### PR DESCRIPTION
## What

A **safe, presentation-only** design-system conformance pass across the Quotes, Offers, and Buy-Plans partials. Hand-rolled markup is replaced with the app's **existing** canonical classes/macros (`app/static/styles.css` `@layer components` + `shared/_macros.html`) so the same visual outcome renders consistently, plus the documented gray-600 contrast floor. **No redesign, no new classes/colors/spacing, no layout or behavior change.** The diff is a balanced 83+/83- pure class swap — no `hx-*`, `@click`, `x-data`, `id`, `name`, or structure touched.

## Changes by rule

- **Rule 2 (form-label):** `quotes/edit_form.html` — 4× the verbatim `block text-xs font-medium text-gray-700 mb-1` → `.form-label`.
- **Rule 6 (.input):** `quotes/edit_form.html` — 3 inputs + 1 textarea carrying the exact legacy string → `.input`.
- **Rule 1 (contrast floor):** size-safe `text-xs text-gray-400/500` captions/labels/help/empty-state copy → `.text-secondary` across `quotes/detail`, `quotes/line_row`, `quotes/edit_form`, `offers/review_queue`, `offers/changelog`, `offers/_qualification_fields`, `buy_plans/detail`, `_detail_lines`, `_detail_sidebar`. (text-sm reader copy left untouched — `.text-secondary` is text-xs and would resize it.)
- **Rule 4 (buttons):** `line_row` Save was `bg-brand-500` (now a **gray** scale) — an objectively-wrong primary CTA → `.btn-primary`; Cancel → `.btn-secondary`. `quotes/detail` action bar + shared `buy_plans` modal Cancel moved off inline `px-4 py-2 rounded-md` onto the `.btn` family (semantic emerald/rose/neutral colors preserved).
- **Rule 3 (headings):** section-title / modal-title headings whose raw declaration is byte-identical to a recipe → `.h2` / `.h3` (`quotes/detail`, `buy_plans/detail` 6 modal titles, `_detail_lines`, `_detail_sidebar`).
- **Rule 9 (radius):** `rounded-md` on inputs → `rounded-lg` (`quotes/detail` markup + add-line inputs).
- **Readability bug — `buy_plans/_detail_action_banner.html`:** every banner retoned off raw `blue-50/200/800` onto the documented palette — **accent** for pending/action (buyer, approval, verify, draft), **rose** for the rejected banner (fixes the contradictory rose icon on a blue body), **emerald** for the approved-inbound banner; the amber warning banner is kept.

## Verification

- `tests/test_static_analysis.py` (design-system ratchets) + `test_template_ui_integrity.py` + `test_template_env.py`: **69 passed**.
- Route-render tests for the three surfaces (buy-plan workflow/PO-verify/hub, quote send/workflow, offer qualification/overhaul, approval review): **235 passed**.
- `pre-commit run --files` on all changed files: clean (exit 0).
- All utility classes used are safelisted in `tailwind.config.js` (`accent-*`, `emerald-*`, `rose-*`, `amber-*` full scales).

## Skipped (noted, not guessed)

- Legacy `min-w-full divide-y divide-gray-200` tables in `quotes/detail`, `quotes/preview`, `quotes/pricing_history` — **not** converted to `.data-table`: the element-level `.data-table td` color rule would clobber intentional per-cell colors (emerald price, gray-600 secondary) and change row density, so it is not a same-outcome swap.
- Offer-entry inputs (`_offer_form_fields`, `_field_macros`, `_qual_checklist`) use a different legacy variant (`px-2 ... rounded`, not the exact rule-6 string); `.input` would change horizontal padding, so left as-is.
- Header `<h1>`s (`text-2xl ... ` without `leading-tight`) left to avoid a line-height shift; text-sm low-contrast inline labels left to avoid a size reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF