### PR TITLE
fix(sightings): group by the enriched material-card manufacturer/brand

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -541,7 +541,16 @@ async def sightings_list(
     if filters.group_by in ("brand", "manufacturer"):
         groups: dict[str, list] = {}
         for r in requirements:
-            key = getattr(r, filters.group_by, "") or "Unknown"
+            # Group by the ENRICHED value from the linked material card (the manufacturer/
+            # brand derived from the MPN) first; fall back to the requirement's own field.
+            # The requirement's raw brand/manufacturer is blank on most rows (customer input),
+            # so keying off it alone collapsed nearly every part into "Unknown" — making the
+            # By-Brand / By-Manufacturer grouping look broken. material_card is lazy="joined"
+            # (already loaded), so this adds no query.
+            mc = r.material_card
+            key = (
+                (getattr(mc, filters.group_by, None) if mc else None) or getattr(r, filters.group_by, None) or "Unknown"
+            )
             groups.setdefault(key, []).append(r)
 
     ctx = {

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -236,6 +236,36 @@ class TestSightingsFilters:
         assert resp.status_code == 200
         assert "TestMfr" in resp.text
 
+    def test_group_by_manufacturer_uses_material_card(self, client, db_session):
+        """Regression: By-Manufacturer grouping keys off the ENRICHED material-card
+        manufacturer, not the requirement's own (usually blank) field.
+
+        The requirement's raw manufacturer is customer input and is empty on most rows, so
+        keying off it alone collapsed nearly every part into 'Unknown' — which read as 'the
+        filter doesn't work'. The linked material card carries the real (MPN-derived)
+        manufacturer.
+        """
+        req = Requisition(name="MC-Group RFQ", status="open", customer_name="Acme Corp")
+        db_session.add(req)
+        db_session.flush()
+        mc = MaterialCard(normalized_mpn="grpmc001", display_mpn="GRP-MC-001", manufacturer="EnrichedMfr")
+        db_session.add(mc)
+        db_session.flush()
+        r = Requirement(
+            requisition_id=req.id,
+            primary_mpn="GRP-MC-001",
+            manufacturer="",  # blank raw field — the common real case
+            target_qty=100,
+            sourcing_status="open",
+            material_card_id=mc.id,
+        )
+        db_session.add(r)
+        db_session.commit()
+
+        resp = client.get("/v2/partials/sightings?group_by=manufacturer")
+        assert resp.status_code == 200
+        assert "EnrichedMfr" in resp.text  # grouped under the card's manufacturer, not "Unknown"
+
     def test_group_by_brand(self, client, db_session):
         _seed_data(db_session)
         resp = client.get("/v2/partials/sightings?group_by=brand")


### PR DESCRIPTION
**Bug (reported):** on the RFQ/sightings page, the Flat / By Brand / By Manufacturer filter doesn't seem to work.

**Root cause:** grouping keyed off the requirement's *own* brand/manufacturer field, which is raw customer input and blank on almost every row (live: 2/46 have a brand, 3/46 a manufacturer). So By Brand / By Manufacturer collapsed ~44/46 parts into one "Unknown" bucket.

**Fix:** group by the linked **material card's** manufacturer/brand (the MPN-derived, enriched value — 37/46 populated, giving real groups: Texas Instruments, Maxim, Espressif…), falling back to the requirement's field then "Unknown". `material_card` is `lazy="joined"`, so no extra query. Regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF