### PR TITLE
test: salvage nightly-coverage drafts #708/#709/#710 (246 tests)

### DIFF
--- a/tests/test_buy_plans_router_gaps2.py
+++ b/tests/test_buy_plans_router_gaps2.py
@@ -1,0 +1,161 @@
+"""tests/test_buy_plans_router_gaps2.py — Second coverage-gap pass for buy_plans router.
+
+Covers uncovered paths that were not in test_buy_plans_router_gaps.py:
+  Lines 911-912: buy_plan_verify_po_partial ValueError → 400
+  Lines 916-919: buy_plan_verify_po_partial origin=approvals_hub returns render_tab_body
+
+Called by: pytest
+Depends on: app/routers/htmx/buy_plans.py, conftest.py fixtures
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.responses import HTMLResponse
+
+
+def _ok_html() -> HTMLResponse:
+    return HTMLResponse("<html><body>ok</body></html>")
+
+
+# ── buy_plan fixture ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def buy_plan(db_session, test_requisition, test_user):
+    """A DRAFT buy plan owned by test_requisition."""
+    from app.constants import BuyPlanStatus
+    from app.models.buy_plan import BuyPlan
+
+    plan = BuyPlan(
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.DRAFT,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(plan)
+    db_session.commit()
+    db_session.refresh(plan)
+    return plan
+
+
+# ── PO approver client fixture ────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def po_approver_client(db_session, test_user):
+    """TestClient with require_buyplan_po_approver overridden to test_user."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_buyplan_po_approver, require_user
+    from app.main import app
+
+    def _db():
+        yield db_session
+
+    def _user():
+        return test_user
+
+    overrides = {
+        get_db: _db,
+        require_user: _user,
+        require_admin: _user,
+        require_buyer: _user,
+        require_buyplan_po_approver: _user,
+    }
+    for dep, fn in overrides.items():
+        app.dependency_overrides[dep] = fn
+    try:
+        from fastapi.testclient import TestClient
+
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in overrides:
+            app.dependency_overrides.pop(dep, None)
+
+
+# ── buy_plan_verify_po_partial: ValueError → 400 (lines 911-912) ──────────────
+
+
+def test_verify_po_value_error_returns_400(po_approver_client, buy_plan):
+    """verify_po raises ValueError → 400 (lines 911-912).
+
+    The existing test_buy_plans_router_gaps.py covers the success and my_queue paths but
+    not the ValueError branch. This test closes that gap.
+    """
+    with patch(
+        "app.services.buyplan_workflow.verify_po",
+        side_effect=ValueError("line not awaiting verification"),
+    ):
+        resp = po_approver_client.post(
+            f"/v2/partials/buy-plans/{buy_plan.id}/lines/1/verify-po",
+            data={"action": "approve"},
+        )
+    assert resp.status_code == 400
+
+
+def test_verify_po_permission_error_returns_400(po_approver_client, buy_plan):
+    """verify_po raises PermissionError → 400 (line 911: except (ValueError,
+    PermissionError)).
+
+    Both exceptions share the same handler on line 911.
+    """
+    with patch(
+        "app.services.buyplan_workflow.verify_po",
+        side_effect=PermissionError("not a po approver"),
+    ):
+        resp = po_approver_client.post(
+            f"/v2/partials/buy-plans/{buy_plan.id}/lines/1/verify-po",
+            data={"action": "approve"},
+        )
+    assert resp.status_code == 400
+
+
+# ── buy_plan_verify_po_partial: origin=approvals_hub (lines 916-919) ──────────
+
+
+def test_verify_po_origin_approvals_hub(po_approver_client, buy_plan):
+    """origin=approvals_hub → render_tab_body("po-approval", hub_scope) (lines 916-919).
+
+    The render_tab_body import is lazy (inside the conditional), so patch at its
+    source location: app.routers.htmx.approvals_hub.render_tab_body.
+    """
+    with patch("app.services.buyplan_workflow.verify_po"):
+        with patch("app.services.buyplan_workflow.check_completion", return_value=None):
+            with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()):
+                with patch(
+                    "app.routers.htmx.approvals_hub.render_tab_body",
+                    return_value=_ok_html(),
+                ) as mock_render:
+                    resp = po_approver_client.post(
+                        f"/v2/partials/buy-plans/{buy_plan.id}/lines/1/verify-po",
+                        data={"action": "approve", "origin": "approvals_hub", "hub_scope": "pending"},
+                    )
+    assert resp.status_code == 200
+    mock_render.assert_called_once()
+    # Verify the tab and scope arguments were forwarded correctly
+    call_args = mock_render.call_args[0]
+    assert "po-approval" in call_args
+    assert "pending" in call_args
+
+
+def test_verify_po_origin_approvals_hub_default_scope(po_approver_client, buy_plan):
+    """origin=approvals_hub without hub_scope → defaults to 'all' (line 900)."""
+    with patch("app.services.buyplan_workflow.verify_po"):
+        with patch("app.services.buyplan_workflow.check_completion", return_value=None):
+            with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()):
+                with patch(
+                    "app.routers.htmx.approvals_hub.render_tab_body",
+                    return_value=_ok_html(),
+                ) as mock_render:
+                    resp = po_approver_client.post(
+                        f"/v2/partials/buy-plans/{buy_plan.id}/lines/1/verify-po",
+                        data={"action": "approve", "origin": "approvals_hub"},
+                    )
+    assert resp.status_code == 200
+    call_args = mock_render.call_args[0]
+    assert "all" in call_args

--- a/tests/test_clay_oauth_async_coverage.py
+++ b/tests/test_clay_oauth_async_coverage.py
@@ -1,0 +1,263 @@
+"""tests/test_clay_oauth_async_coverage.py — Async-function coverage for clay_oauth
+service.
+
+Covers: register_client, _persist_tokens, exchange_code, refresh, get_access_token.
+
+Called by: pytest (asyncio_mode=auto — no @pytest.mark.asyncio needed) Depends on:
+conftest.py, app.services.clay_oauth
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("TESTING", "1")
+
+
+class TestRegisterClient:
+    async def test_returns_existing_client_id(self):
+        """register_client() returns stored client_id without HTTP call."""
+        from app.services.clay_oauth import register_client
+
+        with patch("app.services.clay_oauth._load", return_value="cid-existing") as mock_load:
+            result = await register_client()
+
+        assert result == "cid-existing"
+        mock_load.assert_called_once_with("CLAY_OAUTH_CLIENT_ID")
+
+    async def test_registers_new_client_via_http(self):
+        """register_client() POSTs to CLAY_REGISTER_URL and stores returned
+        client_id."""
+        from app.services.clay_oauth import register_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"client_id": "cid-new"}
+
+        with (
+            patch("app.services.clay_oauth._load", return_value=None),
+            patch("app.services.clay_oauth.http") as mock_http,
+            patch("app.services.clay_oauth._store") as mock_store,
+        ):
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            result = await register_client()
+
+        assert result == "cid-new"
+        mock_store.assert_called_once_with({"CLAY_OAUTH_CLIENT_ID": "cid-new"})
+
+    async def test_raises_on_http_error(self):
+        """register_client() raises RuntimeError when registration HTTP call fails."""
+        from app.services.clay_oauth import register_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+
+        with (
+            patch("app.services.clay_oauth._load", return_value=None),
+            patch("app.services.clay_oauth.http") as mock_http,
+        ):
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            with pytest.raises(RuntimeError, match="Clay client registration failed"):
+                await register_client()
+
+    async def test_raises_when_response_missing_client_id(self):
+        """register_client() raises RuntimeError when DCR response omits client_id."""
+        from app.services.clay_oauth import register_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.json.return_value = {}
+
+        with (
+            patch("app.services.clay_oauth._load", return_value=None),
+            patch("app.services.clay_oauth.http") as mock_http,
+        ):
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            with pytest.raises(RuntimeError, match="missing client_id"):
+                await register_client()
+
+
+class TestPersistTokens:
+    def test_skips_when_no_access_token(self):
+        """_persist_tokens() does nothing when access_token is absent from dict."""
+        from app.services.clay_oauth import _persist_tokens
+
+        with patch("app.services.clay_oauth._store") as mock_store:
+            _persist_tokens({})
+
+        mock_store.assert_not_called()
+
+    def test_stores_tokens_with_refresh_token(self):
+        """_persist_tokens() includes CLAY_OAUTH_REFRESH_TOKEN when provided."""
+        from app.services.clay_oauth import _persist_tokens
+
+        tok = {"access_token": "at-abc", "refresh_token": "rt-xyz", "expires_in": 3600}
+
+        with patch("app.services.clay_oauth._store") as mock_store:
+            _persist_tokens(tok)
+
+        mock_store.assert_called_once()
+        updates = mock_store.call_args[0][0]
+        assert updates["CLAY_OAUTH_ACCESS_TOKEN"] == "at-abc"
+        assert updates["CLAY_OAUTH_REFRESH_TOKEN"] == "rt-xyz"
+        assert updates["CLAY_OAUTH_NEEDS_RECONNECT"] is None
+        assert "CLAY_OAUTH_EXPIRES_AT" in updates
+
+    def test_stores_tokens_without_refresh_token(self):
+        """_persist_tokens() omits CLAY_OAUTH_REFRESH_TOKEN when not in response
+        (rotation-aware)."""
+        from app.services.clay_oauth import _persist_tokens
+
+        tok = {"access_token": "at-abc", "expires_in": 3600}
+
+        with patch("app.services.clay_oauth._store") as mock_store:
+            _persist_tokens(tok)
+
+        updates = mock_store.call_args[0][0]
+        assert updates["CLAY_OAUTH_ACCESS_TOKEN"] == "at-abc"
+        assert "CLAY_OAUTH_REFRESH_TOKEN" not in updates
+        assert "CLAY_OAUTH_EXPIRES_AT" in updates
+
+
+class TestExchangeCode:
+    async def test_returns_true_on_success(self):
+        """exchange_code() persists tokens and returns True on 200 response."""
+        from app.services.clay_oauth import exchange_code
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"access_token": "at-xyz"}
+
+        with (
+            patch("app.services.clay_oauth.http") as mock_http,
+            patch("app.services.clay_oauth._persist_tokens") as mock_persist,
+        ):
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            result = await exchange_code("code-abc", "verifier-def", "cid-123")
+
+        assert result is True
+        mock_persist.assert_called_once_with({"access_token": "at-xyz"})
+
+    async def test_returns_false_on_http_error(self):
+        """exchange_code() returns False when HTTP call fails."""
+        from app.services.clay_oauth import exchange_code
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.json.return_value = {}
+
+        with patch("app.services.clay_oauth.http") as mock_http:
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            result = await exchange_code("code-bad", "verifier-bad", "cid-123")
+
+        assert result is False
+
+
+class TestRefresh:
+    async def test_returns_none_when_no_refresh_token(self):
+        """Refresh() returns None immediately when CLAY_OAUTH_REFRESH_TOKEN is
+        absent."""
+        from app.services.clay_oauth import refresh
+
+        with patch("app.services.clay_oauth._load", return_value=None):
+            result = await refresh()
+
+        assert result is None
+
+    async def test_returns_none_and_sets_needs_reconnect_on_http_failure(self):
+        """Refresh() marks needs_reconnect and returns None on HTTP failure."""
+        from app.services.clay_oauth import refresh
+
+        def _load_side(key):
+            return {"CLAY_OAUTH_REFRESH_TOKEN": "rt-token", "CLAY_OAUTH_CLIENT_ID": "cid-123"}.get(key)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.json.return_value = {}
+
+        with (
+            patch("app.services.clay_oauth._load", side_effect=_load_side),
+            patch("app.services.clay_oauth.http") as mock_http,
+            patch("app.services.clay_oauth._store") as mock_store,
+        ):
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            result = await refresh()
+
+        assert result is None
+        mock_store.assert_called_once()
+        updates = mock_store.call_args[0][0]
+        assert updates["CLAY_OAUTH_NEEDS_RECONNECT"] == "1"
+        assert updates["CLAY_OAUTH_ACCESS_TOKEN"] is None
+
+    async def test_returns_access_token_on_success(self):
+        """Refresh() persists new tokens and returns the new access token."""
+        from app.services.clay_oauth import refresh
+
+        def _load_side(key):
+            return {
+                "CLAY_OAUTH_REFRESH_TOKEN": "rt-token",
+                "CLAY_OAUTH_CLIENT_ID": "cid-123",
+                "CLAY_OAUTH_ACCESS_TOKEN": "new-at",
+            }.get(key)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"access_token": "new-at"}
+
+        with (
+            patch("app.services.clay_oauth._load", side_effect=_load_side),
+            patch("app.services.clay_oauth.http") as mock_http,
+            patch("app.services.clay_oauth._persist_tokens"),
+        ):
+            mock_http.post = AsyncMock(return_value=mock_resp)
+            result = await refresh()
+
+        assert result == "new-at"
+
+
+class TestGetAccessToken:
+    async def test_returns_none_when_no_token_and_no_refresh_token(self):
+        """get_access_token() returns None when both access token and refresh token are
+        absent."""
+        from app.services.clay_oauth import get_access_token
+
+        with patch("app.services.clay_oauth._load", return_value=None):
+            result = await get_access_token()
+
+        assert result is None
+
+    async def test_refreshes_when_token_is_expired(self):
+        """get_access_token() calls refresh() when stored token is past expiry
+        buffer."""
+        from app.services.clay_oauth import get_access_token
+
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
+        def _load_side(key):
+            return {"CLAY_OAUTH_ACCESS_TOKEN": "old-at", "CLAY_OAUTH_EXPIRES_AT": past}.get(key)
+
+        with (
+            patch("app.services.clay_oauth._load", side_effect=_load_side),
+            patch("app.services.clay_oauth.refresh", new_callable=AsyncMock, return_value="new-at") as mock_refresh,
+        ):
+            result = await get_access_token()
+
+        assert result == "new-at"
+        mock_refresh.assert_called_once()
+
+    async def test_returns_token_when_still_valid(self):
+        """get_access_token() returns stored token directly when expiry is in the
+        future."""
+        from app.services.clay_oauth import get_access_token
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        def _load_side(key):
+            return {"CLAY_OAUTH_ACCESS_TOKEN": "valid-at", "CLAY_OAUTH_EXPIRES_AT": future}.get(key)
+
+        with patch("app.services.clay_oauth._load", side_effect=_load_side):
+            result = await get_access_token()
+
+        assert result == "valid-at"

--- a/tests/test_coverage_nightly2_2026_07_05.py
+++ b/tests/test_coverage_nightly2_2026_07_05.py
@@ -1,0 +1,520 @@
+"""test_coverage_nightly2_2026_07_05.py — Nightly coverage fill-in (part 2).
+
+Targets modules below 85% coverage:
+  - app/jobs/worker_liveness_jobs.py (0%)
+  - app/jobs/maintenance_jobs.py (84%)
+
+Called by: pytest
+Depends on: conftest (db_session), unittest.mock
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ["TESTING"] = "1"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# app/jobs/worker_liveness_jobs.py
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestAsUtc:
+    def test_none_returns_none(self):
+        from app.jobs.worker_liveness_jobs import _as_utc
+
+        assert _as_utc(None) is None
+
+    def test_naive_datetime_gets_utc(self):
+        from app.jobs.worker_liveness_jobs import _as_utc
+
+        naive = datetime(2025, 6, 1, 12, 0, 0)
+        result = _as_utc(naive)
+        assert result.tzinfo == UTC
+        assert result.hour == 12
+
+    def test_aware_datetime_returned_as_is(self):
+        from app.jobs.worker_liveness_jobs import _as_utc
+
+        aware = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        result = _as_utc(aware)
+        assert result is aware
+
+
+class TestHeartbeatIsStale:
+    def test_not_running_never_stale(self):
+        from app.jobs.worker_liveness_jobs import heartbeat_is_stale
+
+        now = datetime.now(UTC)
+        assert heartbeat_is_stale(False, None, now, 5) is False
+
+    def test_not_running_old_heartbeat_still_not_stale(self):
+        from app.jobs.worker_liveness_jobs import heartbeat_is_stale
+
+        now = datetime.now(UTC)
+        hb = now - timedelta(hours=24)
+        assert heartbeat_is_stale(False, hb, now, 5) is False
+
+    def test_running_no_heartbeat_is_stale(self):
+        from app.jobs.worker_liveness_jobs import heartbeat_is_stale
+
+        now = datetime.now(UTC)
+        assert heartbeat_is_stale(True, None, now, 5) is True
+
+    def test_running_recent_heartbeat_not_stale(self):
+        from app.jobs.worker_liveness_jobs import heartbeat_is_stale
+
+        now = datetime.now(UTC)
+        hb = now - timedelta(minutes=2)
+        assert heartbeat_is_stale(True, hb, now, 5) is False
+
+    def test_running_old_heartbeat_is_stale(self):
+        from app.jobs.worker_liveness_jobs import heartbeat_is_stale
+
+        now = datetime.now(UTC)
+        hb = now - timedelta(minutes=10)
+        assert heartbeat_is_stale(True, hb, now, 5) is True
+
+    def test_naive_heartbeat_coerced_to_utc(self):
+        from app.jobs.worker_liveness_jobs import heartbeat_is_stale
+
+        now = datetime.now(UTC)
+        naive_hb = datetime.now() - timedelta(minutes=10)
+        assert heartbeat_is_stale(True, naive_hb, now, 5) is True
+
+
+class TestShouldAlertStaleHeartbeat:
+    def test_stale_and_not_alerted_returns_true(self):
+        from app.jobs.worker_liveness_jobs import should_alert_stale_heartbeat
+
+        now = datetime.now(UTC)
+        hb = now - timedelta(minutes=10)
+        result = should_alert_stale_heartbeat(
+            is_running=True,
+            last_heartbeat=hb,
+            now=now,
+            stale_after_minutes=5,
+            already_alerted=False,
+        )
+        assert result is True
+
+    def test_stale_but_already_alerted_returns_false(self):
+        from app.jobs.worker_liveness_jobs import should_alert_stale_heartbeat
+
+        now = datetime.now(UTC)
+        hb = now - timedelta(minutes=10)
+        result = should_alert_stale_heartbeat(
+            is_running=True,
+            last_heartbeat=hb,
+            now=now,
+            stale_after_minutes=5,
+            already_alerted=True,
+        )
+        assert result is False
+
+    def test_not_stale_returns_false(self):
+        from app.jobs.worker_liveness_jobs import should_alert_stale_heartbeat
+
+        now = datetime.now(UTC)
+        hb = now - timedelta(minutes=1)
+        result = should_alert_stale_heartbeat(
+            is_running=True,
+            last_heartbeat=hb,
+            now=now,
+            stale_after_minutes=5,
+            already_alerted=False,
+        )
+        assert result is False
+
+    def test_not_running_returns_false(self):
+        from app.jobs.worker_liveness_jobs import should_alert_stale_heartbeat
+
+        now = datetime.now(UTC)
+        result = should_alert_stale_heartbeat(
+            is_running=False,
+            last_heartbeat=None,
+            now=now,
+            stale_after_minutes=5,
+            already_alerted=False,
+        )
+        assert result is False
+
+
+class TestAlreadyAlerted:
+    def test_returns_true_when_cache_hit(self):
+        with patch("app.cache.intel_cache.get_cached", return_value={"alerted": 1}):
+            from app.jobs.worker_liveness_jobs import _already_alerted
+
+            assert _already_alerted("ics-label") is True
+
+    def test_returns_false_when_cache_miss(self):
+        with patch("app.cache.intel_cache.get_cached", return_value=None):
+            from app.jobs.worker_liveness_jobs import _already_alerted
+
+            assert _already_alerted("ics-label") is False
+
+
+class TestEmitAlert:
+    @pytest.mark.asyncio
+    async def test_sets_debounce_cache_and_calls_teams(self):
+        mock_teams = AsyncMock(return_value=None)
+        with (
+            patch("app.cache.intel_cache.set_cached") as mock_set,
+            patch("app.services.teams_notifications.post_teams_channel", mock_teams),
+            patch("app.services.search_worker_base.monitoring.capture_sentry_message"),
+        ):
+            from app.jobs.worker_liveness_jobs import _emit_alert
+
+            await _emit_alert("ICS", "Heartbeat stale for ICS worker", 60)
+
+        mock_set.assert_called_once_with("worker_alert:ICS", {"alerted": 1}, ttl_days=60 / 1440)
+        mock_teams.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_teams_failure_does_not_raise(self):
+        with (
+            patch("app.cache.intel_cache.set_cached"),
+            patch(
+                "app.services.teams_notifications.post_teams_channel",
+                side_effect=Exception("network error"),
+            ),
+            patch("app.services.search_worker_base.monitoring.capture_sentry_message"),
+        ):
+            from app.jobs.worker_liveness_jobs import _emit_alert
+
+            # Should not raise — Teams failure is caught and logged
+            await _emit_alert("ICS", "test message", 60)
+
+
+class TestRegisterWorkerLivenessJobs:
+    def test_registers_one_job(self):
+        from app.jobs.worker_liveness_jobs import register_worker_liveness_jobs
+
+        mock_scheduler = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.worker_liveness_check_minutes = 5
+        register_worker_liveness_jobs(mock_scheduler, mock_settings)
+        mock_scheduler.add_job.assert_called_once()
+
+    def test_job_id_is_correct(self):
+        from app.jobs.worker_liveness_jobs import register_worker_liveness_jobs
+
+        mock_scheduler = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.worker_liveness_check_minutes = 3
+        register_worker_liveness_jobs(mock_scheduler, mock_settings)
+        call_kwargs = mock_scheduler.add_job.call_args[1]
+        assert call_kwargs["id"] == "worker_liveness_check"
+
+
+class TestJobMonitorWorkerHeartbeats:
+    @pytest.mark.asyncio
+    async def test_all_rows_none_no_alerts(self):
+        from app.jobs.worker_liveness_jobs import _job_monitor_worker_heartbeats
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None
+
+        mock_settings = MagicMock()
+        mock_settings.worker_heartbeat_stale_minutes = 10
+        mock_settings.worker_alert_debounce_minutes = 60
+
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.config.settings", mock_settings),
+        ):
+            await _job_monitor_worker_heartbeats.__wrapped__()
+
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stale_worker_triggers_alert(self):
+        from app.jobs.worker_liveness_jobs import _job_monitor_worker_heartbeats
+
+        now = datetime.now(UTC)
+        mock_row = MagicMock()
+        mock_row.is_running = True
+        mock_row.last_heartbeat = now - timedelta(minutes=30)
+        mock_row.circuit_breaker_open = False
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = mock_row
+
+        mock_settings = MagicMock()
+        mock_settings.worker_heartbeat_stale_minutes = 10
+        mock_settings.worker_alert_debounce_minutes = 60
+
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.config.settings", mock_settings),
+            patch("app.cache.intel_cache.get_cached", return_value=None),
+            patch("app.cache.intel_cache.set_cached"),
+            patch("app.services.teams_notifications.post_teams_channel", AsyncMock()),
+            patch("app.services.search_worker_base.monitoring.capture_sentry_message"),
+        ):
+            await _job_monitor_worker_heartbeats.__wrapped__()
+
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_open_triggers_alert(self):
+        from app.jobs.worker_liveness_jobs import _job_monitor_worker_heartbeats
+
+        now = datetime.now(UTC)
+        mock_row = MagicMock()
+        mock_row.is_running = True
+        # Fresh heartbeat — not stale
+        mock_row.last_heartbeat = now - timedelta(minutes=1)
+        mock_row.circuit_breaker_open = True
+        mock_row.circuit_breaker_reason = "Rate limit exceeded"
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = mock_row
+
+        mock_settings = MagicMock()
+        mock_settings.worker_heartbeat_stale_minutes = 10
+        mock_settings.worker_alert_debounce_minutes = 60
+
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.config.settings", mock_settings),
+            patch("app.cache.intel_cache.get_cached", return_value=None),
+            patch("app.cache.intel_cache.set_cached"),
+            patch("app.services.teams_notifications.post_teams_channel", AsyncMock()),
+            patch("app.services.search_worker_base.monitoring.capture_sentry_message"),
+        ):
+            await _job_monitor_worker_heartbeats.__wrapped__()
+
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_already_alerted_skips_alert(self):
+        from app.jobs.worker_liveness_jobs import _job_monitor_worker_heartbeats
+
+        now = datetime.now(UTC)
+        mock_row = MagicMock()
+        mock_row.is_running = True
+        mock_row.last_heartbeat = now - timedelta(minutes=30)
+        mock_row.circuit_breaker_open = False
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = mock_row
+
+        mock_settings = MagicMock()
+        mock_settings.worker_heartbeat_stale_minutes = 10
+        mock_settings.worker_alert_debounce_minutes = 60
+
+        mock_teams = AsyncMock()
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.config.settings", mock_settings),
+            patch("app.cache.intel_cache.get_cached", return_value={"alerted": 1}),
+            patch("app.services.teams_notifications.post_teams_channel", mock_teams),
+        ):
+            await _job_monitor_worker_heartbeats.__wrapped__()
+
+        # Already alerted — no Teams message sent
+        mock_teams.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_heartbeat_age_unknown_when_none(self):
+        from app.jobs.worker_liveness_jobs import _job_monitor_worker_heartbeats
+
+        mock_row = MagicMock()
+        mock_row.is_running = True
+        mock_row.last_heartbeat = None  # Never seen — age = "unknown"
+        mock_row.circuit_breaker_open = False
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = mock_row
+
+        mock_settings = MagicMock()
+        mock_settings.worker_heartbeat_stale_minutes = 10
+        mock_settings.worker_alert_debounce_minutes = 60
+
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.config.settings", mock_settings),
+            patch("app.cache.intel_cache.get_cached", return_value=None),
+            patch("app.cache.intel_cache.set_cached"),
+            patch("app.services.teams_notifications.post_teams_channel", AsyncMock()),
+            patch("app.services.search_worker_base.monitoring.capture_sentry_message"),
+        ):
+            await _job_monitor_worker_heartbeats.__wrapped__()
+
+        mock_db.close.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# app/jobs/maintenance_jobs.py — missing lines 20-44, 162-190
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestRegisterMaintenanceJobs:
+    def test_registers_all_six_jobs(self):
+        from app.jobs.maintenance_jobs import register_maintenance_jobs
+
+        mock_scheduler = MagicMock()
+        mock_settings = MagicMock()
+        register_maintenance_jobs(mock_scheduler, mock_settings)
+        assert mock_scheduler.add_job.call_count == 6
+
+    def test_cache_cleanup_job_registered(self):
+        from app.jobs.maintenance_jobs import register_maintenance_jobs
+
+        mock_scheduler = MagicMock()
+        mock_settings = MagicMock()
+        register_maintenance_jobs(mock_scheduler, mock_settings)
+        job_ids = [call[1]["id"] for call in mock_scheduler.add_job.call_args_list]
+        assert "cache_cleanup" in job_ids
+
+    def test_contact_dedup_job_registered(self):
+        from app.jobs.maintenance_jobs import register_maintenance_jobs
+
+        mock_scheduler = MagicMock()
+        mock_settings = MagicMock()
+        register_maintenance_jobs(mock_scheduler, mock_settings)
+        job_ids = [call[1]["id"] for call in mock_scheduler.add_job.call_args_list]
+        assert "contact_dedup" in job_ids
+
+
+class TestJobContactDedup:
+    @pytest.mark.asyncio
+    async def test_with_duplicate_contacts_merges_them(self):
+        from app.jobs.maintenance_jobs import _job_contact_dedup
+
+        # Build fake duplicate pair
+        dupe = MagicMock()
+        dupe.customer_site_id = 1
+        dupe.em = "dup@example.com"
+
+        contact_keeper = MagicMock()
+        contact_keeper.id = 10
+        contact_keeper.full_name = "Jane Doe"
+        contact_keeper.title = "Engineer"
+        contact_keeper.phone = "555-0100"
+        contact_keeper.notes = "VIP"
+        contact_keeper.linkedin_url = None
+
+        contact_dup = MagicMock()
+        contact_dup.id = 11
+        contact_dup.full_name = None
+        contact_dup.title = None
+        contact_dup.phone = None
+        contact_dup.notes = None
+        contact_dup.linkedin_url = None
+
+        mock_db = MagicMock()
+
+        # First query: find duplicate groups (.filter → .group_by → .having → .all)
+        mock_db.query.return_value.filter.return_value.group_by.return_value.having.return_value.all.return_value = [
+            dupe
+        ]
+        # Second query: fetch contacts in that group (.filter → .order_by → .all)
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+            contact_keeper,
+            contact_dup,
+        ]
+
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.services.contact_merge_service.merge_contacts") as mock_merge,
+        ):
+            await _job_contact_dedup.__wrapped__()
+
+        mock_merge.assert_called_once_with(contact_keeper.id, contact_dup.id, mock_db)
+        mock_db.commit.assert_called()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_merged_count_logged(self):
+        from app.jobs.maintenance_jobs import _job_contact_dedup
+
+        dupe = MagicMock()
+        dupe.customer_site_id = 2
+        dupe.em = "log@example.com"
+
+        c1 = MagicMock()
+        c1.id = 20
+        c1.full_name = "Alice"
+        c1.title = "PM"
+        c1.phone = None
+        c1.notes = None
+        c1.linkedin_url = None
+
+        c2 = MagicMock()
+        c2.id = 21
+        c2.full_name = None
+        c2.title = None
+        c2.phone = None
+        c2.notes = None
+        c2.linkedin_url = None
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.group_by.return_value.having.return_value.all.return_value = [
+            dupe
+        ]
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+            c1,
+            c2,
+        ]
+
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.services.contact_merge_service.merge_contacts"),
+        ):
+            await _job_contact_dedup.__wrapped__()
+
+        # Commit called with merged > 0 path executed
+        mock_db.commit.assert_called()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_merge_exception_skipped_continues(self):
+        from app.jobs.maintenance_jobs import _job_contact_dedup
+
+        dupe = MagicMock()
+        dupe.customer_site_id = 3
+        dupe.em = "err@example.com"
+
+        c1 = MagicMock()
+        c1.id = 30
+        c1.full_name = "Bob"
+        c1.title = None
+        c1.phone = None
+        c1.notes = None
+        c1.linkedin_url = None
+
+        c2 = MagicMock()
+        c2.id = 31
+        c2.full_name = None
+        c2.title = None
+        c2.phone = None
+        c2.notes = None
+        c2.linkedin_url = None
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.group_by.return_value.having.return_value.all.return_value = [
+            dupe
+        ]
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+            c1,
+            c2,
+        ]
+
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch(
+                "app.services.contact_merge_service.merge_contacts",
+                side_effect=Exception("merge failed"),
+            ),
+        ):
+            # Should not raise — per-pair exceptions are caught and logged
+            await _job_contact_dedup.__wrapped__()
+
+        mock_db.close.assert_called_once()

--- a/tests/test_coverage_nightly_2026_07_05.py
+++ b/tests/test_coverage_nightly_2026_07_05.py
@@ -1,0 +1,672 @@
+"""test_coverage_nightly_2026_07_05.py — Nightly coverage fill-in.
+
+Targets modules below 85% coverage:
+  - app/jobs/resell_jobs.py (73%)
+  - app/services/ticket_prompt_service.py (82%)
+  - app/services/prepayment_notifications.py (75%)
+
+Called by: pytest
+Depends on: conftest (db_session), unittest.mock
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+os.environ["TESTING"] = "1"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# app/jobs/resell_jobs.py
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestResellJobs:
+    """Cover the error branches and zero-result path in _job_expire_resell_lists."""
+
+    def _make_job(self):
+        from app.jobs.resell_jobs import _job_expire_resell_lists
+
+        return _job_expire_resell_lists
+
+    @pytest.mark.asyncio
+    async def test_zero_expired_no_log(self):
+        job = self._make_job()
+        mock_db = MagicMock()
+        # Lazy imports inside function body — patch at the source module
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.services.excess_service.expire_overdue_lists", return_value=0),
+        ):
+            # when expired=0 the "if expired:" branch is skipped — no raise
+            await job.__wrapped__()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_positive_expired_logs(self):
+        job = self._make_job()
+        mock_db = MagicMock()
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch("app.services.excess_service.expire_overdue_lists", return_value=3),
+        ):
+            await job.__wrapped__()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sqlalchemy_error_rollback(self):
+        import sqlalchemy.exc
+
+        job = self._make_job()
+        mock_db = MagicMock()
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch(
+                "app.services.excess_service.expire_overdue_lists",
+                side_effect=sqlalchemy.exc.SQLAlchemyError("db error"),
+            ),
+        ):
+            await job.__wrapped__()  # Must NOT raise
+        mock_db.rollback.assert_called_once()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_rollback(self):
+        job = self._make_job()
+        mock_db = MagicMock()
+        with (
+            patch("app.database.SessionLocal", return_value=mock_db),
+            patch(
+                "app.services.excess_service.expire_overdue_lists",
+                side_effect=RuntimeError("unexpected"),
+            ),
+        ):
+            await job.__wrapped__()  # Must NOT raise
+        mock_db.rollback.assert_called_once()
+        mock_db.close.assert_called_once()
+
+    def test_register_resell_jobs(self):
+        from app.jobs.resell_jobs import register_resell_jobs
+
+        scheduler = MagicMock()
+        settings = MagicMock()
+        register_resell_jobs(scheduler, settings)
+        scheduler.add_job.assert_called_once()
+        call_kwargs = scheduler.add_job.call_args
+        assert call_kwargs[1]["id"] == "expire_resell_lists" or call_kwargs.kwargs.get("id") == "expire_resell_lists"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# app/services/ticket_prompt_service.py
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _make_mock_ticket(ticket_type="bug", *, with_all_fields=False):
+    """Return a MagicMock shaped like a TroubleTicket."""
+    t = MagicMock()
+    t.ticket_number = "TKT-001"
+    t.ticket_type = ticket_type
+    t.description = "Something broke"
+    t.current_page = "/sourcing"
+    t.current_view = "sourcing_list"
+    t.browser_info = "Chrome/120"
+    t.admin_notes = "Fix ASAP"
+    if with_all_fields:
+        t.console_errors = "TypeError: Cannot read property"
+        t.network_errors = {"url": "/api/foo", "status": 500}
+        t.page_state = "modal_open=true"
+        t.screenshot_path = "/screenshots/abc.png"
+        t.screenshot_b64 = None
+    else:
+        t.console_errors = None
+        t.network_errors = None
+        t.page_state = None
+        t.screenshot_path = None
+        t.screenshot_b64 = None
+    return t
+
+
+class TestBuildBugPrompt:
+    def test_minimal_fields(self):
+        from app.services.ticket_prompt_service import _build_bug_prompt
+
+        t = _make_mock_ticket()
+        result = _build_bug_prompt(t)
+        assert "TKT-001" in result
+        assert "Something broke" in result
+
+    def test_all_optional_fields(self):
+        from app.services.ticket_prompt_service import _build_bug_prompt
+
+        t = _make_mock_ticket(with_all_fields=True)
+        result = _build_bug_prompt(t)
+        assert "TypeError" in result
+        assert "/api/foo" in result or "500" in result
+        assert "modal_open" in result
+        assert "screenshot" in result.lower()
+
+    def test_screenshot_b64_triggers_screenshot_line(self):
+        from app.services.ticket_prompt_service import _build_bug_prompt
+
+        t = _make_mock_ticket()
+        t.screenshot_path = None
+        t.screenshot_b64 = "base64data"
+        result = _build_bug_prompt(t)
+        assert "screenshot" in result.lower()
+
+    def test_no_description(self):
+        from app.services.ticket_prompt_service import _build_bug_prompt
+
+        t = _make_mock_ticket()
+        t.description = None
+        result = _build_bug_prompt(t)
+        assert "TKT-001" in result
+
+
+class TestBuildFeaturePrompt:
+    def test_minimal_fields(self):
+        from app.services.ticket_prompt_service import _build_feature_prompt
+
+        t = _make_mock_ticket(ticket_type="feature")
+        t.description = "Add export button"
+        result = _build_feature_prompt(t)
+        assert "TKT-001" in result
+        assert "Add export button" in result
+
+    def test_screenshot_included(self):
+        from app.services.ticket_prompt_service import _build_feature_prompt
+
+        t = _make_mock_ticket(ticket_type="feature")
+        t.screenshot_path = "/screenshots/feature.png"
+        result = _build_feature_prompt(t)
+        assert "screenshot" in result.lower()
+
+    def test_b64_screenshot_included(self):
+        from app.services.ticket_prompt_service import _build_feature_prompt
+
+        t = _make_mock_ticket(ticket_type="feature")
+        t.screenshot_path = None
+        t.screenshot_b64 = "b64data"
+        result = _build_feature_prompt(t)
+        assert "screenshot" in result.lower()
+
+    def test_no_description(self):
+        from app.services.ticket_prompt_service import _build_feature_prompt
+
+        t = _make_mock_ticket(ticket_type="feature")
+        t.description = None
+        result = _build_feature_prompt(t)
+        assert "TKT-001" in result
+
+    def test_no_current_page(self):
+        from app.services.ticket_prompt_service import _build_feature_prompt
+
+        t = _make_mock_ticket(ticket_type="feature")
+        t.current_page = None
+        result = _build_feature_prompt(t)
+        assert "TKT-001" in result
+
+    def test_no_admin_notes(self):
+        from app.services.ticket_prompt_service import _build_feature_prompt
+
+        t = _make_mock_ticket(ticket_type="feature")
+        t.admin_notes = None
+        result = _build_feature_prompt(t)
+        assert "TKT-001" in result
+
+
+class TestGenerateTicketPrompt:
+    @pytest.mark.asyncio
+    async def test_bug_prompt_generated_and_persisted(self, db_session: Session):
+        from app.constants import TicketType
+        from app.services.ticket_prompt_service import generate_ticket_prompt
+
+        t = MagicMock()
+        t.ticket_number = "TKT-BUG-1"
+        t.ticket_type = TicketType.BUG
+        t.description = "Breaks on save"
+        t.current_page = "/edit"
+        t.current_view = None
+        t.browser_info = None
+        t.console_errors = None
+        t.network_errors = None
+        t.page_state = None
+        t.screenshot_path = None
+        t.screenshot_b64 = None
+        t.admin_notes = None
+
+        with patch("app.services.ticket_prompt_service.claude_text", new=AsyncMock(return_value="  Fix the bug  ")):
+            result = await generate_ticket_prompt(db_session, t)
+
+        assert result == "Fix the bug"
+        assert t.generated_prompt == "Fix the bug"
+
+    @pytest.mark.asyncio
+    async def test_feature_prompt_generated(self, db_session: Session):
+        from app.constants import TicketType
+        from app.services.ticket_prompt_service import generate_ticket_prompt
+
+        t = MagicMock()
+        t.ticket_number = "TKT-FEAT-1"
+        t.ticket_type = TicketType.FEATURE
+        t.description = "Add export"
+        t.current_page = "/reports"
+        t.current_view = None
+        t.screenshot_path = None
+        t.screenshot_b64 = None
+        t.admin_notes = "High priority"
+
+        with patch("app.services.ticket_prompt_service.claude_text", new=AsyncMock(return_value="Build the feature")):
+            result = await generate_ticket_prompt(db_session, t)
+
+        assert result == "Build the feature"
+
+    @pytest.mark.asyncio
+    async def test_claude_returns_none_returns_none(self, db_session: Session):
+        from app.constants import TicketType
+        from app.services.ticket_prompt_service import generate_ticket_prompt
+
+        t = MagicMock()
+        t.ticket_number = "TKT-NULL-1"
+        t.ticket_type = TicketType.BUG
+        t.description = None
+        t.current_page = None
+        t.current_view = None
+        t.browser_info = None
+        t.console_errors = None
+        t.network_errors = None
+        t.page_state = None
+        t.screenshot_path = None
+        t.screenshot_b64 = None
+        t.admin_notes = None
+
+        with patch("app.services.ticket_prompt_service.claude_text", new=AsyncMock(return_value=None)):
+            result = await generate_ticket_prompt(db_session, t)
+
+        assert result is None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# app/services/prepayment_notifications.py  — additional coverage
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _make_prepayment_stub(db: Session) -> object:
+    """Minimal Prepayment-shaped mock backed by the real DB so foreign-key refs work."""
+    from app.models import User
+    from app.models.buy_plan import BuyPlan, BuyPlanLine
+    from app.models.quality_plan import Prepayment
+    from app.models.quotes import Quote
+    from app.models.sourcing import Requisition
+    from app.models.vendors import VendorCard
+
+    u = User(
+        email=f"pn-u-{uuid.uuid4().hex[:6]}@trioscs.com",
+        role="buyer",
+        azure_id=uuid.uuid4().hex,
+        is_active=True,
+        created_at=datetime.now(UTC),
+    )
+    db.add(u)
+    db.flush()
+    req = Requisition(
+        name=f"REQ-{uuid.uuid4().hex[:6]}",
+        customer_name="Cust",
+        status="active",
+        created_by=u.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(req)
+    db.flush()
+    q = Quote(
+        requisition_id=req.id,
+        quote_number=uuid.uuid4().hex,
+        line_items=[],
+        status="sent",
+        created_by_id=u.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.flush()
+    bp = BuyPlan(
+        requisition_id=req.id,
+        quote_id=q.id,
+        status="active",
+        so_status="approved",
+        submitted_by_id=u.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(bp)
+    db.flush()
+    vc = VendorCard(
+        normalized_name=uuid.uuid4().hex,
+        display_name="Vendor Display",
+        legal_name=None,
+    )
+    db.add(vc)
+    db.flush()
+    line = BuyPlanLine(
+        buy_plan_id=bp.id,
+        quantity=1,
+        unit_cost=100.0,
+        status="pending_verify",
+        po_number="PO-100",
+        po_confirmed_at=datetime.now(UTC),
+    )
+    db.add(line)
+    db.flush()
+    pp = Prepayment(
+        buy_plan_id=bp.id,
+        buy_plan_line_id=line.id,
+        vendor_card_id=vc.id,
+        vendor_name="Vendor Snapshot",
+        total_incl_fees=Decimal("1000.00"),
+        currency="USD",
+        created_by_id=u.id,
+        status="requested",
+    )
+    db.add(pp)
+    db.commit()
+    return pp
+
+
+class TestPrepaymentNotificationsExtra:
+    def test_schedule_prepayment_notify_no_loop(self):
+        """With no running event loop, close() is called on the coro (no dispatch)."""
+        from app.services.prepayment_notifications import schedule_prepayment_notify
+
+        coro = MagicMock()
+        coro.close = MagicMock()
+
+        # asyncio is imported lazily inside the function body — patch at source
+        with patch("asyncio.get_running_loop", side_effect=RuntimeError("no loop")):
+            schedule_prepayment_notify(coro)
+
+        coro.close.assert_called_once()
+
+    def test_schedule_prepayment_notify_with_loop(self):
+        """With a running event loop, create_task is called."""
+        from app.services.prepayment_notifications import schedule_prepayment_notify
+
+        coro = MagicMock()
+        mock_loop = MagicMock()
+
+        with patch("asyncio.get_running_loop", return_value=mock_loop):
+            schedule_prepayment_notify(coro)
+
+        mock_loop.create_task.assert_called_once_with(coro)
+
+    def test_beneficiary_vendor_name_fallback(self, db_session: Session):
+        """_beneficiary falls back to vendor_name when legal_name is None."""
+        from app.services.prepayment_notifications import _beneficiary
+
+        pp = _make_prepayment_stub(db_session)
+        pp.vendor_name = "Snapshot Name"
+        # legal_name is None from _make_prepayment_stub
+        result = _beneficiary(pp)
+        assert result == "Snapshot Name"
+
+    def test_beneficiary_display_name_fallback(self, db_session: Session):
+        """_beneficiary falls back to vc.display_name when no legal or snapshot."""
+        from app.services.prepayment_notifications import _beneficiary
+
+        pp = _make_prepayment_stub(db_session)
+        pp.vendor_name = None
+        # vc.legal_name is None, vc.display_name = "Vendor Display"
+        result = _beneficiary(pp)
+        assert result == "Vendor Display"
+
+    def test_beneficiary_dash_when_no_card(self, db_session: Session):
+        """_beneficiary returns '—' when no vendor_card and no vendor_name."""
+        from app.services.prepayment_notifications import _beneficiary
+
+        pp = _make_prepayment_stub(db_session)
+        pp.vendor_name = None
+        pp.vendor_card = None
+        result = _beneficiary(pp)
+        assert result == "—"
+
+    def test_confirm_url_with_token(self, db_session: Session):
+        """_confirm_url returns a URL when pay_token is set."""
+        from app.services.prepayment_notifications import _confirm_url
+
+        pp = _make_prepayment_stub(db_session)
+        pp.pay_token = "tok-abc123"
+        with patch("app.services.prepayment_notifications.settings") as mock_settings:
+            mock_settings.app_url = "https://app.example.com"
+            url = _confirm_url(pp)
+        assert url == "https://app.example.com/p/confirm/tok-abc123"
+
+    def test_confirm_url_none_when_no_token(self, db_session: Session):
+        """_confirm_url returns None when pay_token is absent."""
+        from app.services.prepayment_notifications import _confirm_url
+
+        pp = _make_prepayment_stub(db_session)
+        pp.pay_token = None
+        result = _confirm_url(pp)
+        assert result is None
+
+    def test_facts_buyer_remarks_included(self, db_session: Session):
+        """_facts appends buyer_remarks when present."""
+        from app.services.prepayment_notifications import _facts
+
+        pp = _make_prepayment_stub(db_session)
+        pp.buyer_remarks = "Rush order"
+        facts = dict(_facts(pp, "requested"))
+        assert "Buyer remarks" in facts
+        assert facts["Buyer remarks"] == "Rush order"
+
+    def test_facts_approved_with_approver(self, db_session: Session):
+        """_facts includes Approved by + Approved at on the approved event."""
+        from app.services.prepayment_notifications import _facts
+
+        pp = _make_prepayment_stub(db_session)
+        pp.buyer_remarks = None
+        facts = dict(_facts(pp, "approved", approver="Jane Smith", decided_at=datetime.now(UTC)))
+        assert "Approved by" in facts
+        assert facts["Approved by"] == "Jane Smith"
+        assert "Approved at" in facts
+
+    def test_facts_approved_without_approver(self, db_session: Session):
+        """_facts approved event without approver/decided_at skips those rows."""
+        from app.services.prepayment_notifications import _facts
+
+        pp = _make_prepayment_stub(db_session)
+        pp.buyer_remarks = None
+        facts = dict(_facts(pp, "approved", approver=None, decided_at=None))
+        assert "Approved by" not in facts
+        assert "Approved at" not in facts
+
+    def test_facts_voided_with_reason(self, db_session: Session):
+        """_facts voided event adds void_reason row."""
+        from app.services.prepayment_notifications import _facts
+
+        pp = _make_prepayment_stub(db_session)
+        pp.void_reason = "Cancelled by buyer"
+        pp.buyer_remarks = None
+        facts = dict(_facts(pp, "voided"))
+        assert "Void reason" in facts
+
+    def test_facts_paid_with_wire_reference(self, db_session: Session):
+        """_facts paid event includes wire_reference and paid_by_label."""
+        from app.services.prepayment_notifications import _facts
+
+        pp = _make_prepayment_stub(db_session)
+        pp.wire_reference = "WIRE-XYZ"
+        pp.paid_by_label = "MK"
+        pp.buyer_remarks = None
+        facts = dict(_facts(pp, "paid"))
+        assert "Wire reference" in facts
+        assert facts["Wire reference"] == "WIRE-XYZ"
+        assert facts["Paid by"] == "MK"
+
+    def test_facts_paid_without_wire_reference(self, db_session: Session):
+        """_facts paid event without wire_reference skips those rows."""
+        from app.services.prepayment_notifications import _facts
+
+        pp = _make_prepayment_stub(db_session)
+        pp.wire_reference = None
+        pp.paid_by_label = None
+        pp.buyer_remarks = None
+        facts = dict(_facts(pp, "paid"))
+        assert "Wire reference" not in facts
+
+    def test_email_html_with_confirm_button(self, db_session: Session):
+        """_email_html includes the confirm-wire button on approved event when pay_token
+        set."""
+        from app.services.prepayment_notifications import _email_html
+
+        pp = _make_prepayment_stub(db_session)
+        pp.pay_token = "tok-confirm"
+        pp.buyer_remarks = None
+        with patch("app.services.prepayment_notifications.settings") as mock_settings:
+            mock_settings.app_url = "https://avail.test"
+            html = _email_html(pp, "approved")
+        assert "Confirm wire sent" in html
+        assert "tok-confirm" in html
+
+    def test_email_html_no_confirm_button_when_no_token(self, db_session: Session):
+        """_email_html omits the button when pay_token is None."""
+        from app.services.prepayment_notifications import _email_html
+
+        pp = _make_prepayment_stub(db_session)
+        pp.pay_token = None
+        pp.buyer_remarks = None
+        html = _email_html(pp, "approved")
+        assert "Confirm wire sent" not in html
+
+    def test_send_group_email_no_admin_token(self, db_session: Session):
+        """_send_group_email returns False when no admin has a live Graph token."""
+        from app.services.prepayment_notifications import _send_group_email
+
+        with patch("app.services.prepayment_notifications.settings") as mock_s:
+            mock_s.admin_emails = []  # no admins configured
+            import asyncio
+
+            result = asyncio.get_event_loop().run_until_complete(
+                _send_group_email(db_session, ["ap@example.com"], "Subject", "<p>body</p>")
+            )
+        assert result is False
+
+    def test_send_group_email_empty_recipients(self, db_session: Session):
+        """_send_group_email returns False for an empty recipient list."""
+        import asyncio
+
+        from app.services.prepayment_notifications import _send_group_email
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _send_group_email(db_session, [], "Subject", "<p>body</p>")
+        )
+        assert result is False
+
+    def test_write_failure_alert_exception_does_not_raise(self, db_session: Session):
+        """_write_failure_alert's inner exception path is swallowed."""
+        from app.services.prepayment_notifications import _write_failure_alert
+
+        pp = _make_prepayment_stub(db_session)
+
+        # Patch db.add to raise on second call (after adding the first ActivityLog)
+        orig_add = db_session.add
+        call_count = [0]
+
+        def bad_add(obj):
+            call_count[0] += 1
+            if call_count[0] > 1:
+                raise RuntimeError("db exploded")
+            return orig_add(obj)
+
+        with patch.object(db_session, "add", side_effect=bad_add):
+            _write_failure_alert(db_session, pp)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_notify_paid_inner_no_prepayment(self, db_session: Session):
+        """_notify_paid_inner returns early when prepayment not found."""
+        from app.services.prepayment_notifications import _notify_paid_inner
+
+        result = _notify_paid_inner(db_session, prepayment_id=99999)
+        assert result == {"alerted": []}
+
+    @pytest.mark.asyncio
+    async def test_notify_prepayment_paid_own_session(self):
+        """notify_prepayment_paid opens its own session when db=None."""
+        from app.services import prepayment_notifications as pn
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None  # prepayment not found — return early
+        mock_db.close = MagicMock()
+
+        # SessionLocal is lazily imported inside the function body
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            await pn.notify_prepayment_paid(99999, db=None)
+
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notify_inner_own_session_closed(self):
+        """_notify opens its own session when db=None and closes it after."""
+        from app.services import prepayment_notifications as pn
+
+        mock_db = MagicMock()
+        mock_db.get.return_value = None  # prepayment not found
+        mock_db.close = MagicMock()
+
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            await pn.notify_prepayment_requested(99999, db=None)
+
+        mock_db.close.assert_called_once()
+
+    def test_heading_voided_with_reason(self):
+        """_heading for voided event includes the reason."""
+        from app.services.prepayment_notifications import _heading
+
+        result = _heading("voided", reason="plan torn down")
+        assert "DO NOT WIRE" in result
+        assert "plan torn down" in result
+
+    def test_heading_voided_no_reason(self):
+        """_heading for voided event uses '—' when no reason."""
+        from app.services.prepayment_notifications import _heading
+
+        result = _heading("voided", reason=None)
+        assert "DO NOT WIRE" in result
+        assert "—" in result
+
+    def test_heading_unknown_event_defaults_to_requested(self):
+        """_heading for unknown event falls back to requested heading."""
+        from app.services.prepayment_notifications import _heading
+
+        result = _heading("something_new")
+        assert "PENDING APPROVAL" in result
+
+    def test_notify_inner_prepayment_not_found(self, db_session: Session):
+        """_notify_inner returns empty result when prepayment not found."""
+        import asyncio
+
+        from app.services.prepayment_notifications import _notify_inner
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _notify_inner(db_session, prepayment_id=99999, event="requested")
+        )
+        assert result == {"email_sent": False, "teams_sent": False, "recipients": []}
+
+    def test_notify_paid_inner_no_user_ids(self, db_session: Session):
+        """_notify_paid_inner returns empty alerted when no user IDs could be
+        resolved."""
+        from app.services.prepayment_notifications import _notify_paid_inner
+
+        pp = _make_prepayment_stub(db_session)
+        pp.created_by_id = None
+        pp.buy_plan.submitted_by_id = None
+        db_session.flush()
+        # No managers in DB, no created_by_id, no submitted_by_id
+        result = _notify_paid_inner(db_session, pp.id)
+        # May or may not be empty depending on managers in DB — just verify no raise
+        assert isinstance(result, dict)
+        assert "alerted" in result

--- a/tests/test_credential_service.py
+++ b/tests/test_credential_service.py
@@ -1,10 +1,9 @@
 """test_credential_service.py — Round-trip tests for credential encrypt/decrypt.
 
-Covers encrypt_value, decrypt_value, mask_value, get_credential, and
-credential_is_set from the credential service.
+Covers encrypt_value, decrypt_value, mask_value, get_credential, and credential_is_set
+from the credential service.
 
-Called by: pytest
-Depends on: app.services.credential_service, app.models.ApiSource
+Called by: pytest Depends on: app.services.credential_service, app.models.ApiSource
 """
 
 import os
@@ -155,3 +154,291 @@ class TestCredentialIsSet:
     def test_false_when_nothing_set(self, db_session, monkeypatch):
         monkeypatch.delenv("NOPE_KEY", raising=False)
         assert credential_is_set(db_session, "nonexistent", "NOPE_KEY") is False
+
+
+# ── _get_fernet with ENCRYPTION_SALT set ─────────────────────────────
+
+
+class TestGetFernetWithSalt:
+    """Exercises line 38 — the settings.encryption_salt branch inside _get_fernet()."""
+
+    def test_encrypt_decrypt_round_trip_with_salt(self, monkeypatch):
+        from types import SimpleNamespace
+
+        import app.services.credential_service as cred_svc
+
+        fake_settings = SimpleNamespace(
+            secret_key=cred_svc.settings.secret_key,
+            encryption_salt="custom-test-salt",
+        )
+        monkeypatch.setattr(cred_svc, "settings", fake_settings)
+
+        # Both encrypt_value and decrypt_value call _get_fernet() which now
+        # takes the salt branch (line 38); the round-trip must still hold.
+        plaintext = "salted-secret-value"
+        assert decrypt_value(encrypt_value(plaintext)) == plaintext
+
+
+# ── _try_decrypt ──────────────────────────────────────────────────────
+
+
+class TestTryDecrypt:
+    """Unit tests for _try_decrypt (lines 80-86 — the except handler)."""
+
+    def test_returns_none_for_none_input(self):
+        from app.services.credential_service import _try_decrypt
+
+        assert _try_decrypt(None, "SOME_VAR") is None
+
+    def test_returns_plaintext_for_valid_ciphertext(self):
+        from app.services.credential_service import _try_decrypt
+
+        encrypted = encrypt_value("my-credential-value")
+        assert _try_decrypt(encrypted, "SOME_VAR") == "my-credential-value"
+
+    def test_returns_none_and_logs_on_corrupt_ciphertext(self):
+        from app.services.credential_service import _try_decrypt
+
+        # Junk input triggers the except block at lines 84-86.
+        result = _try_decrypt("not-valid-fernet-data", "BAD_VAR")
+        assert result is None
+
+
+# ── get_credential with decrypt failure ───────────────────────────────
+
+
+class TestGetCredentialDecryptFailure:
+    """Exercises lines 107-114 (decrypt error path) and line 117 (env fallback
+    warning)."""
+
+    def _add_corrupted_source(self, db_session, name: str, key: str) -> None:
+        src = ApiSource(
+            name=name,
+            display_name=f"{name} display",
+            category="api",
+            source_type="aggregator",
+            status="active",
+            env_vars=[key],
+            credentials={key: "corrupted-not-valid-fernet-data"},
+        )
+        db_session.add(src)
+        db_session.commit()
+
+    def test_returns_none_when_decrypt_fails_and_no_env_var(self, db_session, monkeypatch):
+        monkeypatch.delenv("CORRUPT_KEY_A", raising=False)
+        self._add_corrupted_source(db_session, "corrupt_src_a", "CORRUPT_KEY_A")
+        result = get_credential(db_session, "corrupt_src_a", "CORRUPT_KEY_A")
+        assert result is None
+
+    def test_returns_env_var_when_decrypt_fails_with_fallback(self, db_session, monkeypatch):
+        # Covers line 117 — logger.warning for env var fallback after decrypt failure.
+        monkeypatch.setenv("CORRUPT_KEY_B", "env-fallback-value")
+        self._add_corrupted_source(db_session, "corrupt_src_b", "CORRUPT_KEY_B")
+        result = get_credential(db_session, "corrupt_src_b", "CORRUPT_KEY_B")
+        assert result == "env-fallback-value"
+
+
+# ── get_all_credentials_for_source ────────────────────────────────────
+
+
+class TestGetAllCredentialsForSource:
+    """Tests for lines 126-137 — the loop over env_vars decrypting each one."""
+
+    def test_returns_empty_dict_when_source_not_found(self, db_session):
+        from app.services.credential_service import get_all_credentials_for_source
+
+        assert get_all_credentials_for_source(db_session, "ghost_source_xyz") == {}
+
+    def test_returns_all_decrypted_db_credentials(self, db_session):
+        from app.services.credential_service import get_all_credentials_for_source
+
+        src = ApiSource(
+            name="all_creds_src_1",
+            display_name="All Creds 1",
+            category="api",
+            source_type="aggregator",
+            status="active",
+            env_vars=["KEY_ALPHA", "KEY_BETA"],
+            credentials={
+                "KEY_ALPHA": encrypt_value("alpha-val"),
+                "KEY_BETA": encrypt_value("beta-val"),
+            },
+        )
+        db_session.add(src)
+        db_session.commit()
+
+        result = get_all_credentials_for_source(db_session, "all_creds_src_1")
+        assert result == {"KEY_ALPHA": "alpha-val", "KEY_BETA": "beta-val"}
+
+    def test_falls_back_to_env_var_for_missing_db_credential(self, db_session, monkeypatch):
+        from app.services.credential_service import get_all_credentials_for_source
+
+        monkeypatch.setenv("ENV_ONLY_KEY_X", "env-only-val")
+        src = ApiSource(
+            name="all_creds_src_2",
+            display_name="All Creds 2",
+            category="api",
+            source_type="aggregator",
+            status="active",
+            env_vars=["ENV_ONLY_KEY_X"],
+            credentials={},
+        )
+        db_session.add(src)
+        db_session.commit()
+
+        result = get_all_credentials_for_source(db_session, "all_creds_src_2")
+        assert result == {"ENV_ONLY_KEY_X": "env-only-val"}
+
+    def test_omits_var_when_no_db_cred_and_no_env_var(self, db_session, monkeypatch):
+        from app.services.credential_service import get_all_credentials_for_source
+
+        monkeypatch.delenv("NO_VAL_KEY", raising=False)
+        src = ApiSource(
+            name="all_creds_src_3",
+            display_name="All Creds 3",
+            category="api",
+            source_type="aggregator",
+            status="active",
+            env_vars=["NO_VAL_KEY"],
+            credentials={},
+        )
+        db_session.add(src)
+        db_session.commit()
+
+        result = get_all_credentials_for_source(db_session, "all_creds_src_3")
+        assert result == {}
+
+
+# ── get_credentials_batch ─────────────────────────────────────────────
+
+
+class TestGetCredentialsBatch:
+    """Tests for lines 157-167 — the batch loop."""
+
+    def test_returns_db_credential(self, db_session):
+        from app.services.credential_service import get_credentials_batch
+
+        src = ApiSource(
+            name="batch_src_1",
+            display_name="Batch 1",
+            category="api",
+            source_type="aggregator",
+            status="active",
+            env_vars=["BATCH_KEY_A"],
+            credentials={"BATCH_KEY_A": encrypt_value("batch-val-a")},
+        )
+        db_session.add(src)
+        db_session.commit()
+
+        result = get_credentials_batch(db_session, [("batch_src_1", "BATCH_KEY_A")])
+        assert result == {("batch_src_1", "BATCH_KEY_A"): "batch-val-a"}
+
+    def test_falls_back_to_env_var(self, db_session, monkeypatch):
+        from app.services.credential_service import get_credentials_batch
+
+        monkeypatch.setenv("BATCH_ENV_VAR", "env-batch-val")
+        result = get_credentials_batch(db_session, [("no_src_batch", "BATCH_ENV_VAR")])
+        assert result == {("no_src_batch", "BATCH_ENV_VAR"): "env-batch-val"}
+
+    def test_returns_none_when_no_value_anywhere(self, db_session, monkeypatch):
+        from app.services.credential_service import get_credentials_batch
+
+        monkeypatch.delenv("MISSING_BATCH_VAR", raising=False)
+        result = get_credentials_batch(db_session, [("no_src_batch2", "MISSING_BATCH_VAR")])
+        assert result == {("no_src_batch2", "MISSING_BATCH_VAR"): None}
+
+    def test_handles_multiple_sources_and_env_mix(self, db_session, monkeypatch):
+        from app.services.credential_service import get_credentials_batch
+
+        monkeypatch.setenv("MULTI_ENV_VAR", "env-multi-val")
+        src = ApiSource(
+            name="batch_src_2",
+            display_name="Batch 2",
+            category="api",
+            source_type="aggregator",
+            status="active",
+            env_vars=["MULTI_DB_KEY"],
+            credentials={"MULTI_DB_KEY": encrypt_value("db-multi-val")},
+        )
+        db_session.add(src)
+        db_session.commit()
+
+        requests_list = [
+            ("batch_src_2", "MULTI_DB_KEY"),
+            ("no_src_multi", "MULTI_ENV_VAR"),
+        ]
+        result = get_credentials_batch(db_session, requests_list)
+        assert result[("batch_src_2", "MULTI_DB_KEY")] == "db-multi-val"
+        assert result[("no_src_multi", "MULTI_ENV_VAR")] == "env-multi-val"
+
+
+# ── get_credential_cached ─────────────────────────────────────────────
+
+
+class TestGetCredentialCached:
+    """Tests for lines 181-195 — in-process TTL cache + lazy SessionLocal."""
+
+    def setup_method(self):
+        import app.services.credential_service as cred_svc
+
+        cred_svc._cred_cache.clear()
+
+    def teardown_method(self):
+        import app.services.credential_service as cred_svc
+
+        cred_svc._cred_cache.clear()
+
+    def test_cache_miss_calls_db_and_stores_result(self):
+        from unittest.mock import MagicMock, patch
+
+        from app.services.credential_service import _cred_cache, get_credential_cached
+
+        mock_db = MagicMock()
+
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            with patch(
+                "app.services.credential_service.get_credential",
+                return_value="fetched-val",
+            ) as mock_get:
+                result = get_credential_cached("cac_src1", "CAC_VAR1")
+
+        assert result == "fetched-val"
+        mock_get.assert_called_once_with(mock_db, "cac_src1", "CAC_VAR1")
+        mock_db.close.assert_called_once()
+        assert ("cac_src1", "CAC_VAR1") in _cred_cache
+
+    def test_cache_hit_skips_db_entirely(self):
+        import time
+        from unittest.mock import patch
+
+        from app.services.credential_service import _cred_cache, get_credential_cached
+
+        _cred_cache[("cac_src2", "CAC_VAR2")] = ("cached-hit-val", time.time())
+
+        with patch("app.database.SessionLocal") as mock_sl:
+            result = get_credential_cached("cac_src2", "CAC_VAR2")
+
+        assert result == "cached-hit-val"
+        mock_sl.assert_not_called()
+
+    def test_expired_cache_entry_triggers_refetch(self):
+        import time
+        from unittest.mock import MagicMock, patch
+
+        import app.services.credential_service as cred_svc
+
+        old_time = time.time() - (cred_svc._CACHE_TTL + 5)
+        cred_svc._cred_cache[("cac_src3", "CAC_VAR3")] = ("stale-val", old_time)
+
+        mock_db = MagicMock()
+
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            with patch(
+                "app.services.credential_service.get_credential",
+                return_value="fresh-val",
+            ) as mock_get:
+                result = cred_svc.get_credential_cached("cac_src3", "CAC_VAR3")
+
+        assert result == "fresh-val"
+        mock_get.assert_called_once()
+        mock_db.close.assert_called_once()

--- a/tests/test_htmx_views_nightly31.py
+++ b/tests/test_htmx_views_nightly31.py
@@ -20,6 +20,7 @@ Depends on: conftest.py fixtures (client, db_session, test_user, admin_user, man
             test_company), app.routers.htmx_views
 """
 
+import json
 import os
 
 os.environ["TESTING"] = "1"
@@ -105,6 +106,8 @@ class TestV2PageTroubleTickets:
         with patch("app.routers.htmx_views.get_user", return_value=admin_user):
             resp = client.get("/v2/trouble-tickets")
         assert resp.status_code == 200
+        # base_page shell lazy-loads the admin workspace partial on page load.
+        assert 'hx-get="/v2/partials/trouble-tickets/workspace"' in resp.text
 
 
 # ── v2_page: module access redirect / deny-all (lines 211-216) ───────────────
@@ -163,6 +166,8 @@ class TestV2PageMyDay:
         with patch("app.routers.htmx_views.get_user", return_value=test_user):
             resp = client.get("/v2/my-day")
         assert resp.status_code == 200
+        # base_page shell lazy-loads the my-day partial on page load.
+        assert 'hx-get="/v2/partials/my-day"' in resp.text
 
 
 # ── v2_page: search partial URL (current file lines 235-239) ─────────────────
@@ -176,6 +181,8 @@ class TestV2PageSearch:
         with patch("app.routers.htmx_views.get_user", return_value=test_user):
             resp = client.get("/v2/search?mpn=LM317T")
         assert resp.status_code == 200
+        # The ?mpn= deep-link must ride along into the lazy-loaded partial URL.
+        assert 'hx-get="/v2/partials/search?mpn=LM317T"' in resp.text
 
     def test_search_results_partial_returns_200(self, client: TestClient):
         """Lines 352-356: /v2/partials/search/results uses require_user (overridden)."""
@@ -187,6 +194,10 @@ class TestV2PageSearch:
         ):
             resp = client.get("/v2/partials/search/results?q=LM317T")
         assert resp.status_code == 200
+        # Empty fast_search result renders the no-results state with the query echoed
+        # into the pre-filled refine input.
+        assert "No results found" in resp.text
+        assert 'value="LM317T"' in resp.text
 
 
 # ── v2_page: customers/{id}?tab= partial URL injection (line 297) ─────────────
@@ -202,6 +213,8 @@ class TestV2PageCustomerDetailTab:
         with patch("app.routers.htmx_views.get_user", return_value=test_user):
             resp = client.get(f"/v2/customers/{test_company.id}?tab=quotes")
         assert resp.status_code == 200
+        # The ?tab= deep-link must be appended to the detail partial URL.
+        assert f'hx-get="/v2/partials/customers/{test_company.id}?tab=quotes"' in resp.text
 
 
 # ── Requisition activity digest (lines 388-396) ───────────────────────────────
@@ -222,6 +235,9 @@ class TestRequisitionActivityDigest:
         ):
             resp = client.get(f"/v2/partials/requisitions/{req.id}/activity-digest", headers=HX)
         assert resp.status_code == 200
+        # 'insufficient' digest state renders the empty-state copy inside the card.
+        assert "activity-digest-card" in resp.text
+        assert "Not enough activity to summarize yet." in resp.text
 
     def test_digest_unknown_req_returns_404(self, client: TestClient):
         """get_requisition_or_404 raises 404 for unknown req_id."""
@@ -244,6 +260,9 @@ class TestCustomerActivityDigest:
         ):
             resp = client.get(f"/v2/partials/customers/{test_company.id}/activity-digest", headers=HX)
         assert resp.status_code == 200
+        # 'insufficient' digest state renders the empty-state copy inside the card.
+        assert "activity-digest-card" in resp.text
+        assert "Not enough activity to summarize yet." in resp.text
 
     def test_digest_unknown_company_returns_404(self, client: TestClient):
         """Line 411: HTTPException(404) when company_id not in DB."""
@@ -280,6 +299,7 @@ class TestRequisitionsBulkAction:
         client: TestClient,
         db_session: Session,
         test_user: User,
+        admin_user: User,
     ):
         """Lines 436-466: buyer+is_manager_or_admin patch covers full assign path."""
         req = _req(db_session, test_user)
@@ -294,9 +314,12 @@ class TestRequisitionsBulkAction:
         ):
             resp = client.post(
                 "/v2/partials/requisitions/bulk/assign",
-                data={"ids": str(req.id), "owner_id": str(test_user.id)},
+                data={"ids": str(req.id), "owner_id": str(admin_user.id)},
             )
         assert resp.status_code == 200
+        assert "<div>ok</div>" in resp.text  # refreshed list partial is returned
+        db_session.refresh(req)
+        assert req.created_by == admin_user.id  # ownership actually reassigned + committed
 
 
 # ── Inline edit cell – invalid-field and not-found branches ──────────────────
@@ -352,8 +375,13 @@ class TestRequisitionInlineSave:
                 f"/v2/partials/requisitions/{req.id}/inline",
                 data={"field": "status", "value": "closed"},
             )
-        # ValueError is caught; endpoint returns the row partial (200)
+        # ValueError is caught; endpoint returns the row partial (200) with the
+        # error message threaded into the showToast HX-Trigger.
         assert resp.status_code == 200
+        assert "N31-REQ" in resp.text  # row partial re-rendered
+        assert json.loads(resp.headers["HX-Trigger"])["showToast"]["message"] == "Cannot transition"
+        db_session.refresh(req)
+        assert req.status == RequisitionStatus.OPEN  # failed transition left status untouched
 
     def test_owner_field_by_buyer_returns_403(self, client: TestClient, db_session: Session, test_user: User):
         """Line 556: buyer (non-manager) trying to change owner → HTTPException 403."""

--- a/tests/test_htmx_views_nightly31.py
+++ b/tests/test_htmx_views_nightly31.py
@@ -1,0 +1,367 @@
+"""tests/test_htmx_views_nightly31.py — Coverage boost for htmx_views.py missing lines.
+
+Targets the following previously uncovered lines in app/routers/htmx_views.py:
+  - 202       v2_page: 403 for non-admin accessing trouble-tickets
+  - 211-216   v2_page: module access gate redirect/deny
+  - 233       v2_page: trouble-tickets partial URL for admin
+  - 241       v2_page: my-day partial URL
+  - 247-248   v2_page: search/results path with ?q=
+  - 297       v2_page: customers/{id}?tab= partial URL injection
+  - 388-396   requisition_activity_digest body
+  - 408-420   customer_activity_digest body
+  - 436,438-466  requisitions_bulk_action (try/except, invalid action, assign success)
+  - 505       requisition_inline_edit_cell not-found branch
+  - 530       requisition_inline_save not-found branch
+  - 545-546   requisition_inline_save status ValueError handler
+  - 556       requisition_inline_save owner 403 for non-manager
+
+Called by: pytest autodiscovery
+Depends on: conftest.py fixtures (client, db_session, test_user, admin_user, manager_user,
+            test_company), app.routers.htmx_views
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import RequisitionStatus
+from app.models import Company, Requisition, User
+
+HX = {"HX-Request": "true"}
+
+
+# ── Local helpers ─────────────────────────────────────────────────────────────
+
+
+def _req(db: Session, user: User, **kw) -> Requisition:
+    defaults = dict(
+        name="N31-REQ",
+        customer_name="N31 Corp",
+        status=RequisitionStatus.OPEN,
+        created_by=user.id,
+        created_at=datetime.now(UTC),
+    )
+    defaults.update(kw)
+    obj = Requisition(**defaults)
+    db.add(obj)
+    db.flush()
+    return obj
+
+
+@pytest.fixture()
+def _manager_client(db_session: Session, manager_user: User) -> TestClient:
+    """TestClient authenticated as manager_user for bulk-assign tests."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    def _db():
+        yield db_session
+
+    def _user():
+        return manager_user
+
+    async def _token():
+        return "mock-token"
+
+    overridden = [get_db, require_user, require_admin, require_buyer, require_fresh_token]
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[require_user] = _user
+    app.dependency_overrides[require_admin] = _user
+    app.dependency_overrides[require_buyer] = _user
+    app.dependency_overrides[require_fresh_token] = _token
+
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in overridden:
+            app.dependency_overrides.pop(dep, None)
+
+
+# ── v2_page: trouble-tickets gate (lines 201-202, 233) ───────────────────────
+
+
+class TestV2PageTroubleTickets:
+    """Line 202: HTTPException(403) for non-admin; line 233: partial URL set."""
+
+    def test_non_admin_trouble_tickets_gets_403(self, client: TestClient, test_user: User):
+        """Line 202: buyer role is rejected before page shell renders."""
+        with patch("app.routers.htmx_views.get_user", return_value=test_user):
+            resp = client.get("/v2/trouble-tickets")
+        assert resp.status_code == 403
+
+    def test_admin_trouble_tickets_gets_200(self, client: TestClient, admin_user: User):
+        """Line 233: admin passes line 201 check; partial_url set to trouble-
+        tickets/workspace."""
+        with patch("app.routers.htmx_views.get_user", return_value=admin_user):
+            resp = client.get("/v2/trouble-tickets")
+        assert resp.status_code == 200
+
+
+# ── v2_page: module access redirect / deny-all (lines 211-216) ───────────────
+
+
+class TestV2PageModuleGate:
+    """Lines 211-216: access gate redirects to first allowed module or returns 403."""
+
+    def test_denied_module_redirects_to_first_allowed(self, client: TestClient, db_session: Session):
+        """Lines 211-215: buyer with requisitions denied redirects (302) to next
+        module."""
+        user = User(
+            email="limited31@trioscs.com",
+            name="Limited31",
+            role="buyer",
+            azure_id="azure-limited31",
+            access_overrides={"requisitions": False},
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        with patch("app.routers.htmx_views.get_user", return_value=user):
+            resp = client.get("/v2/requisitions", follow_redirects=False)
+        # Buyer still has other module access → redirect to first allowed
+        assert resp.status_code == 302
+
+    def test_agent_user_denied_all_modules_gets_403(self, client: TestClient, db_session: Session):
+        """Lines 211, 213-214, 216-219: agent has no module defaults → 403 HTML."""
+        agent = User(
+            email="agent31@trioscs.com",
+            name="Agent31",
+            role="agent",
+            azure_id="azure-agent31",
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(agent)
+        db_session.commit()
+        db_session.refresh(agent)
+
+        with patch("app.routers.htmx_views.get_user", return_value=agent):
+            resp = client.get("/v2/requisitions")
+        assert resp.status_code == 403
+        assert b"don" in resp.content  # "You don't have access..."
+
+
+# ── v2_page: my-day partial URL (line 241) ───────────────────────────────────
+
+
+class TestV2PageMyDay:
+    """Line 241: partial_url = /v2/partials/my-day."""
+
+    def test_my_day_full_page_returns_200(self, client: TestClient, test_user: User):
+        """Line 241: my-day sets partial_url; buyer has MY_DAY access by default."""
+        with patch("app.routers.htmx_views.get_user", return_value=test_user):
+            resp = client.get("/v2/my-day")
+        assert resp.status_code == 200
+
+
+# ── v2_page: search partial URL (current file lines 235-239) ─────────────────
+
+
+class TestV2PageSearch:
+    """v2_page search branch: partial_url set from ?mpn= param."""
+
+    def test_search_page_with_mpn_param(self, client: TestClient, test_user: User):
+        """Lines 238-239: /v2/search?mpn=LM317T builds partial_url with mpn param."""
+        with patch("app.routers.htmx_views.get_user", return_value=test_user):
+            resp = client.get("/v2/search?mpn=LM317T")
+        assert resp.status_code == 200
+
+    def test_search_results_partial_returns_200(self, client: TestClient):
+        """Lines 352-356: /v2/partials/search/results uses require_user (overridden)."""
+        from unittest.mock import patch as _patch
+
+        with _patch(
+            "app.services.global_search_service.fast_search",
+            return_value={"best_match": None, "groups": {}, "total_count": 0},
+        ):
+            resp = client.get("/v2/partials/search/results?q=LM317T")
+        assert resp.status_code == 200
+
+
+# ── v2_page: customers/{id}?tab= partial URL injection (line 297) ─────────────
+
+
+class TestV2PageCustomerDetailTab:
+    """Line 297: tab param threaded into partial_url for customer detail deep-links."""
+
+    def test_customer_detail_with_tab_returns_200(
+        self, client: TestClient, db_session: Session, test_user: User, test_company: Company
+    ):
+        """Line 297: /v2/customers/{id}?tab=quotes appends tab to partial_url."""
+        with patch("app.routers.htmx_views.get_user", return_value=test_user):
+            resp = client.get(f"/v2/customers/{test_company.id}?tab=quotes")
+        assert resp.status_code == 200
+
+
+# ── Requisition activity digest (lines 388-396) ───────────────────────────────
+
+
+class TestRequisitionActivityDigest:
+    """Lines 388-396: GET /v2/partials/requisitions/{req_id}/activity-digest."""
+
+    def test_digest_returns_200(self, client: TestClient, db_session: Session, test_user: User):
+        """Lines 391-396: builds digest with mocked service, renders template."""
+        req = _req(db_session, test_user)
+        db_session.commit()
+
+        mock_digest = {"state": "insufficient"}
+        with patch(
+            "app.services.activity_digest_service.get_or_build_digest",
+            new=AsyncMock(return_value=mock_digest),
+        ):
+            resp = client.get(f"/v2/partials/requisitions/{req.id}/activity-digest", headers=HX)
+        assert resp.status_code == 200
+
+    def test_digest_unknown_req_returns_404(self, client: TestClient):
+        """get_requisition_or_404 raises 404 for unknown req_id."""
+        resp = client.get("/v2/partials/requisitions/999999/activity-digest", headers=HX)
+        assert resp.status_code == 404
+
+
+# ── Customer activity digest (lines 408-420) ──────────────────────────────────
+
+
+class TestCustomerActivityDigest:
+    """Lines 408-420: GET /v2/partials/customers/{company_id}/activity-digest."""
+
+    def test_digest_returns_200(self, client: TestClient, test_company: Company):
+        """Lines 410-420: company found, digest built with mocked service."""
+        mock_digest = {"state": "insufficient"}
+        with patch(
+            "app.services.activity_digest_service.get_or_build_digest",
+            new=AsyncMock(return_value=mock_digest),
+        ):
+            resp = client.get(f"/v2/partials/customers/{test_company.id}/activity-digest", headers=HX)
+        assert resp.status_code == 200
+
+    def test_digest_unknown_company_returns_404(self, client: TestClient):
+        """Line 411: HTTPException(404) when company_id not in DB."""
+        resp = client.get("/v2/partials/customers/999999/activity-digest", headers=HX)
+        assert resp.status_code == 404
+
+
+# ── Bulk requisition action (lines 436, 438-466) ──────────────────────────────
+
+
+class TestRequisitionsBulkAction:
+    """POST /v2/partials/requisitions/bulk/{action} — try/except, validation, assign."""
+
+    def test_invalid_id_format_returns_400(self, client: TestClient):
+        """Lines 436, 438-439: non-integer ids_str hits ValueError → 400."""
+        resp = client.post(
+            "/v2/partials/requisitions/bulk/assign",
+            data={"ids": "abc,def"},
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_action_returns_400(self, client: TestClient, db_session: Session, test_user: User):
+        """Line 446: action='delete' not in valid_actions → HTTPException 400."""
+        req = _req(db_session, test_user)
+        db_session.commit()
+        resp = client.post(
+            "/v2/partials/requisitions/bulk/delete",
+            data={"ids": str(req.id)},
+        )
+        assert resp.status_code == 400
+
+    def test_assign_by_manager_returns_200(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+    ):
+        """Lines 436-466: buyer+is_manager_or_admin patch covers full assign path."""
+        req = _req(db_session, test_user)
+        db_session.commit()
+
+        with (
+            patch("app.routers.htmx.requisitions_edit.is_manager_or_admin", return_value=True),
+            patch(
+                "app.routers.htmx.requisitions_edit.requisitions_list_partial",
+                new=AsyncMock(return_value=HTMLResponse("<div>ok</div>")),
+            ),
+        ):
+            resp = client.post(
+                "/v2/partials/requisitions/bulk/assign",
+                data={"ids": str(req.id), "owner_id": str(test_user.id)},
+            )
+        assert resp.status_code == 200
+
+
+# ── Inline edit cell – invalid-field and not-found branches ──────────────────
+
+
+class TestRequisitionInlineEditCell:
+    """Lines 484, 488: invalid-field 400 and not-found 404 in inline edit cell."""
+
+    def test_invalid_field_returns_400(self, client: TestClient):
+        """Line 484: field not in valid_fields → HTMLResponse 400."""
+        resp = client.get(
+            "/v2/partials/requisitions/1/edit/bogusfield",
+            headers=HX,
+        )
+        assert resp.status_code == 400
+
+    def test_not_found_returns_404_html(self, client: TestClient):
+        """Line 488: patch get_req_for_user → None → HTMLResponse 404."""
+        with patch("app.routers.htmx.requisitions_edit.get_req_for_user", return_value=None):
+            resp = client.get(
+                "/v2/partials/requisitions/1/edit/name",
+                headers=HX,
+            )
+        assert resp.status_code == 404
+
+
+# ── Inline save – not-found and error branches (lines 530, 545-546, 556) ──────
+
+
+class TestRequisitionInlineSave:
+    """Lines 530, 545-546, 556: not-found, ValueError, and owner-403 paths."""
+
+    def test_not_found_returns_404_html(self, client: TestClient):
+        """Line 530: patch get_req_for_user → None → HTMLResponse 404."""
+        with patch("app.routers.htmx.requisitions_edit.get_req_for_user", return_value=None):
+            resp = client.patch(
+                "/v2/partials/requisitions/1/inline",
+                data={"field": "name", "value": "New Name"},
+            )
+        assert resp.status_code == 404
+
+    def test_status_value_error_is_caught(self, client: TestClient, db_session: Session, test_user: User):
+        """Lines 545-546: invalid status transition raises ValueError → caught, msg
+        set."""
+        req = _req(db_session, test_user)
+        db_session.commit()
+
+        with patch(
+            "app.services.requisition_state.transition",
+            side_effect=ValueError("Cannot transition"),
+        ):
+            resp = client.patch(
+                f"/v2/partials/requisitions/{req.id}/inline",
+                data={"field": "status", "value": "closed"},
+            )
+        # ValueError is caught; endpoint returns the row partial (200)
+        assert resp.status_code == 200
+
+    def test_owner_field_by_buyer_returns_403(self, client: TestClient, db_session: Session, test_user: User):
+        """Line 556: buyer (non-manager) trying to change owner → HTTPException 403."""
+        req = _req(db_session, test_user)
+        db_session.commit()
+
+        resp = client.patch(
+            f"/v2/partials/requisitions/{req.id}/inline",
+            data={"field": "owner", "value": str(test_user.id)},
+        )
+        assert resp.status_code == 403

--- a/tests/test_prepayment_notifications_gaps.py
+++ b/tests/test_prepayment_notifications_gaps.py
@@ -1,0 +1,432 @@
+"""test_prepayment_notifications_gaps.py — Coverage gap tests for
+prepayment_notifications.
+
+Covers lines not reached by the main test file:
+  - run_prepayment_notify_bg._run inner function (vanished prepayment, success, exception)
+  - schedule_prepayment_notify (no-loop path and loop-running path)
+  - _send_group_email internals (empty recipients, no admin token, token unavailable,
+    successful send, partial failure, all failures)
+  - _write_failure_alert edge cases (no user_ids → early return, commit exception → rollback)
+  - _notify_paid_inner edge cases (not found, no user_ids, commit exception → rollback)
+
+Called by: pytest
+Depends on: app.services.prepayment_notifications, conftest (db_session), unittest.mock.
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import ActivityLog, User
+from app.models.buy_plan import BuyPlan, BuyPlanLine
+from app.models.quality_plan import Prepayment
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+from app.models.vendors import VendorCard
+from app.services.prepayment_notifications import (
+    _notify_paid_inner,
+    _send_group_email,
+    _write_failure_alert,
+    run_prepayment_notify_bg,
+    schedule_prepayment_notify,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _unique_email() -> str:
+    return f"user-{uuid.uuid4().hex[:8]}@test.com"
+
+
+def _make_user(
+    db: Session,
+    *,
+    role: str = "manager",
+    access_token: str | None = None,
+    is_active: bool = True,
+) -> User:
+    u = User(
+        email=_unique_email(),
+        name="Test User",
+        role=role,
+        azure_id=f"az-{uuid.uuid4().hex[:8]}",
+        is_active=is_active,
+        access_token=access_token,
+        created_at=datetime.now(UTC),
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_stub_prepayment(db: Session, *, created_by_id: int | None = None) -> Prepayment:
+    """Minimal Prepayment graph for _write_failure_alert and _notify_paid_inner
+    tests."""
+    creator_id = created_by_id or 0
+    req = Requisition(
+        name=f"REQ-{uuid.uuid4().hex[:6]}",
+        customer_name="AcmeCo",
+        status="active",
+        created_by=creator_id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(req)
+    db.flush()
+    q = Quote(
+        requisition_id=req.id,
+        quote_number=f"Q-{uuid.uuid4().hex[:8]}",
+        line_items=[],
+        status="sent",
+        created_by_id=creator_id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.flush()
+    bp = BuyPlan(
+        requisition_id=req.id,
+        quote_id=q.id,
+        status="active",
+        so_status="approved",
+        submitted_by_id=created_by_id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(bp)
+    db.flush()
+    vc = VendorCard(
+        normalized_name=f"vc-{uuid.uuid4().hex[:8]}",
+        display_name="Test Vendor",
+    )
+    db.add(vc)
+    db.flush()
+    line = BuyPlanLine(
+        buy_plan_id=bp.id,
+        quantity=1,
+        unit_cost=100.0,
+        status="pending_verify",
+        po_confirmed_at=datetime.now(UTC),
+    )
+    db.add(line)
+    db.flush()
+    pp = Prepayment(
+        buy_plan_id=bp.id,
+        buy_plan_line_id=line.id,
+        vendor_card_id=vc.id,
+        vendor_name="Test Vendor",
+        total_incl_fees=Decimal("1000.00"),
+        currency="USD",
+        created_by_id=created_by_id,
+        status="pending",
+    )
+    db.add(pp)
+    db.commit()
+    return pp
+
+
+# ── run_prepayment_notify_bg._run ─────────────────────────────────────────────
+
+
+async def _run_immediately(coro, *, task_name, suppress_in_testing=False):
+    """Helper: actually execute the coroutine passed to
+    safe_background_task."""
+    await coro
+
+
+@pytest.mark.asyncio
+async def test_run_bg_skips_when_prepayment_vanished():
+    """_run logs a warning and returns without calling coro_fn when prepayment is
+    gone."""
+    coro_fn = AsyncMock()
+    mock_db = MagicMock()
+    mock_db.get.return_value = None  # prepayment no longer exists
+
+    with patch("app.services.prepayment_notifications.safe_background_task", side_effect=_run_immediately):
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            await run_prepayment_notify_bg(coro_fn, 99999)
+
+    coro_fn.assert_not_called()
+    mock_db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_bg_calls_coro_fn_when_prepayment_exists():
+    """_run calls coro_fn(prepayment_id, db=...) when the prepayment is found."""
+    coro_fn = AsyncMock()
+    mock_db = MagicMock()
+    mock_db.get.return_value = MagicMock()  # prepayment found
+
+    with patch("app.services.prepayment_notifications.safe_background_task", side_effect=_run_immediately):
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            await run_prepayment_notify_bg(coro_fn, 1)
+
+    coro_fn.assert_called_once_with(1, db=mock_db)
+    mock_db.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_bg_logs_exception_and_closes_session():
+    """_run catches exceptions from coro_fn, logs them, and still closes the session."""
+    coro_fn = AsyncMock(side_effect=RuntimeError("graph down"))
+    mock_db = MagicMock()
+    mock_db.get.return_value = MagicMock()
+
+    with patch("app.services.prepayment_notifications.safe_background_task", side_effect=_run_immediately):
+        with patch("app.database.SessionLocal", return_value=mock_db):
+            await run_prepayment_notify_bg(coro_fn, 1)  # must not raise
+
+    mock_db.close.assert_called_once()
+
+
+# ── schedule_prepayment_notify ────────────────────────────────────────────────
+
+
+def test_schedule_no_loop_closes_coroutine():
+    """With no running loop, schedule_prepayment_notify closes the coroutine cleanly."""
+    mock_coro = MagicMock()
+
+    with patch("asyncio.get_running_loop", side_effect=RuntimeError("no running loop")):
+        schedule_prepayment_notify(mock_coro)
+
+    mock_coro.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_schedule_with_loop_creates_task():
+    """With a running loop, schedule_prepayment_notify schedules the coro as a task."""
+    import asyncio
+
+    async def _dummy():
+        pass
+
+    coro = _dummy()
+    loop = asyncio.get_running_loop()
+
+    with patch.object(loop, "create_task") as mock_create:
+        schedule_prepayment_notify(coro)
+
+    mock_create.assert_called_once_with(coro)
+    coro.close()  # prevent coroutine-never-awaited warning
+
+
+# ── _send_group_email ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_group_email_empty_recipients():
+    """_send_group_email returns False immediately when the recipient list is empty."""
+    mock_db = MagicMock()
+    result = await _send_group_email(mock_db, [], "subject", "<html/>")
+    assert result is False
+    mock_db.query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_group_email_no_admin_with_access_token():
+    """_send_group_email returns False when no admin in settings.admin_emails has a
+    token."""
+    admin = MagicMock()
+    admin.access_token = None  # no live token
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.all.return_value = [admin]
+
+    with patch("app.services.prepayment_notifications.settings") as mock_settings:
+        mock_settings.admin_emails = ["admin@test.com"]
+        result = await _send_group_email(mock_db, ["ap@test.com"], "subj", "<html/>")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_group_email_token_refresh_fails():
+    """_send_group_email returns False when get_valid_token returns falsy."""
+    admin = MagicMock()
+    admin.access_token = "stale-token"
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.all.return_value = [admin]
+
+    with patch("app.services.prepayment_notifications.settings") as mock_settings:
+        mock_settings.admin_emails = ["admin@test.com"]
+        with patch(
+            "app.utils.token_manager.get_valid_token",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await _send_group_email(mock_db, ["ap@test.com"], "subj", "<html/>")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_group_email_sends_to_all_recipients():
+    """_send_group_email posts to each address and returns True on success."""
+    admin = MagicMock()
+    admin.access_token = "tok-live"
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.all.return_value = [admin]
+
+    mock_gc = MagicMock()
+    mock_gc.post_json = AsyncMock()
+
+    with patch("app.services.prepayment_notifications.settings") as mock_settings:
+        mock_settings.admin_emails = ["admin@test.com"]
+        with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok-live"):
+            with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+                result = await _send_group_email(
+                    mock_db,
+                    ["acc@test.com", "ap@test.com"],
+                    "subj",
+                    "<html/>",
+                )
+
+    assert result is True
+    assert mock_gc.post_json.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_send_group_email_partial_recipient_failure_returns_true():
+    """_send_group_email returns True when at least one send succeeds despite one
+    failure."""
+    admin = MagicMock()
+    admin.access_token = "tok-live"
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.all.return_value = [admin]
+
+    mock_gc = MagicMock()
+    mock_gc.post_json = AsyncMock(side_effect=[None, RuntimeError("timeout")])
+
+    with patch("app.services.prepayment_notifications.settings") as mock_settings:
+        mock_settings.admin_emails = ["admin@test.com"]
+        with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok-live"):
+            with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+                result = await _send_group_email(
+                    mock_db,
+                    ["acc@test.com", "ap@test.com"],
+                    "subj",
+                    "<html/>",
+                )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_send_group_email_all_recipients_fail_returns_false():
+    """_send_group_email returns False when every post_json call raises."""
+    admin = MagicMock()
+    admin.access_token = "tok-live"
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.all.return_value = [admin]
+
+    mock_gc = MagicMock()
+    mock_gc.post_json = AsyncMock(side_effect=RuntimeError("all failed"))
+
+    with patch("app.services.prepayment_notifications.settings") as mock_settings:
+        mock_settings.admin_emails = ["admin@test.com"]
+        with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok-live"):
+            with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+                result = await _send_group_email(mock_db, ["ap@test.com"], "subj", "<html/>")
+
+    assert result is False
+
+
+# ── _write_failure_alert ──────────────────────────────────────────────────────
+
+
+def test_write_failure_alert_no_user_ids_returns_early(db_session: Session):
+    """_write_failure_alert logs and returns when no requester or admin exists."""
+    pp = MagicMock()
+    pp.id = 42
+    pp.created_by_id = None  # no requester
+    pp.buy_plan_id = None
+    pp.buy_plan = None
+    # No active admin users in the test DB.
+
+    _write_failure_alert(db_session, pp)
+
+    assert db_session.query(ActivityLog).filter(ActivityLog.subject.like("Prepayment #42%")).count() == 0
+
+
+def test_write_failure_alert_exception_triggers_rollback():
+    """_write_failure_alert calls db.rollback when db.commit raises."""
+    pp = MagicMock()
+    pp.id = 77
+    pp.created_by_id = 1
+    pp.buy_plan = None
+    pp.buy_plan_id = None
+
+    mock_db = MagicMock()
+    # No admins so that user_ids = {1} from created_by_id alone.
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+    mock_db.commit.side_effect = Exception("commit failed")
+
+    _write_failure_alert(mock_db, pp)
+
+    mock_db.rollback.assert_called_once()
+
+
+# ── _notify_paid_inner ────────────────────────────────────────────────────────
+
+
+def test_notify_paid_inner_prepayment_not_found(db_session: Session):
+    """_notify_paid_inner returns empty alerted list when prepayment ID doesn't
+    exist."""
+    result = _notify_paid_inner(db_session, 99999)
+    assert result == {"alerted": []}
+
+
+def test_notify_paid_inner_no_recipients_returns_empty():
+    """_notify_paid_inner skips commit and returns empty when no user_ids are
+    resolved."""
+    pp = MagicMock()
+    pp.id = 55
+    pp.created_by_id = None  # no buyer
+    pp.buy_plan = None  # no plan → no salesperson
+    pp.buy_plan_id = None
+
+    mock_db = MagicMock()
+    mock_db.get.return_value = pp
+    mock_db.query.return_value.filter.return_value.all.return_value = []  # no managers
+
+    result = _notify_paid_inner(mock_db, 55)
+
+    assert result == {"alerted": []}
+    mock_db.commit.assert_not_called()
+
+
+def test_notify_paid_inner_exception_triggers_rollback():
+    """_notify_paid_inner calls db.rollback when commit fails."""
+    pp = MagicMock()
+    pp.id = 66
+    pp.created_by_id = 7  # one buyer in user_ids
+    pp.buy_plan = None
+    pp.buy_plan_id = None
+    pp.paid_amount = None
+    pp.total_incl_fees = Decimal("500.00")
+    pp.currency = "USD"
+    pp.vendor_card = None
+    pp.vendor_name = "AcmeCo"
+    pp.buy_plan_line = None
+    pp.void_reason = None
+    pp.wire_reference = None
+    pp.paid_by_label = None
+
+    mock_db = MagicMock()
+    mock_db.get.return_value = pp
+    mock_db.query.return_value.filter.return_value.all.return_value = []  # no managers
+    mock_db.commit.side_effect = Exception("db gone")
+
+    result = _notify_paid_inner(mock_db, 66)
+
+    mock_db.rollback.assert_called_once()
+    assert result == {"alerted": []}

--- a/tests/test_proactive_router_coverage.py
+++ b/tests/test_proactive_router_coverage.py
@@ -129,8 +129,13 @@ class TestBatchDismissWithMatchIds:
         assert match.status == "dismissed"
         assert match.dismiss_reason == "batch_dismiss"
 
-    async def test_empty_match_ids_skips_update(self, ac):
-        """Empty match_ids list → skips the bulk-update block, still returns 200."""
+    async def test_empty_match_ids_skips_update(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        """Empty match_ids list → skips the bulk-update block; existing matches
+        untouched."""
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
         with (
             patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
             patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
@@ -138,6 +143,9 @@ class TestBatchDismissWithMatchIds:
             resp = await ac.post("/v2/partials/proactive/batch-dismiss", data={})
 
         assert resp.status_code == 200
+        db_session.refresh(match)
+        assert match.status == "new"
+        assert match.dismiss_reason is None
 
 
 # ── Lines 156-178, 203, 215: prepare page happy path ─────────────────
@@ -491,6 +499,8 @@ class TestDoNotOffer:
 
     async def test_accepts_customer_site_id_as_company_id_fallback(self, ac, db_session, test_user, test_company):
         """customer_site_id form field is accepted when company_id is absent."""
+        from app.models.intelligence import ProactiveDoNotOffer
+
         test_company.account_owner_id = test_user.id
         db_session.commit()
 
@@ -501,6 +511,10 @@ class TestDoNotOffer:
             )
 
         assert resp.status_code == 200
+        assert b"<tr" in resp.content
+        dno = db_session.query(ProactiveDoNotOffer).filter_by(mpn="LM7805").one()
+        assert dno.company_id == test_company.id  # fallback field became the company linkage
+        assert dno.created_by_id == test_user.id
 
     async def test_invalid_company_id_returns_400(self, ac):
         """Lines 669-670: non-integer company_id → 400."""
@@ -686,8 +700,12 @@ class TestDirectBatchDismiss:
         assert m1.status == "dismissed"
         assert m2.status == "dismissed"
 
-    async def test_empty_match_ids_does_not_update(self, db_session, test_user):
+    async def test_empty_match_ids_does_not_update(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
         from app.routers.htmx.proactive import proactive_batch_dismiss
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
 
         with (
             patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
@@ -696,6 +714,9 @@ class TestDirectBatchDismiss:
             resp = await proactive_batch_dismiss(_post_req({}), user=test_user, db=db_session)
 
         assert resp.status_code == 200
+        db_session.refresh(match)
+        assert match.status == "new"
+        assert match.dismiss_reason is None
 
 
 # ── Direct: proactive_prepare_page (lines 156-178, 203, 215) ─────────────────
@@ -1137,12 +1158,13 @@ class TestDirectDoNotOffer:
         assert db_session.query(ProactiveDoNotOffer).filter_by(mpn="BC547").first() is None
 
     async def test_customer_site_id_field_accepted(self, db_session, test_user, test_company):
+        from app.models.intelligence import ProactiveDoNotOffer
         from app.routers.htmx.proactive import proactive_do_not_offer
 
         test_company.account_owner_id = test_user.id
         db_session.commit()
 
-        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=True):
+        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=False):
             resp = await proactive_do_not_offer(
                 _post_req({"mpn": "NE555", "customer_site_id": str(test_company.id)}),
                 user=test_user,
@@ -1150,6 +1172,9 @@ class TestDirectDoNotOffer:
             )
 
         assert resp.status_code == 200
+        dno = db_session.query(ProactiveDoNotOffer).filter_by(mpn="NE555").one()
+        assert dno.company_id == test_company.id  # customer_site_id fallback became the company linkage
+        assert dno.created_by_id == test_user.id
 
     async def test_missing_mpn_raises_400(self, db_session, test_user):
         from fastapi import HTTPException

--- a/tests/test_proactive_router_coverage.py
+++ b/tests/test_proactive_router_coverage.py
@@ -1,0 +1,1203 @@
+"""tests/test_proactive_router_coverage.py — Targeted coverage for
+app/routers/htmx/proactive.py.
+
+Covers the uncovered HTMX endpoint lines:
+  110-117  proactive_batch_dismiss with non-empty match_ids
+  156-178  proactive_prepare_page valid matches + site path
+  203,215  proactive_prepare_page context rendering (same flow)
+  348-436  proactive_draft_for_prepare draft generation + exception fallback
+  466-473  proactive_send_offer sell_price_ form-field parsing
+  477-528  proactive_send_offer token+service flow + success re-render
+  602      proactive_convert ValueError not "already converted" → 403
+  667-690  proactive_do_not_offer creates record, dedup, returns HTML
+
+Coverage strategy: use ``httpx.AsyncClient`` (ASGITransport) so endpoint
+coroutines run in the SAME event loop as the test.  Starlette's TestClient
+spawns the ASGI event loop in a background thread; coverage's sys.settrace is
+thread-local and does not follow the coroutine back into that thread, so async
+lines after ``await`` are invisible to coverage.  AsyncClient keeps everything
+on one event loop, so every statement is measured correctly.
+
+Called by: pytest
+Depends on: app/routers/htmx/proactive.py, tests/conftest.py
+"""
+
+from unittest.mock import AsyncMock, patch
+from urllib.parse import urlencode
+
+import httpx
+import pytest
+from fastapi.responses import HTMLResponse
+from httpx import ASGITransport
+from sqlalchemy.orm import Session
+from starlette.requests import Request as _SR
+
+from app.models import ProactiveMatch, SiteContact, User
+
+# ── Async client fixture ──────────────────────────────────────────────
+
+
+@pytest.fixture()
+async def ac(db_session: Session, test_user: User):
+    """httpx.AsyncClient backed by the ASGI app with auth overrides.
+
+    Runs in the same event loop as the calling test so that coverage's sys.settrace
+    traces every coroutine line inside the endpoint handlers. The
+    ``_restore_dependency_overrides`` autouse fixture in conftest.py handles teardown of
+    the overrides after each test.
+    """
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    def _db():
+        yield db_session
+
+    async def _fresh_token():
+        return "mock-token"
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[require_user] = lambda: test_user
+    app.dependency_overrides[require_admin] = lambda: test_user
+    app.dependency_overrides[require_buyer] = lambda: test_user
+    app.dependency_overrides[require_fresh_token] = _fresh_token
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _make_match(
+    db: Session,
+    user: User,
+    requisition,
+    offer,
+    site,
+    *,
+    company_id: int | None = None,
+) -> ProactiveMatch:
+    """Create and commit a ProactiveMatch owned by *user*."""
+    match = ProactiveMatch(
+        offer_id=offer.id,
+        requisition_id=requisition.id,
+        customer_site_id=site.id,
+        salesperson_id=user.id,
+        mpn="LM317T",
+        status="new",
+        **({"company_id": company_id} if company_id is not None else {}),
+    )
+    db.add(match)
+    db.commit()
+    db.refresh(match)
+    return match
+
+
+_EMPTY_MATCHES: dict = {"groups": [], "stats": {"total": 0}}
+
+
+def _html_ok() -> HTMLResponse:
+    return HTMLResponse("<div>ok</div>")
+
+
+# ── Lines 110-117: batch dismiss with match_ids ───────────────────────
+
+
+class TestBatchDismissWithMatchIds:
+    """POST /v2/partials/proactive/batch-dismiss with non-empty match_ids."""
+
+    async def test_updates_status_to_dismissed(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            resp = await ac.post(
+                "/v2/partials/proactive/batch-dismiss",
+                data={"match_ids": str(match.id)},
+            )
+
+        assert resp.status_code == 200
+        db_session.refresh(match)
+        assert match.status == "dismissed"
+        assert match.dismiss_reason == "batch_dismiss"
+
+    async def test_empty_match_ids_skips_update(self, ac):
+        """Empty match_ids list → skips the bulk-update block, still returns 200."""
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            resp = await ac.post("/v2/partials/proactive/batch-dismiss", data={})
+
+        assert resp.status_code == 200
+
+
+# ── Lines 156-178, 203, 215: prepare page happy path ─────────────────
+
+
+class TestPreparePage:
+    """POST /v2/proactive/prepare/{site_id} — valid match_ids."""
+
+    async def test_renders_prepare_template_for_valid_match(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl:
+            resp = await ac.post(
+                f"/v2/proactive/prepare/{test_customer_site.id}",
+                data={"match_ids": str(match.id)},
+            )
+
+        assert resp.status_code == 200
+        # Lines 203-215: verify template context was built with matches + site info
+        template_name, ctx = mock_tpl.call_args[0]
+        assert ctx["site_id"] == test_customer_site.id
+        assert "matches" in ctx
+        assert len(ctx["matches"]) == 1
+        assert ctx["matches"][0]["mpn"] == "LM317T"
+
+    async def test_prepare_with_contacts_includes_contact_data(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        """Contacts at the site are serialised into the template context."""
+        contact = SiteContact(
+            customer_site_id=test_customer_site.id,
+            full_name="Jane Buyer",
+            email="jane@acme.com",
+            is_primary=True,
+        )
+        db_session.add(contact)
+        db_session.flush()
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl:
+            resp = await ac.post(
+                f"/v2/proactive/prepare/{test_customer_site.id}",
+                data={"match_ids": str(match.id)},
+            )
+
+        assert resp.status_code == 200
+        _, ctx = mock_tpl.call_args[0]
+        assert len(ctx["contacts"]) == 1
+        assert ctx["contacts"][0]["full_name"] == "Jane Buyer"
+        assert ctx["contacts"][0]["has_email"] is True
+
+    async def test_no_match_ids_redirects(self, ac, test_customer_site):
+        """Empty match_ids → 303 redirect to /v2/proactive."""
+        resp = await ac.post(
+            f"/v2/proactive/prepare/{test_customer_site.id}",
+            data={},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+
+    async def test_match_not_found_in_db_redirects(self, ac, test_customer_site):
+        """match_ids non-empty but salesperson filter returns nothing → 303 redirect."""
+        resp = await ac.post(
+            f"/v2/proactive/prepare/{test_customer_site.id}",
+            data={"match_ids": "99999"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+
+
+# ── Lines 348-436: draft generation ──────────────────────────────────
+
+
+class TestDraftForPrepare:
+    """POST /v2/partials/proactive/draft — match found, AI draft path."""
+
+    async def test_draft_success_injects_subject_and_body_via_script(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value={"subject": "Parts Available", "body": "Hello! We have LM317T."},
+        ):
+            resp = await ac.post(
+                "/v2/partials/proactive/draft",
+                data={"match_ids": str(match.id)},
+            )
+
+        assert resp.status_code == 200
+        assert b"<script>" in resp.content
+        assert b"Parts Available" in resp.content
+
+    async def test_draft_with_contact_id_passes_first_name(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        """Lines 361-367: contact_ids[0] first name is resolved and passed to AI."""
+        contact = SiteContact(
+            customer_site_id=test_customer_site.id,
+            full_name="Alice Smith",
+            email="alice@acme.com",
+            is_primary=True,
+        )
+        db_session.add(contact)
+        db_session.flush()
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value={"subject": "Hi Alice!", "body": "We have parts for you."},
+        ) as mock_draft:
+            resp = await ac.post(
+                "/v2/partials/proactive/draft",
+                data={"match_ids": str(match.id), "contact_ids": str(contact.id)},
+            )
+
+        assert resp.status_code == 200
+        assert mock_draft.called
+        _, kwargs = mock_draft.call_args
+        assert kwargs.get("contact_name") == "Alice"
+
+    async def test_draft_with_sell_price_field_passes_value_to_service(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        """Lines 369-379: sell_price_<id> form field overrides the default markup."""
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value={"subject": "Offer", "body": "Details inside."},
+        ) as mock_draft:
+            resp = await ac.post(
+                "/v2/partials/proactive/draft",
+                data={"match_ids": str(match.id), f"sell_price_{match.id}": "3.25"},
+            )
+
+        assert resp.status_code == 200
+        assert mock_draft.called
+        _, kwargs = mock_draft.call_args
+        assert kwargs["parts"][0]["sell_price"] == pytest.approx(3.25)
+
+    async def test_draft_ai_exception_returns_fallback_html(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        """Lines 433-436: exception from AI service → fallback 'unavailable' partial."""
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("AI service down"),
+        ):
+            resp = await ac.post(
+                "/v2/partials/proactive/draft",
+                data={"match_ids": str(match.id)},
+            )
+
+        assert resp.status_code == 200
+        body_lower = resp.content.lower()
+        assert b"unavailable" in body_lower or b"manually" in body_lower
+
+    async def test_draft_no_match_ids_returns_error_html(self, ac):
+        resp = await ac.post("/v2/partials/proactive/draft", data={})
+        assert resp.status_code == 200
+        assert b"No matches selected" in resp.content
+
+    async def test_draft_match_not_in_db_returns_error_html(self, ac):
+        resp = await ac.post(
+            "/v2/partials/proactive/draft",
+            data={"match_ids": "99999"},
+        )
+        assert resp.status_code == 200
+        assert b"No valid matches" in resp.content
+
+
+# ── Lines 466-528: proactive_send_offer ──────────────────────────────
+
+
+class TestSendOffer:
+    """POST /v2/proactive/send — sell-price parsing and full service flow."""
+
+    async def test_sell_price_field_parsed_and_forwarded(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        """Lines 466-473: sell_price_<id> form field is parsed and passed to service."""
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                return_value={"line_items": [], "recipient_emails": ["a@b.com"]},
+            ) as mock_send,
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            resp = await ac.post(
+                "/v2/proactive/send",
+                data={
+                    "match_ids": str(match.id),
+                    "contact_ids": "1",
+                    f"sell_price_{match.id}": "2.50",
+                },
+            )
+
+        assert resp.status_code == 200
+        _, kwargs = mock_send.call_args
+        assert kwargs.get("sell_prices", {}).get(str(match.id)) == pytest.approx(2.50)
+
+    async def test_full_flow_renders_success_message(
+        self, ac, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        """Lines 477-522: token fetched → service called → success banner rendered."""
+        _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="mock-token"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                return_value={"line_items": [{"mpn": "LM317T"}], "recipient_emails": ["a@b.com"]},
+            ),
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl,
+        ):
+            resp = await ac.post(
+                "/v2/proactive/send",
+                data={
+                    "match_ids": "1",
+                    "contact_ids": "99",
+                    "subject": "Proactive Offer",
+                    "body": "Hello, please review.",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert mock_tpl.called
+        _, ctx = mock_tpl.call_args[0]
+        assert "Offer sent" in ctx.get("success_msg", "")
+
+    async def test_no_match_ids_raises_400(self, ac):
+        resp = await ac.post("/v2/proactive/send", data={"contact_ids": "1"})
+        assert resp.status_code == 400
+
+    async def test_no_contact_ids_raises_400(self, ac):
+        resp = await ac.post("/v2/proactive/send", data={"match_ids": "1"})
+        assert resp.status_code == 400
+
+    async def test_value_error_from_service_raises_400(self, ac):
+        """Lines 524-525: ValueError from send_proactive_offer → 400."""
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                side_effect=ValueError("No contacts found"),
+            ),
+        ):
+            resp = await ac.post(
+                "/v2/proactive/send",
+                data={"match_ids": "1", "contact_ids": "1"},
+            )
+        assert resp.status_code == 400
+
+    async def test_unexpected_exception_raises_500(self, ac):
+        """Lines 526-528: unexpected (non-ValueError) exception → 500."""
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("network failure"),
+            ),
+        ):
+            resp = await ac.post(
+                "/v2/proactive/send",
+                data={"match_ids": "1", "contact_ids": "1"},
+            )
+        assert resp.status_code == 500
+
+
+# ── Line 602: proactive_convert non-already-converted ValueError → 403 ─
+
+
+class TestConvertValueError403:
+    """POST /v2/partials/proactive/{offer_id}/convert — ValueError without 'already
+    converted'."""
+
+    async def test_value_error_not_already_converted_returns_403(self, ac, test_proactive_offer):
+        with patch(
+            "app.services.proactive_service.convert_proactive_to_win",
+            side_effect=ValueError("Not authorized to convert"),
+        ):
+            resp = await ac.post(f"/v2/partials/proactive/{test_proactive_offer.id}/convert")
+
+        assert resp.status_code == 403
+
+    async def test_already_converted_value_error_returns_409(self, ac, test_proactive_offer):
+        with patch(
+            "app.services.proactive_service.convert_proactive_to_win",
+            side_effect=ValueError("Offer already converted"),
+        ):
+            resp = await ac.post(f"/v2/partials/proactive/{test_proactive_offer.id}/convert")
+
+        assert resp.status_code == 409
+
+    async def test_offer_not_found_returns_404(self, ac):
+        resp = await ac.post("/v2/partials/proactive/99999/convert")
+        assert resp.status_code == 404
+
+
+# ── Lines 667-690: proactive_do_not_offer ────────────────────────────
+
+
+class TestDoNotOffer:
+    """POST /v2/partials/proactive/do-not-offer — creates record, dedup, returns
+    HTML."""
+
+    async def test_creates_record_and_returns_hidden_row(self, ac, db_session, test_user, test_company):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=False):
+            resp = await ac.post(
+                "/v2/partials/proactive/do-not-offer",
+                data={"mpn": "LM317T", "company_id": str(test_company.id)},
+            )
+
+        assert resp.status_code == 200
+        assert b"<tr" in resp.content
+
+    async def test_dedup_when_already_suppressed_still_returns_html(self, ac, db_session, test_user, test_company):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=True):
+            resp = await ac.post(
+                "/v2/partials/proactive/do-not-offer",
+                data={"mpn": "BC547", "company_id": str(test_company.id)},
+            )
+
+        assert resp.status_code == 200
+        assert b"<tr" in resp.content
+
+    async def test_accepts_customer_site_id_as_company_id_fallback(self, ac, db_session, test_user, test_company):
+        """customer_site_id form field is accepted when company_id is absent."""
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=False):
+            resp = await ac.post(
+                "/v2/partials/proactive/do-not-offer",
+                data={"mpn": "LM7805", "customer_site_id": str(test_company.id)},
+            )
+
+        assert resp.status_code == 200
+
+    async def test_invalid_company_id_returns_400(self, ac):
+        """Lines 669-670: non-integer company_id → 400."""
+        resp = await ac.post(
+            "/v2/partials/proactive/do-not-offer",
+            data={"mpn": "LM317T", "company_id": "not-a-number"},
+        )
+        assert resp.status_code == 400
+
+    async def test_missing_mpn_returns_400(self, ac):
+        resp = await ac.post(
+            "/v2/partials/proactive/do-not-offer",
+            data={"mpn": "", "company_id": "1"},
+        )
+        assert resp.status_code == 400
+
+    async def test_missing_company_id_returns_400(self, ac):
+        resp = await ac.post(
+            "/v2/partials/proactive/do-not-offer",
+            data={"mpn": "LM317T"},
+        )
+        assert resp.status_code == 400
+
+    async def test_unauthorized_company_returns_403(self, ac, db_session, test_company):
+        """Lines 676-677: user doesn't own the company → 403."""
+        test_company.account_owner_id = None
+        db_session.commit()
+
+        resp = await ac.post(
+            "/v2/partials/proactive/do-not-offer",
+            data={"mpn": "LM317T", "company_id": str(test_company.id)},
+        )
+        assert resp.status_code == 403
+
+    async def test_nonexistent_company_returns_403(self, ac):
+        resp = await ac.post(
+            "/v2/partials/proactive/do-not-offer",
+            data={"mpn": "LM317T", "company_id": "99999"},
+        )
+        assert resp.status_code == 403
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DIRECT CALL TESTS
+#
+# These call async endpoint functions directly (bypassing ASGI dispatch) so that
+# coverage.py traces every statement including post-await resumptions.  Using
+# TestClient or AsyncClient routes through ASGI transport which creates a task/
+# thread boundary that prevents coverage from recording coroutine-resume lines.
+# Direct await in the same async test function avoids that boundary entirely.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _post_req(form_data: dict | list) -> _SR:
+    """Minimal Starlette POST request with URL-encoded form body."""
+    items = list(form_data.items()) if isinstance(form_data, dict) else form_data
+    body = urlencode(items).encode()
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/test",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/x-www-form-urlencoded"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+    }
+    buf = [body]
+
+    async def receive():
+        return {"type": "http.request", "body": buf.pop() if buf else b"", "more_body": False}
+
+    return _SR(scope=scope, receive=receive)
+
+
+def _get_req(query_string: str = "") -> _SR:
+    """Minimal Starlette GET request with optional query string."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/test",
+        "query_string": query_string.encode() if query_string else b"",
+        "headers": [],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return _SR(scope=scope, receive=receive)
+
+
+# ── Direct: proactive_list_partial (lines 55-68) ──────────────────────────────
+
+
+class TestDirectListPartial:
+    """Direct calls to proactive_list_partial — covers lines 55-68."""
+
+    async def test_matches_tab_builds_context(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_list_partial
+
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.services.proactive_service.get_sent_offers", return_value=[]),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl,
+        ):
+            resp = await proactive_list_partial(_get_req(), tab="matches", user=test_user, db=db_session)
+
+        assert resp.status_code == 200
+        _, ctx = mock_tpl.call_args[0]
+        assert ctx["tab"] == "matches"
+        assert ctx["match_count"] == 0
+
+    async def test_sent_tab_calls_get_sent_offers(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_list_partial
+
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.services.proactive_service.get_sent_offers", return_value=[{"id": 1}]) as mock_sent,
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            await proactive_list_partial(_get_req(), tab="sent", user=test_user, db=db_session)
+
+        mock_sent.assert_called_once()
+
+    async def test_success_msg_from_query_string(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_list_partial
+
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.services.proactive_service.get_sent_offers", return_value=[]),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl,
+        ):
+            await proactive_list_partial(
+                _get_req("success_msg=Offer+sent"), tab="matches", user=test_user, db=db_session
+            )
+
+        _, ctx = mock_tpl.call_args[0]
+        assert ctx["success_msg"] == "Offer sent"
+
+
+# ── Direct: proactive_batch_dismiss (lines 110-117) ───────────────────────────
+
+
+class TestDirectBatchDismiss:
+    """Direct calls to proactive_batch_dismiss — covers lines 110-117."""
+
+    async def test_updates_db_when_match_ids_provided(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_batch_dismiss
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+        req = _post_req({"match_ids": str(match.id)})
+
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            resp = await proactive_batch_dismiss(req, user=test_user, db=db_session)
+
+        assert resp.status_code == 200
+        db_session.refresh(match)
+        assert match.status == "dismissed"
+        assert match.dismiss_reason == "batch_dismiss"
+
+    async def test_multiple_ids_dismissed(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_batch_dismiss
+
+        m1 = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+        m2 = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+        req = _post_req([("match_ids", str(m1.id)), ("match_ids", str(m2.id))])
+
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            await proactive_batch_dismiss(req, user=test_user, db=db_session)
+
+        db_session.refresh(m1)
+        db_session.refresh(m2)
+        assert m1.status == "dismissed"
+        assert m2.status == "dismissed"
+
+    async def test_empty_match_ids_does_not_update(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_batch_dismiss
+
+        with (
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            resp = await proactive_batch_dismiss(_post_req({}), user=test_user, db=db_session)
+
+        assert resp.status_code == 200
+
+
+# ── Direct: proactive_prepare_page (lines 156-178, 203, 215) ─────────────────
+
+
+class TestDirectPreparePage:
+    """Direct calls to proactive_prepare_page — covers lines 156-178, 203, 215."""
+
+    async def test_valid_match_renders_prepare_template(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_prepare_page
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+        req = _post_req({"match_ids": str(match.id)})
+
+        with patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl:
+            resp = await proactive_prepare_page(test_customer_site.id, req, user=test_user, db=db_session)
+
+        assert resp.status_code == 200
+        _, ctx = mock_tpl.call_args[0]
+        assert ctx["site_id"] == test_customer_site.id
+        assert len(ctx["matches"]) == 1
+        assert ctx["matches"][0]["mpn"] == "LM317T"
+
+    async def test_redirects_on_empty_match_ids(self, db_session, test_user, test_customer_site):
+        from app.routers.htmx.proactive import proactive_prepare_page
+
+        resp = await proactive_prepare_page(test_customer_site.id, _post_req({}), user=test_user, db=db_session)
+        assert resp.status_code == 303
+
+    async def test_redirects_when_match_not_owned(self, db_session, test_user, test_customer_site):
+        from app.routers.htmx.proactive import proactive_prepare_page
+
+        resp = await proactive_prepare_page(
+            test_customer_site.id, _post_req({"match_ids": "99999"}), user=test_user, db=db_session
+        )
+        assert resp.status_code == 303
+
+    async def test_contact_data_serialised_in_context(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_prepare_page
+
+        contact = SiteContact(
+            customer_site_id=test_customer_site.id,
+            full_name="Bob Smith",
+            email="bob@acme.com",
+            is_primary=True,
+        )
+        db_session.add(contact)
+        db_session.flush()
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl:
+            await proactive_prepare_page(
+                test_customer_site.id,
+                _post_req({"match_ids": str(match.id)}),
+                user=test_user,
+                db=db_session,
+            )
+
+        _, ctx = mock_tpl.call_args[0]
+        assert ctx["contacts"][0]["email"] == "bob@acme.com"
+        assert ctx["contacts"][0]["has_email"] is True
+
+
+# ── Direct: proactive_draft_for_prepare (lines 348-436) ──────────────────────
+
+
+class TestDirectDraftForPrepare:
+    """Direct calls to proactive_draft_for_prepare — covers lines 348-436."""
+
+    async def test_ai_success_returns_script_block(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value={"subject": "Stock Alert", "body": "We have LM317T available."},
+        ):
+            resp = await proactive_draft_for_prepare(
+                _post_req({"match_ids": str(match.id)}), user=test_user, db=db_session
+            )
+
+        assert resp.status_code == 200
+        assert b"<script>" in resp.body
+        assert b"Stock Alert" in resp.body
+
+    async def test_ai_failure_returns_fallback_html(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("AI down"),
+        ):
+            resp = await proactive_draft_for_prepare(
+                _post_req({"match_ids": str(match.id)}), user=test_user, db=db_session
+            )
+
+        assert resp.status_code == 200
+        body_lower = resp.body.lower()
+        assert b"unavailable" in body_lower or b"manually" in body_lower
+
+    async def test_ai_returns_none_gives_fallback(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            resp = await proactive_draft_for_prepare(
+                _post_req({"match_ids": str(match.id)}), user=test_user, db=db_session
+            )
+
+        assert resp.status_code == 200
+        assert b"unavailable" in resp.body.lower() or b"Auto-draft" in resp.body
+
+    async def test_contact_id_resolves_first_name(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        contact = SiteContact(
+            customer_site_id=test_customer_site.id,
+            full_name="Carol Chen",
+            email="carol@acme.com",
+            is_primary=True,
+        )
+        db_session.add(contact)
+        db_session.flush()
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value={"subject": "Hi Carol", "body": "Hello!"},
+        ) as mock_ai:
+            await proactive_draft_for_prepare(
+                _post_req({"match_ids": str(match.id), "contact_ids": str(contact.id)}),
+                user=test_user,
+                db=db_session,
+            )
+
+        _, kwargs = mock_ai.call_args
+        assert kwargs.get("contact_name") == "Carol"
+
+    async def test_sell_price_field_parsed_into_parts(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value={"subject": "s", "body": "b"},
+        ) as mock_ai:
+            await proactive_draft_for_prepare(
+                _post_req({"match_ids": str(match.id), f"sell_price_{match.id}": "1.99"}),
+                user=test_user,
+                db=db_session,
+            )
+
+        _, kwargs = mock_ai.call_args
+        assert kwargs["parts"][0]["sell_price"] == pytest.approx(1.99)
+
+    async def test_invalid_sell_price_silently_skipped(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+
+        with patch(
+            "app.services.proactive_email.draft_proactive_email",
+            new_callable=AsyncMock,
+            return_value={"subject": "s", "body": "b"},
+        ) as mock_ai:
+            await proactive_draft_for_prepare(
+                _post_req({"match_ids": str(match.id), f"sell_price_{match.id}": "bad"}),
+                user=test_user,
+                db=db_session,
+            )
+
+        _, kwargs = mock_ai.call_args
+        # Falls back to cost*1.3, not 0 or "bad"
+        assert kwargs["parts"][0]["sell_price"] >= 0
+
+    async def test_no_match_ids_returns_error_html(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        resp = await proactive_draft_for_prepare(_post_req({}), user=test_user, db=db_session)
+        assert b"No matches selected" in resp.body
+
+    async def test_match_not_owned_returns_error_html(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_draft_for_prepare
+
+        resp = await proactive_draft_for_prepare(_post_req({"match_ids": "99999"}), user=test_user, db=db_session)
+        assert b"No valid matches" in resp.body
+
+
+# ── Direct: proactive_send_offer (lines 456, 458, 460-528) ───────────────────
+
+
+class TestDirectSendOffer:
+    """Direct calls to proactive_send_offer — covers lines 456, 458, 460-528."""
+
+    async def test_sell_price_fields_parsed_and_forwarded(
+        self, db_session, test_user, test_requisition, test_offer, test_customer_site
+    ):
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
+        req = _post_req(
+            {
+                "match_ids": str(match.id),
+                "contact_ids": "1",
+                f"sell_price_{match.id}": "3.50",
+            }
+        )
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                return_value={"line_items": [], "recipient_emails": ["a@b.com"]},
+            ) as mock_svc,
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            resp = await proactive_send_offer(req, user=test_user, db=db_session)
+
+        assert resp.status_code == 200
+        _, kwargs = mock_svc.call_args
+        assert kwargs["sell_prices"].get(str(match.id)) == pytest.approx(3.50)
+
+    async def test_body_text_converted_to_html(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        req = _post_req({"match_ids": "1", "contact_ids": "1", "body": "Hello!\nLine2."})
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                return_value={"line_items": [], "recipient_emails": ["x@y.com"]},
+            ) as mock_svc,
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            await proactive_send_offer(req, user=test_user, db=db_session)
+
+        _, kwargs = mock_svc.call_args
+        assert kwargs["email_html"] is not None
+        assert "<br>" in kwargs["email_html"]
+
+    async def test_empty_body_passes_none_html(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        req = _post_req({"match_ids": "1", "contact_ids": "1", "body": ""})
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                return_value={"line_items": [], "recipient_emails": []},
+            ) as mock_svc,
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            await proactive_send_offer(req, user=test_user, db=db_session)
+
+        _, kwargs = mock_svc.call_args
+        assert kwargs["email_html"] is None
+
+    async def test_invalid_sell_price_silently_skipped(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        req = _post_req({"match_ids": "1", "contact_ids": "1", "sell_price_1": "not-a-number"})
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                return_value={"line_items": [], "recipient_emails": []},
+            ) as mock_svc,
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()),
+        ):
+            await proactive_send_offer(req, user=test_user, db=db_session)
+
+        _, kwargs = mock_svc.call_args
+        assert kwargs["sell_prices"] == {}
+
+    async def test_value_error_raises_http_400(self, db_session, test_user):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        req = _post_req({"match_ids": "1", "contact_ids": "1"})
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                side_effect=ValueError("No contacts found"),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await proactive_send_offer(req, user=test_user, db=db_session)
+
+        assert exc_info.value.status_code == 400
+
+    async def test_runtime_error_raises_http_500(self, db_session, test_user):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        req = _post_req({"match_ids": "1", "contact_ids": "1"})
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("Network failure"),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await proactive_send_offer(req, user=test_user, db=db_session)
+
+        assert exc_info.value.status_code == 500
+
+    async def test_success_message_shows_parts_and_contacts(self, db_session, test_user):
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        req = _post_req({"match_ids": "1", "contact_ids": "1", "subject": "Offer"})
+
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch(
+                "app.services.proactive_service.send_proactive_offer",
+                new_callable=AsyncMock,
+                return_value={
+                    "line_items": [{"mpn": "A"}, {"mpn": "B"}],
+                    "recipient_emails": ["a@b.com", "c@d.com"],
+                },
+            ),
+            patch("app.services.proactive_service.get_matches_for_user", return_value=_EMPTY_MATCHES),
+            patch("app.routers.htmx.proactive.template_response", return_value=_html_ok()) as mock_tpl,
+        ):
+            await proactive_send_offer(req, user=test_user, db=db_session)
+
+        _, ctx = mock_tpl.call_args[0]
+        assert "2 contact" in ctx["success_msg"] or "2 parts" in ctx["success_msg"]
+
+    async def test_no_match_ids_raises_400(self, db_session, test_user):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        with pytest.raises(HTTPException) as exc_info:
+            await proactive_send_offer(_post_req({"contact_ids": "1"}), user=test_user, db=db_session)
+
+        assert exc_info.value.status_code == 400
+
+    async def test_no_contact_ids_raises_400(self, db_session, test_user):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_send_offer
+
+        with pytest.raises(HTTPException) as exc_info:
+            await proactive_send_offer(_post_req({"match_ids": "1"}), user=test_user, db=db_session)
+
+        assert exc_info.value.status_code == 400
+
+
+# ── Direct: proactive_do_not_offer (lines 661-690) ───────────────────────────
+
+
+class TestDirectDoNotOffer:
+    """Direct calls to proactive_do_not_offer — covers lines 661-690."""
+
+    async def test_creates_dno_record(self, db_session, test_user, test_company):
+        from app.models.intelligence import ProactiveDoNotOffer
+        from app.routers.htmx.proactive import proactive_do_not_offer
+
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=False):
+            resp = await proactive_do_not_offer(
+                _post_req({"mpn": "LM317T", "company_id": str(test_company.id)}),
+                user=test_user,
+                db=db_session,
+            )
+
+        assert resp.status_code == 200
+        dno = db_session.query(ProactiveDoNotOffer).filter_by(mpn="LM317T", company_id=test_company.id).first()
+        assert dno is not None
+        assert dno.created_by_id == test_user.id
+
+    async def test_dedup_skips_second_insert(self, db_session, test_user, test_company):
+        from app.models.intelligence import ProactiveDoNotOffer
+        from app.routers.htmx.proactive import proactive_do_not_offer
+
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=True):
+            resp = await proactive_do_not_offer(
+                _post_req({"mpn": "BC547", "company_id": str(test_company.id)}),
+                user=test_user,
+                db=db_session,
+            )
+
+        assert resp.status_code == 200
+        assert db_session.query(ProactiveDoNotOffer).filter_by(mpn="BC547").first() is None
+
+    async def test_customer_site_id_field_accepted(self, db_session, test_user, test_company):
+        from app.routers.htmx.proactive import proactive_do_not_offer
+
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        with patch("app.services.proactive_helpers.is_do_not_offer", return_value=True):
+            resp = await proactive_do_not_offer(
+                _post_req({"mpn": "NE555", "customer_site_id": str(test_company.id)}),
+                user=test_user,
+                db=db_session,
+            )
+
+        assert resp.status_code == 200
+
+    async def test_missing_mpn_raises_400(self, db_session, test_user):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_do_not_offer
+
+        with pytest.raises(HTTPException) as exc_info:
+            await proactive_do_not_offer(_post_req({"mpn": "", "company_id": "1"}), user=test_user, db=db_session)
+
+        assert exc_info.value.status_code == 400
+
+    async def test_non_integer_company_id_raises_400(self, db_session, test_user):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_do_not_offer
+
+        with pytest.raises(HTTPException) as exc_info:
+            await proactive_do_not_offer(
+                _post_req({"mpn": "LM317T", "company_id": "abc"}), user=test_user, db=db_session
+            )
+
+        assert exc_info.value.status_code == 400
+
+    async def test_unauthorized_company_raises_403(self, db_session, test_user, test_company):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_do_not_offer
+
+        test_company.account_owner_id = None
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await proactive_do_not_offer(
+                _post_req({"mpn": "LM317T", "company_id": str(test_company.id)}),
+                user=test_user,
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 403
+
+    async def test_nonexistent_company_raises_403(self, db_session, test_user):
+        from fastapi import HTTPException
+
+        from app.routers.htmx.proactive import proactive_do_not_offer
+
+        with pytest.raises(HTTPException) as exc_info:
+            await proactive_do_not_offer(
+                _post_req({"mpn": "LM317T", "company_id": "99999"}), user=test_user, db=db_session
+            )
+
+        assert exc_info.value.status_code == 403

--- a/tests/test_ticket_prompt_coverage.py
+++ b/tests/test_ticket_prompt_coverage.py
@@ -1,0 +1,209 @@
+"""test_ticket_prompt_coverage.py — Coverage gap tests for ticket_prompt_service.
+
+Covers lines not reached by test_ticket_kind_and_prompt.py:
+  - _build_bug_prompt: all optional field branches (browser_info, console_errors,
+    network_errors, page_state, screenshot_path, screenshot_b64)
+  - _build_feature_prompt: current_view and screenshot branches
+  - generate_ticket_prompt: returns None when claude_text returns falsy
+
+Called by: pytest
+Depends on: app.services.ticket_prompt_service, app.models.trouble_ticket,
+            conftest (db_session), unittest.mock.
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.constants import TicketType
+from app.models.trouble_ticket import TroubleTicket
+from app.services.ticket_prompt_service import (
+    _build_bug_prompt,
+    _build_feature_prompt,
+    generate_ticket_prompt,
+)
+
+_CLAUDE_PATCH = "app.services.ticket_prompt_service.claude_text"
+
+
+# ── Fixture ───────────────────────────────────────────────────────────────────
+
+
+def _make_ticket(db: Session, *, num: str = "TT-GAP-001", **kw) -> TroubleTicket:
+    t = TroubleTicket(
+        ticket_number=num,
+        title=kw.pop("title", "Gap test"),
+        description=kw.pop("description", "A description"),
+        status=kw.pop("status", "submitted"),
+        source=kw.pop("source", "report_button"),
+        created_at=datetime.now(UTC),
+        **kw,
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+# ── _build_bug_prompt ─────────────────────────────────────────────────────────
+
+
+def test_build_bug_prompt_all_optional_fields(db_session: Session):
+    """_build_bug_prompt includes every optional field when all are present."""
+    t = _make_ticket(
+        db_session,
+        num="TT-BUG-ALL",
+        ticket_type=TicketType.BUG,
+        description="It crashed",
+        current_page="/v2/search",
+        current_view="SearchResults",
+        browser_info="Chrome 120 / macOS",
+        console_errors="TypeError: Cannot read properties of null",
+        network_errors='[{"status":500,"url":"/api/search"}]',
+        page_state='{"query":"LM317","rows":0}',
+        screenshot_path="/uploads/ss_001.png",
+        admin_notes="Check the null-guard in search_service.py",
+    )
+
+    result = _build_bug_prompt(t)
+
+    assert "TT-BUG-ALL" in result
+    assert "It crashed" in result
+    assert "/v2/search" in result
+    assert "SearchResults" in result
+    assert "Chrome 120" in result
+    assert "TypeError" in result
+    assert "/api/search" in result
+    assert "LM317" in result
+    assert "screenshot" in result.lower()
+    assert "Check the null-guard" in result
+
+
+def test_build_bug_prompt_screenshot_b64_branch(db_session: Session):
+    """_build_bug_prompt adds the screenshot note when only screenshot_b64 is set."""
+    t = _make_ticket(
+        db_session,
+        num="TT-BUG-B64",
+        ticket_type=TicketType.BUG,
+        screenshot_b64="data:image/png;base64,abc123",
+    )
+
+    result = _build_bug_prompt(t)
+
+    assert "screenshot" in result.lower()
+
+
+def test_build_bug_prompt_no_optional_fields(db_session: Session):
+    """_build_bug_prompt works when all optional fields are absent."""
+    t = _make_ticket(
+        db_session,
+        num="TT-BUG-MIN",
+        ticket_type=TicketType.BUG,
+        # All optional fields left at their column defaults (None).
+    )
+
+    result = _build_bug_prompt(t)
+
+    assert "TT-BUG-MIN" in result
+    # None of the optional sections should appear.
+    assert "Browser:" not in result
+    assert "JS/console errors:" not in result
+    assert "Network log:" not in result
+    assert "Page state:" not in result
+    assert "screenshot" not in result.lower()
+    assert "Admin notes" not in result
+
+
+# ── _build_feature_prompt ─────────────────────────────────────────────────────
+
+
+def test_build_feature_prompt_all_optional_fields(db_session: Session):
+    """_build_feature_prompt includes current_view and screenshot when set."""
+    t = _make_ticket(
+        db_session,
+        num="TT-FEAT-ALL",
+        ticket_type=TicketType.FEATURE,
+        description="Add dark mode",
+        current_page="/v2/dashboard",
+        current_view="DashboardMain",
+        screenshot_path="/uploads/ss_feat.png",
+        admin_notes="Use Tailwind dark: classes",
+    )
+
+    result = _build_feature_prompt(t)
+
+    assert "TT-FEAT-ALL" in result
+    assert "Add dark mode" in result
+    assert "/v2/dashboard" in result
+    assert "DashboardMain" in result
+    assert "screenshot" in result.lower()
+    assert "Tailwind dark:" in result
+
+
+def test_build_feature_prompt_screenshot_b64_branch(db_session: Session):
+    """_build_feature_prompt adds the screenshot note when screenshot_b64 is set."""
+    t = _make_ticket(
+        db_session,
+        num="TT-FEAT-B64",
+        ticket_type=TicketType.FEATURE,
+        screenshot_b64="data:image/png;base64,xyz",
+    )
+
+    result = _build_feature_prompt(t)
+
+    assert "screenshot" in result.lower()
+
+
+def test_build_feature_prompt_no_optional_fields(db_session: Session):
+    """_build_feature_prompt works when all optional fields are absent."""
+    t = _make_ticket(
+        db_session,
+        num="TT-FEAT-MIN",
+        ticket_type=TicketType.FEATURE,
+        # All optional fields left at their column defaults (None).
+    )
+
+    result = _build_feature_prompt(t)
+
+    assert "TT-FEAT-MIN" in result
+    assert "Current view:" not in result
+    assert "screenshot" not in result.lower()
+    assert "Admin notes" not in result
+
+
+# ── generate_ticket_prompt ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@patch(_CLAUDE_PATCH, new_callable=AsyncMock)
+async def test_generate_prompt_returns_none_when_claude_returns_empty(mock_ai, db_session: Session):
+    """generate_ticket_prompt returns None when claude_text returns an empty string."""
+    mock_ai.return_value = ""  # falsy → the `if not text` branch
+    t = _make_ticket(db_session, num="TT-EMPTY", ticket_type=TicketType.BUG)
+
+    result = await generate_ticket_prompt(db_session, t)
+
+    assert result is None
+    # generated_prompt must NOT be persisted.
+    db_session.refresh(t)
+    assert t.generated_prompt is None
+
+
+@pytest.mark.asyncio
+@patch(_CLAUDE_PATCH, new_callable=AsyncMock)
+async def test_generate_prompt_returns_none_when_claude_returns_none(mock_ai, db_session: Session):
+    """generate_ticket_prompt returns None when claude_text returns None."""
+    mock_ai.return_value = None
+    t = _make_ticket(db_session, num="TT-NONE", ticket_type=TicketType.FEATURE)
+
+    result = await generate_ticket_prompt(db_session, t)
+
+    assert result is None
+    db_session.refresh(t)
+    assert t.generated_prompt is None

--- a/tests/test_vendors_router_gaps2.py
+++ b/tests/test_vendors_router_gaps2.py
@@ -182,9 +182,15 @@ class TestVendorContactsPartial:
         assert ctx["sort"] == "score"
 
     def test_unknown_sort_key_falls_back_to_name(self, gaps2_client, db_session):
-        """Line 184: unknown sort key → default VendorContact.full_name column."""
+        """Line 184: unknown sort key → default VendorContact.full_name column.
+
+        Name order (Alpha < Zulu) is deliberately the REVERSE of both insertion/id
+        order and email order, so the positional assertion below only passes if
+        the fallback actually sorts by full_name.
+        """
         card = _active_card(db_session, "FallbackVendor")
-        _contact(db_session, card, "fb@fallback.com", "FB Contact")
+        _contact(db_session, card, "aaa@fallback.com", "Zulu Fallback")
+        _contact(db_session, card, "zzz@fallback.com", "Alpha Fallback")
         db_session.commit()
 
         with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
@@ -192,6 +198,10 @@ class TestVendorContactsPartial:
             resp = gaps2_client.get("/v2/partials/vendor-contacts?sort=unknown_col")
 
         assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        assert ctx["sort"] == "unknown_col"
+        names = [c.full_name for c in ctx["contacts"] if c.full_name.endswith("Fallback")]
+        assert names == ["Alpha Fallback", "Zulu Fallback"]
 
     def test_pagination_limit_and_offset(self, gaps2_client, db_session):
         """Lines 187-188: limit/offset are passed to the query and reflected in ctx."""

--- a/tests/test_vendors_router_gaps2.py
+++ b/tests/test_vendors_router_gaps2.py
@@ -1,0 +1,272 @@
+"""tests/test_vendors_router_gaps2.py — Second coverage-gap pass for vendors router.
+
+Covers lines 161-202 (vendor_contacts_partial — global vendor contacts list endpoint).
+That 42-statement block is the single largest uncovered region and crossing it alone
+pushes vendors.py from 83 % to 85 %+.
+
+Called by: pytest
+Depends on: app/routers/htmx/vendors.py, conftest.py fixtures
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi.responses import HTMLResponse
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import User, VendorCard, VendorContact
+
+# ── Client fixture ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def vendor_user(db_session: Session) -> User:
+    """Standard buyer user for vendor contacts tests."""
+    user = User(
+        email="vendor_gaps2@trioscs.com",
+        name="Gaps2 User",
+        role="buyer",
+        azure_id="test-azure-gaps2-buyer",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def gaps2_client(db_session: Session, vendor_user: User) -> TestClient:
+    """TestClient with auth overridden to vendor_user."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    overridden = [get_db, require_user, require_admin, require_buyer, require_fresh_token]
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: vendor_user
+    app.dependency_overrides[require_admin] = lambda: vendor_user
+    app.dependency_overrides[require_buyer] = lambda: vendor_user
+    app.dependency_overrides[require_fresh_token] = lambda: "token"
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in overridden:
+            app.dependency_overrides.pop(dep, None)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _active_card(db: Session, name: str = "Active Supplier") -> VendorCard:
+    """Seed a vendor card that satisfies the is_active/not-blacklisted filter."""
+    card = VendorCard(
+        normalized_name=name.lower(),
+        display_name=name,
+        is_active=True,
+        is_blacklisted=False,
+        created_at=datetime.now(UTC),
+    )
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _contact(db: Session, card: VendorCard, email: str, name: str) -> VendorContact:
+    """Seed a VendorContact linked to *card*."""
+    vc = VendorContact(
+        vendor_card_id=card.id,
+        email=email,
+        full_name=name,
+        source="manual",
+        is_verified=True,
+        confidence=80,
+    )
+    db.add(vc)
+    db.flush()
+    return vc
+
+
+# ── Lines 161-202: vendor_contacts_partial ────────────────────────────────────
+
+
+class TestVendorContactsPartial:
+    """GET /v2/partials/vendor-contacts — global vendor contacts list."""
+
+    def test_returns_200_with_contacts(self, gaps2_client, db_session):
+        """Lines 163-202: endpoint queries contacts, builds ctx, calls template_response."""
+        card = _active_card(db_session, "TechParts Inc")
+        _contact(db_session, card, "sales@techparts.com", "Alice Smith")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>contacts</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts")
+
+        assert resp.status_code == 200
+        # Verify template was called with the expected context keys
+        ctx = mock_tpl.call_args[0][1]
+        assert "contacts" in ctx
+        assert "total" in ctx
+        assert ctx["total"] >= 1
+
+    def test_search_filter_narrows_results(self, gaps2_client, db_session):
+        """Lines 169-176: search term is applied as ilike filter on name/email/vendor."""
+        card = _active_card(db_session, "FilterVendor")
+        # Use a distinctive name prefix that won't appear in the other contact's fields
+        _contact(db_session, card, "zephyr@filtervendor.com", "Zephyr Jones")
+        _contact(db_session, card, "unrelated@totally.com", "Unrelated Person")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>filtered</div>")
+            # Search by the unique first name — only the first contact should match
+            resp = gaps2_client.get("/v2/partials/vendor-contacts?search=zephyr")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        assert ctx["search"] == "zephyr"
+        emails = [c.email for c in ctx["contacts"]]
+        assert "zephyr@filtervendor.com" in emails
+        assert "unrelated@totally.com" not in emails
+
+    def test_sort_by_email_desc(self, gaps2_client, db_session):
+        """Lines 178-185: sort=email&dir=desc is mapped to the correct column/order."""
+        card = _active_card(db_session, "SortVendor")
+        _contact(db_session, card, "aaa@sort.com", "A Person")
+        _contact(db_session, card, "zzz@sort.com", "Z Person")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>sorted</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts?sort=email&dir=desc")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        assert ctx["sort"] == "email"
+        assert ctx["dir"] == "desc"
+
+    def test_sort_by_vendor(self, gaps2_client, db_session):
+        """Lines 178-185: sort=vendor maps to VendorCard.display_name."""
+        card = _active_card(db_session, "VendorSortTest")
+        _contact(db_session, card, "contact@vendorsort.com", "Sort Contact")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>ok</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts?sort=vendor&dir=asc")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        assert ctx["sort"] == "vendor"
+
+    def test_sort_by_score(self, gaps2_client, db_session):
+        """Lines 178-185: sort=score maps to VendorContact.relationship_score."""
+        card = _active_card(db_session, "ScoreSortVendor")
+        _contact(db_session, card, "scored@vendor.com", "Scored Contact")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>ok</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts?sort=score&dir=asc")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        assert ctx["sort"] == "score"
+
+    def test_unknown_sort_key_falls_back_to_name(self, gaps2_client, db_session):
+        """Line 184: unknown sort key → default VendorContact.full_name column."""
+        card = _active_card(db_session, "FallbackVendor")
+        _contact(db_session, card, "fb@fallback.com", "FB Contact")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>ok</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts?sort=unknown_col")
+
+        assert resp.status_code == 200
+
+    def test_pagination_limit_and_offset(self, gaps2_client, db_session):
+        """Lines 187-188: limit/offset are passed to the query and reflected in ctx."""
+        card = _active_card(db_session, "PaginationVendor")
+        for i in range(5):
+            _contact(db_session, card, f"contact{i}@page.com", f"Contact {i}")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>paged</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts?limit=2&offset=1")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        assert ctx["limit"] == 2
+        assert ctx["offset"] == 1
+        assert len(ctx["contacts"]) <= 2
+
+    def test_blacklisted_vendor_contacts_excluded(self, gaps2_client, db_session):
+        """Lines 165-168: contacts from blacklisted vendors are filtered out."""
+        blacklisted = VendorCard(
+            normalized_name="blacklisted co",
+            display_name="Blacklisted Co",
+            is_active=True,
+            is_blacklisted=True,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(blacklisted)
+        db_session.flush()
+        _contact(db_session, blacklisted, "bl@blacklisted.com", "BL Contact")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>ok</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        emails = [c.email for c in ctx["contacts"]]
+        assert "bl@blacklisted.com" not in emails
+
+    def test_inactive_vendor_contacts_excluded(self, gaps2_client, db_session):
+        """Lines 165-168: contacts from inactive vendors are filtered out."""
+        inactive = VendorCard(
+            normalized_name="inactive vendor co",
+            display_name="Inactive Vendor Co",
+            is_active=False,
+            is_blacklisted=False,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(inactive)
+        db_session.flush()
+        _contact(db_session, inactive, "inactive@vendor.com", "Inactive Contact")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>ok</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        emails = [c.email for c in ctx["contacts"]]
+        assert "inactive@vendor.com" not in emails
+
+    def test_empty_search_returns_all_active_contacts(self, gaps2_client, db_session):
+        """Line 169: blank search — the strip() branch is skipped, all contacts returned."""
+        card = _active_card(db_session, "AllContactsVendor")
+        _contact(db_session, card, "one@all.com", "One")
+        _contact(db_session, card, "two@all.com", "Two")
+        db_session.commit()
+
+        with patch("app.routers.htmx.vendors.template_response") as mock_tpl:
+            mock_tpl.return_value = HTMLResponse("<div>all</div>")
+            resp = gaps2_client.get("/v2/partials/vendor-contacts?search=")
+
+        assert resp.status_code == 200
+        ctx = mock_tpl.call_args[0][1]
+        assert ctx["total"] >= 2


### PR DESCRIPTION
Consolidates draft PRs #708, #709, #710 (nightly-coverage jobs, written pre-#714) into one clean, verified branch. Each draft was triaged against post-router-split main in an isolated worktree; this branch carries only the salvageable test files — the drafts' committed `.coverage.*` binaries, `.gitignore` and `MIGRATION_NUMBERS_IN_FLIGHT.txt` droppings are discarded.

**Verified: 246 passed, 0 failed** running all 10 files together on current main (24s, pre-commit clean incl. mypy/ruff).

| Source | Files | Disposition |
|---|---|---|
| #708 | `test_clay_oauth_async_coverage`, `test_credential_service` (superset of main's), `test_htmx_views_nightly31`, `test_proactive_router_coverage` | 3 patch targets renamed to `app.routers.htmx.requisitions_edit.*` (moved in the #714 split); 2 test classes deleted — they exercised `proactive_send_legacy`, which main deliberately removed |
| #709 | `test_buy_plans_router_gaps2`, `test_prepayment_notifications_gaps`, `test_ticket_prompt_coverage` (first coverage of that service), `test_vendors_router_gaps2` | pass unmodified; its `test_prepayment_confirm_route.py` hunk dropped (main's copy is newer — shared `_route_helpers` refactor) |
| #710 | `test_coverage_nightly_2026_07_05`, `test_coverage_nightly2_2026_07_05` | pass unmodified (services/jobs targets untouched by #714) |

Closes #708, closes #709, closes #710 (superseded by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)