### PR TITLE
Buy plans: single-form editing — edit all quantities, vendors, and lines at once

### DIFF
--- a/app/models/buy_plan.py
+++ b/app/models/buy_plan.py
@@ -239,6 +239,19 @@ class BuyPlanLine(Base):
     buyer = relationship("User", foreign_keys=[buyer_id])
     po_verified_by = relationship("User", foreign_keys=[po_verified_by_id])
 
+    @property
+    def has_cut_po(self) -> bool:
+        """True once this line has left AWAITING_PO (a PO is cut / verified / flagged /
+        cancelled).
+
+        Vendor/qty/removal edits on such a line would corrupt live purchasing state, so
+        the line-editing service (``app/services/buyplan_workflow/buyplan_lines.py``)
+        refuses them once this is true — the header sell price can still be corrected
+        (it never touches the PO). Single source of truth for both the service gate and
+        the whole-plan-editor template's per-row "locked" state.
+        """
+        return self.po_confirmed_at is not None or self.status != BuyPlanLineStatus.AWAITING_PO.value
+
     @validates("status")
     def _validate_status(self, _key, value):
         valid = {e.value for e in BuyPlanLineStatus}

--- a/app/models/buy_plan.py
+++ b/app/models/buy_plan.py
@@ -250,7 +250,7 @@ class BuyPlanLine(Base):
         (it never touches the PO). Single source of truth for both the service gate and
         the whole-plan-editor template's per-row "locked" state.
         """
-        return self.po_confirmed_at is not None or self.status != BuyPlanLineStatus.AWAITING_PO.value
+        return bool(self.po_confirmed_at is not None or self.status != BuyPlanLineStatus.AWAITING_PO.value)
 
     @validates("status")
     def _validate_status(self, _key, value):

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -115,6 +115,26 @@ def _parse_optional_float(raw: str | None) -> float | None:
         raise HTTPException(400, "Expected a number.") from e
 
 
+async def _notify_if_completed(plan_id: int, db: Session) -> None:
+    """Fire the completion notification if *plan_id* just auto-completed.
+
+    The auto-complete DECISION now lives at service depth — ``verify_po``,
+    ``remove_buy_plan_line``, and ``bulk_edit_buy_plan_lines`` each call
+    ``check_completion`` themselves right after mutating line state. This shared route
+    tail just re-checks status (cheap no-op the vast majority of the time) to decide
+    whether to fire the ``notify_completed`` side effect — kept a route concern, not a
+    service one. Used identically by the verify-po, remove-line, and bulk-save-lines
+    routes.
+    """
+    from ...services.buyplan_notifications import notify_completed, run_notify_bg
+    from ...services.buyplan_workflow import check_completion
+
+    updated = check_completion(plan_id, db)
+    if updated and updated.status == BuyPlanStatus.COMPLETED:
+        db.commit()
+        await run_notify_bg(notify_completed, plan_id)
+
+
 _APPROVALS_TABS = ("my_queue", "pipeline")
 
 
@@ -960,12 +980,8 @@ async def buy_plan_verify_po_partial(
     db: Session = Depends(get_db),
 ):
     """Ops verifies PO — returns refreshed detail."""
-    from ...services.buyplan_notifications import (
-        notify_completed,
-        notify_po_rejected,
-        run_notify_bg,
-    )
-    from ...services.buyplan_workflow import check_completion, verify_po
+    from ...services.buyplan_notifications import notify_po_rejected, run_notify_bg
+    from ...services.buyplan_workflow import verify_po
 
     form = await request.form()
     action = form.get("action", "approve")
@@ -977,10 +993,7 @@ async def buy_plan_verify_po_partial(
         db.commit()
         if action == "reject":
             await run_notify_bg(notify_po_rejected, plan_id, line_id=line_id)
-        updated = check_completion(plan_id, db)
-        if updated and updated.status == BuyPlanStatus.COMPLETED:
-            db.commit()
-            await run_notify_bg(notify_completed, plan_id)
+        await _notify_if_completed(plan_id, db)
     except (ValueError, PermissionError) as e:
         raise HTTPException(400, str(e)) from e
 
@@ -1224,12 +1237,11 @@ async def buy_plan_remove_line_partial(
     """Remove a line from an editable plan (epic I).
 
     Role×status gate in the service (PermissionError → 403); removing a cut-PO line →
-    400. Removing the plan's last open line can leave every remaining line terminal, so
-    a completion check runs right after — same pattern as verify-po (~line 980) — so an
-    ACTIVE plan can't get stranded short of COMPLETED.
+    400. ``remove_buy_plan_line`` already auto-completes at service depth (removing the
+    plan's last open line can leave every remaining line terminal); this route's
+    ``_notify_if_completed`` just re-checks to decide whether to fire the notification.
     """
-    from ...services.buyplan_notifications import notify_completed, run_notify_bg
-    from ...services.buyplan_workflow import check_completion, remove_buy_plan_line
+    from ...services.buyplan_workflow import remove_buy_plan_line
 
     # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
     get_buyplan_for_user(db, user, plan_id)
@@ -1237,10 +1249,7 @@ async def buy_plan_remove_line_partial(
     try:
         remove_buy_plan_line(plan_id, line_id, user, db)
         db.commit()
-        updated = check_completion(plan_id, db)
-        if updated and updated.status == BuyPlanStatus.COMPLETED:
-            db.commit()
-            await run_notify_bg(notify_completed, plan_id)
+        await _notify_if_completed(plan_id, db)
     except PermissionError as e:
         raise HTTPException(403, str(e)) from e
     except ValueError as e:
@@ -1266,12 +1275,12 @@ async def buy_plan_bulk_lines_partial(
     is left untouched instead of silently deleted; omitted entirely falls back to the
     legacy (unscoped) removal-by-omission behavior. Role×status gate and per-line rules
     are enforced in the service (PermissionError → 403); malformed JSON, a bad shape, or
-    bad line data → 400. Removing the last open line can leave every remaining line
-    terminal, so a completion check runs right after — same pattern as verify-po
-    (~line 980) — so an ACTIVE plan can't get stranded short of COMPLETED.
+    bad line data → 400. ``bulk_edit_buy_plan_lines`` already auto-completes at service
+    depth (removing the last open line can leave every remaining line terminal); this
+    route's ``_notify_if_completed`` just re-checks to decide whether to fire the
+    notification.
     """
-    from ...services.buyplan_notifications import notify_completed, run_notify_bg
-    from ...services.buyplan_workflow import bulk_edit_buy_plan_lines, check_completion
+    from ...services.buyplan_workflow import bulk_edit_buy_plan_lines
 
     # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
     get_buyplan_for_user(db, user, plan_id)
@@ -1294,10 +1303,7 @@ async def buy_plan_bulk_lines_partial(
     try:
         bulk_edit_buy_plan_lines(plan_id, parsed["lines"], user, db, known_line_ids=known_line_ids)
         db.commit()
-        updated = check_completion(plan_id, db)
-        if updated and updated.status == BuyPlanStatus.COMPLETED:
-            db.commit()
-            await run_notify_bg(notify_completed, plan_id)
+        await _notify_if_completed(plan_id, db)
     except PermissionError as e:
         raise HTTPException(403, str(e)) from e
     except ValueError as e:

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -1242,6 +1242,47 @@ async def buy_plan_remove_line_partial(
     return await buy_plan_detail_partial(request, plan_id, user, db)
 
 
+@router.post("/v2/partials/buy-plans/{plan_id}/lines/bulk", response_class=HTMLResponse)
+async def buy_plan_bulk_lines_partial(
+    request: Request,
+    plan_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Save the entire plan's lines (edited qty/sell/vendor, added lines, removed
+    lines) in one POST (epic I "save all").
+
+    Form field ``payload`` is a JSON object ``{"lines": [...]}`` (the Alpine editor
+    posts it via an htmx ``hx-vals`` JSON blob). Role×status gate and per-line rules
+    are enforced in the service (PermissionError → 403); malformed JSON, a bad shape,
+    or bad line data → 400.
+    """
+    from ...services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
+    get_buyplan_for_user(db, user, plan_id)
+
+    form = await request.form()
+    raw_payload = form.get("payload")
+    try:
+        parsed = json.loads(str(raw_payload))
+    except (TypeError, ValueError) as e:
+        raise HTTPException(400, "Malformed lines payload — expected JSON.") from e
+
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("lines"), list):
+        raise HTTPException(400, 'Lines payload must be a JSON object shaped {"lines": [...]}.')
+
+    try:
+        bulk_edit_buy_plan_lines(plan_id, parsed["lines"], user, db)
+        db.commit()
+    except PermissionError as e:
+        raise HTTPException(403, str(e)) from e
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+
+    return await buy_plan_detail_partial(request, plan_id, user, db)
+
+
 @router.post("/v2/partials/buy-plans/{plan_id}/reset", response_class=HTMLResponse)
 async def buy_plan_reset_partial(
     request: Request,

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -1224,9 +1224,12 @@ async def buy_plan_remove_line_partial(
     """Remove a line from an editable plan (epic I).
 
     Role×status gate in the service (PermissionError → 403); removing a cut-PO line →
-    400.
+    400. Removing the plan's last open line can leave every remaining line terminal, so
+    a completion check runs right after — same pattern as verify-po (~line 980) — so an
+    ACTIVE plan can't get stranded short of COMPLETED.
     """
-    from ...services.buyplan_workflow import remove_buy_plan_line
+    from ...services.buyplan_notifications import notify_completed, run_notify_bg
+    from ...services.buyplan_workflow import check_completion, remove_buy_plan_line
 
     # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
     get_buyplan_for_user(db, user, plan_id)
@@ -1234,6 +1237,10 @@ async def buy_plan_remove_line_partial(
     try:
         remove_buy_plan_line(plan_id, line_id, user, db)
         db.commit()
+        updated = check_completion(plan_id, db)
+        if updated and updated.status == BuyPlanStatus.COMPLETED:
+            db.commit()
+            await run_notify_bg(notify_completed, plan_id)
     except PermissionError as e:
         raise HTTPException(403, str(e)) from e
     except ValueError as e:

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -1265,8 +1265,8 @@ async def buy_plan_bulk_lines_partial(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Save the entire plan's lines (edited qty/sell/vendor, added lines, removed
-    lines) in one POST (epic I "save all").
+    """Save the entire plan's lines (edited qty/sell/vendor, added lines, removed lines)
+    in one POST (epic I "save all").
 
     Form field ``payload`` is a JSON object ``{"lines": [...], "known_line_ids": [...]}``
     (the Alpine editor posts it via an htmx ``hx-vals`` JSON blob). ``known_line_ids``

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -1259,12 +1259,19 @@ async def buy_plan_bulk_lines_partial(
     """Save the entire plan's lines (edited qty/sell/vendor, added lines, removed
     lines) in one POST (epic I "save all").
 
-    Form field ``payload`` is a JSON object ``{"lines": [...]}`` (the Alpine editor
-    posts it via an htmx ``hx-vals`` JSON blob). Role×status gate and per-line rules
-    are enforced in the service (PermissionError → 403); malformed JSON, a bad shape,
-    or bad line data → 400.
+    Form field ``payload`` is a JSON object ``{"lines": [...], "known_line_ids": [...]}``
+    (the Alpine editor posts it via an htmx ``hx-vals`` JSON blob). ``known_line_ids``
+    (optional; a list of ints) is every line id the client's form actually rendered —
+    it scopes removal-by-omission so a line added by someone else after the form loaded
+    is left untouched instead of silently deleted; omitted entirely falls back to the
+    legacy (unscoped) removal-by-omission behavior. Role×status gate and per-line rules
+    are enforced in the service (PermissionError → 403); malformed JSON, a bad shape, or
+    bad line data → 400. Removing the last open line can leave every remaining line
+    terminal, so a completion check runs right after — same pattern as verify-po
+    (~line 980) — so an ACTIVE plan can't get stranded short of COMPLETED.
     """
-    from ...services.buyplan_workflow import bulk_edit_buy_plan_lines
+    from ...services.buyplan_notifications import notify_completed, run_notify_bg
+    from ...services.buyplan_workflow import bulk_edit_buy_plan_lines, check_completion
 
     # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
     get_buyplan_for_user(db, user, plan_id)
@@ -1279,9 +1286,18 @@ async def buy_plan_bulk_lines_partial(
     if not isinstance(parsed, dict) or not isinstance(parsed.get("lines"), list):
         raise HTTPException(400, 'Lines payload must be a JSON object shaped {"lines": [...]}.')
 
+    known_line_ids = parsed.get("known_line_ids")
+    if known_line_ids is not None:
+        if not isinstance(known_line_ids, list) or not all(isinstance(i, int) for i in known_line_ids):
+            raise HTTPException(400, "known_line_ids must be a list of whole-number line ids.")
+
     try:
-        bulk_edit_buy_plan_lines(plan_id, parsed["lines"], user, db)
+        bulk_edit_buy_plan_lines(plan_id, parsed["lines"], user, db, known_line_ids=known_line_ids)
         db.commit()
+        updated = check_completion(plan_id, db)
+        if updated and updated.status == BuyPlanStatus.COMPLETED:
+            db.commit()
+            await run_notify_bg(notify_completed, plan_id)
     except PermissionError as e:
         raise HTTPException(403, str(e)) from e
     except ValueError as e:

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -992,11 +992,16 @@ async def buy_plan_verify_po_partial(
     hub_scope = form.get("hub_scope", "all")
 
     try:
-        verify_po(plan_id, line_id, action, user, db, rejection_note=form.get("rejection_note"))
+        line = verify_po(plan_id, line_id, action, user, db, rejection_note=form.get("rejection_note"))
+        # verify_po's own internal (approve-only) check_completion call already mutated
+        # the SAME identity-mapped BuyPlan object `line.buy_plan` resolves to (verify_po
+        # loaded it via db.get(BuyPlan, plan_id) itself) — reading .status off it here
+        # is a free identity-map hit, NOT a second completion scan.
+        just_completed = line.buy_plan is not None and line.buy_plan.status == BuyPlanStatus.COMPLETED.value
         db.commit()
         if action == "reject":
             await run_notify_bg(notify_po_rejected, plan_id, line_id=line_id)
-        await _notify_if_completed(plan_id, db)
+        await _notify_if_completed(plan_id, just_completed)
     except (ValueError, PermissionError) as e:
         raise HTTPException(400, str(e)) from e
 
@@ -1293,15 +1298,21 @@ async def buy_plan_bulk_lines_partial(
     is left untouched instead of silently deleted; omitted entirely falls back to the
     legacy (unscoped) removal-by-omission behavior. Role×status gate and per-line rules
     are enforced in the service (PermissionError → 403); malformed JSON, a bad shape, or
-    bad line data → 400. ``bulk_edit_buy_plan_lines`` already auto-completes at service
-    depth (removing the last open line can leave every remaining line terminal); this
-    route's ``_notify_if_completed`` just re-checks to decide whether to fire the
-    notification.
+    bad line data → 400. ``known_line_ids`` element-level validation (whole numbers,
+    bools rejected) lives in the SERVICE now (``bulk_edit_buy_plan_lines`` owns the
+    contract) — this route only checks the outer shape (a list, if present).
+    ``bulk_edit_buy_plan_lines`` already auto-completes at service depth (removing the
+    last open line can leave every remaining line terminal); the returned plan's
+    ``.status`` is read BEFORE commit to drive ``_notify_if_completed`` without re-
+    deriving the fact via a second ``check_completion`` scan.
     """
     from ...services.buyplan_workflow import bulk_edit_buy_plan_lines
 
-    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
-    get_buyplan_for_user(db, user, plan_id)
+    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation. Matches
+    # bulk_edit_buy_plan_lines's own loader options (see buy_plan_add_line_partial).
+    get_buyplan_for_user(
+        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
+    )
 
     form = await request.form()
     raw_payload = form.get("payload")
@@ -1314,14 +1325,14 @@ async def buy_plan_bulk_lines_partial(
         raise HTTPException(400, 'Lines payload must be a JSON object shaped {"lines": [...]}.')
 
     known_line_ids = parsed.get("known_line_ids")
-    if known_line_ids is not None:
-        if not isinstance(known_line_ids, list) or not all(isinstance(i, int) for i in known_line_ids):
-            raise HTTPException(400, "known_line_ids must be a list of whole-number line ids.")
+    if known_line_ids is not None and not isinstance(known_line_ids, list):
+        raise HTTPException(400, "known_line_ids must be a list of whole-number line ids.")
 
     try:
-        bulk_edit_buy_plan_lines(plan_id, parsed["lines"], user, db, known_line_ids=known_line_ids)
+        updated = bulk_edit_buy_plan_lines(plan_id, parsed["lines"], user, db, known_line_ids=known_line_ids)
+        just_completed = updated.status == BuyPlanStatus.COMPLETED.value
         db.commit()
-        await _notify_if_completed(plan_id, db)
+        await _notify_if_completed(plan_id, just_completed)
     except PermissionError as e:
         raise HTTPException(403, str(e)) from e
     except ValueError as e:

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -1183,9 +1183,7 @@ async def buy_plan_add_line_partial(
     # map does NOT retroactively apply new loader options, so without this the service's
     # joinedload(BuyPlan.lines)/joinedload(BuyPlan.requisition) would do nothing and
     # plan.lines/plan.requisition would lazy-load one row at a time instead.
-    get_buyplan_for_user(
-        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
-    )
+    get_buyplan_for_user(db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
 
     form = await request.form()
     try:
@@ -1224,9 +1222,7 @@ async def buy_plan_edit_line_partial(
 
     # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation. Matches
     # edit_buy_plan_line's own loader options (see buy_plan_add_line_partial for why).
-    get_buyplan_for_user(
-        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
-    )
+    get_buyplan_for_user(db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
 
     form = await request.form()
     quantity = _parse_optional_int(form.get("quantity"))
@@ -1264,9 +1260,7 @@ async def buy_plan_remove_line_partial(
 
     # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation. Matches
     # remove_buy_plan_line's own loader options (see buy_plan_add_line_partial).
-    get_buyplan_for_user(
-        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
-    )
+    get_buyplan_for_user(db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
 
     try:
         updated = remove_buy_plan_line(plan_id, line_id, user, db)
@@ -1310,9 +1304,7 @@ async def buy_plan_bulk_lines_partial(
 
     # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation. Matches
     # bulk_edit_buy_plan_lines's own loader options (see buy_plan_add_line_partial).
-    get_buyplan_for_user(
-        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
-    )
+    get_buyplan_for_user(db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
 
     form = await request.form()
     raw_payload = form.get("payload")

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -115,24 +115,27 @@ def _parse_optional_float(raw: str | None) -> float | None:
         raise HTTPException(400, "Expected a number.") from e
 
 
-async def _notify_if_completed(plan_id: int, db: Session) -> None:
-    """Fire the completion notification if *plan_id* just auto-completed.
+async def _notify_if_completed(plan_id: int, just_completed: bool) -> None:
+    """Fire the completion notification exactly once, driven by a caller-computed
+    *just_completed* flag — NEVER by re-deriving it via a second ``check_completion``
+    call.
 
-    The auto-complete DECISION now lives at service depth — ``verify_po``,
+    The auto-complete DECISION lives entirely at service depth: ``verify_po``,
     ``remove_buy_plan_line``, and ``bulk_edit_buy_plan_lines`` each call
-    ``check_completion`` themselves right after mutating line state. This shared route
-    tail just re-checks status (cheap no-op the vast majority of the time) to decide
-    whether to fire the ``notify_completed`` side effect — kept a route concern, not a
-    service one. Used identically by the verify-po, remove-line, and bulk-save-lines
-    routes.
+    ``check_completion`` themselves right after mutating line state, so by the time
+    control returns to the route the plan/line object already carries the answer in its
+    (still in-session, pre-commit) ``.status``. Callers capture *just_completed* from
+    that status BEFORE ``db.commit()`` (so an expired attribute after commit can't force
+    a surprise re-fetch) and pass it here AFTER commit — re-scanning the plan's lines a
+    second time here would be redundant work and, worse, a second opportunity to invoke
+    completion side effects if the "already complete" short-circuit were ever weakened.
+    Used identically by the verify-po, remove-line, and bulk-save-lines routes.
     """
+    if not just_completed:
+        return
     from ...services.buyplan_notifications import notify_completed, run_notify_bg
-    from ...services.buyplan_workflow import check_completion
 
-    updated = check_completion(plan_id, db)
-    if updated and updated.status == BuyPlanStatus.COMPLETED:
-        db.commit()
-        await run_notify_bg(notify_completed, plan_id)
+    await run_notify_bg(notify_completed, plan_id)
 
 
 _APPROVALS_TABS = ("my_queue", "pipeline")
@@ -1169,8 +1172,15 @@ async def buy_plan_add_line_partial(
     """
     from ...services.buyplan_workflow import add_buy_plan_line
 
-    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
-    get_buyplan_for_user(db, user, plan_id)
+    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation. Same
+    # loader options as add_buy_plan_line's own db.get() so the ownership pre-check's
+    # load isn't silently wasted — a bare Session.get() on a PK already in the identity
+    # map does NOT retroactively apply new loader options, so without this the service's
+    # joinedload(BuyPlan.lines)/joinedload(BuyPlan.requisition) would do nothing and
+    # plan.lines/plan.requisition would lazy-load one row at a time instead.
+    get_buyplan_for_user(
+        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
+    )
 
     form = await request.form()
     try:
@@ -1207,8 +1217,11 @@ async def buy_plan_edit_line_partial(
     """
     from ...services.buyplan_workflow import edit_buy_plan_line
 
-    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
-    get_buyplan_for_user(db, user, plan_id)
+    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation. Matches
+    # edit_buy_plan_line's own loader options (see buy_plan_add_line_partial for why).
+    get_buyplan_for_user(
+        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
+    )
 
     form = await request.form()
     quantity = _parse_optional_int(form.get("quantity"))
@@ -1238,18 +1251,23 @@ async def buy_plan_remove_line_partial(
 
     Role×status gate in the service (PermissionError → 403); removing a cut-PO line →
     400. ``remove_buy_plan_line`` already auto-completes at service depth (removing the
-    plan's last open line can leave every remaining line terminal); this route's
-    ``_notify_if_completed`` just re-checks to decide whether to fire the notification.
+    plan's last open line can leave every remaining line terminal); the returned plan's
+    ``.status`` is read BEFORE commit to drive ``_notify_if_completed`` without re-
+    deriving the fact via a second ``check_completion`` scan.
     """
     from ...services.buyplan_workflow import remove_buy_plan_line
 
-    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
-    get_buyplan_for_user(db, user, plan_id)
+    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation. Matches
+    # remove_buy_plan_line's own loader options (see buy_plan_add_line_partial).
+    get_buyplan_for_user(
+        db, user, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)]
+    )
 
     try:
-        remove_buy_plan_line(plan_id, line_id, user, db)
+        updated = remove_buy_plan_line(plan_id, line_id, user, db)
+        just_completed = updated.status == BuyPlanStatus.COMPLETED.value
         db.commit()
-        await _notify_if_completed(plan_id, db)
+        await _notify_if_completed(plan_id, just_completed)
     except PermissionError as e:
         raise HTTPException(403, str(e)) from e
     except ValueError as e:

--- a/app/services/buyplan_workflow/__init__.py
+++ b/app/services/buyplan_workflow/__init__.py
@@ -9,8 +9,8 @@ package along its audited seams:
     and auto-completion (one module: every transition shares the same engine-
     request/prepayment teardown helpers).
   - `buyplan_po` — buyer PO confirmation + approver PO verification (sync scan).
-  - `buyplan_lines` — claim/flag/resolve, re-source, and the add/edit/remove/SO#
-    line-editing API.
+  - `buyplan_lines` — claim/flag/resolve, re-source, and the add/edit/remove/bulk-
+    save/SO# line-editing API.
   - `buyplan_reports` — favoritism detection + case-report generation.
 
 This `__init__.py` re-exports every public name AND every internal name that
@@ -59,6 +59,7 @@ from .buyplan_lines import (
     _line_margin_pct,
     _owns_plan,
     add_buy_plan_line,
+    bulk_edit_buy_plan_lines,
     can_edit_buy_plan_lines,
     claim_line,
     edit_buy_plan_line,
@@ -105,6 +106,7 @@ __all__ = [
     "_run_reject_side_effects",
     "add_buy_plan_line",
     "approve_buy_plan",
+    "bulk_edit_buy_plan_lines",
     "can_edit_buy_plan_lines",
     "cancel_buy_plan",
     "check_completion",

--- a/app/services/buyplan_workflow/buyplan_approval.py
+++ b/app/services/buyplan_workflow/buyplan_approval.py
@@ -827,13 +827,22 @@ def _apply_line_overrides(plan: BuyPlan, overrides: list[dict], db: Session):
 
 
 def _recalculate_financials(plan: BuyPlan):
-    """Recompute plan-level cost, revenue, margin from lines."""
+    """Recompute plan-level cost, revenue, margin from lines.
+
+    Per-line gates use ``is not None`` (not bare truthiness) so a genuine ``0.0``
+    unit_cost/unit_sell (e.g. a free-sample line) is included in the sum rather than
+    silently skipped — matches the same "0 is a real value, not falsy" fix applied to
+    the line-level writers in ``buyplan_lines.py``. Note this is a defensive/consistency
+    fix, not a behavior change: a truly-zero line contributes exactly 0 to the running
+    total either way the gate is written, so no existing caller's computed total_cost/
+    total_revenue/total_margin_pct changes.
+    """
     total_cost = 0.0
     total_revenue = 0.0
     for line in plan.lines:
-        if line.unit_cost and line.quantity:
+        if line.unit_cost is not None and line.quantity:
             total_cost += float(line.unit_cost) * line.quantity
-        if line.unit_sell and line.quantity:
+        if line.unit_sell is not None and line.quantity:
             total_revenue += float(line.unit_sell) * line.quantity
 
     plan.total_cost = round(total_cost, 2) if total_cost else None

--- a/app/services/buyplan_workflow/buyplan_approval.py
+++ b/app/services/buyplan_workflow/buyplan_approval.py
@@ -832,21 +832,27 @@ def _recalculate_financials(plan: BuyPlan):
     Per-line gates use ``is not None`` (not bare truthiness) so a genuine ``0.0``
     unit_cost/unit_sell (e.g. a free-sample line) is included in the sum rather than
     silently skipped — matches the same "0 is a real value, not falsy" fix applied to
-    the line-level writers in ``buyplan_lines.py``. Note this is a defensive/consistency
-    fix, not a behavior change: a truly-zero line contributes exactly 0 to the running
-    total either way the gate is written, so no existing caller's computed total_cost/
-    total_revenue/total_margin_pct changes.
+    the line-level writers in ``buyplan_lines.py``. The plan-level ``total_cost``/
+    ``total_revenue`` collapse to ``None`` only when NO line ever contributed a real
+    (non-None) value — tracked via ``has_cost``/``has_revenue`` rather than the running
+    total's own truthiness, so a plan whose lines are ALL genuinely $0 (e.g. every line
+    free-sample) reports ``0.0`` ("$0.00", a real fact) instead of ``None`` ("no data",
+    which would be wrong — the data IS there, it's just zero).
     """
     total_cost = 0.0
     total_revenue = 0.0
+    has_cost = False
+    has_revenue = False
     for line in plan.lines:
         if line.unit_cost is not None and line.quantity:
             total_cost += float(line.unit_cost) * line.quantity
+            has_cost = True
         if line.unit_sell is not None and line.quantity:
             total_revenue += float(line.unit_sell) * line.quantity
+            has_revenue = True
 
-    plan.total_cost = round(total_cost, 2) if total_cost else None
-    plan.total_revenue = round(total_revenue, 2) if total_revenue else None
+    plan.total_cost = round(total_cost, 2) if has_cost else None
+    plan.total_revenue = round(total_revenue, 2) if has_revenue else None
     if total_revenue > 0:
         plan.total_margin_pct = round(((total_revenue - total_cost) / total_revenue) * 100, 2)
     else:

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -528,7 +528,7 @@ def _build_new_line(
 
     unit_cost = float(offer.unit_price) if offer.unit_price else None
     resolved_sell = (
-        float(unit_sell)  # type: ignore[arg-type]
+        float(unit_sell)
         if unit_sell is not None
         else (float(requirement.target_price) if requirement.target_price else None)
     )
@@ -630,8 +630,10 @@ def bulk_edit_buy_plan_lines(
     """Save an entire plan's lines in one shot — edits, adds, and removal-by-omission.
 
     The "save all" counterpart to :func:`add_buy_plan_line` / :func:`edit_buy_plan_line` /
-    :func:`remove_buy_plan_line`, reusing their exact per-field rules rather than
-    duplicating them:
+    :func:`remove_buy_plan_line`; the per-field edit rules live in the shared
+    :func:`_apply_line_edit` helper (also used by :func:`edit_buy_plan_line`) and new-
+    line validation/construction lives in :func:`_build_new_line` (also used by
+    :func:`add_buy_plan_line`), so there is exactly one place each rule is encoded:
       - an entry with ``line_id`` edits that existing line. Vendor/qty changes are
         refused once :func:`_has_cut_po` is true — UNLESS the submitted value equals the
         line's current value, which is always a no-op (never trips the guard); this
@@ -655,8 +657,15 @@ def bulk_edit_buy_plan_lines(
         *known_line_ids* omitted (``None``) falls back to the legacy behavior above (the
         route always sends it; this is a backward-compat contract, not a UI choice).
 
-    Gated by :func:`can_edit_buy_plan_lines`. Caller commits; a mid-loop ValueError
-    leaves nothing committed (the router never calls db.commit() after an exception).
+    Every offer any entry references is preloaded in ONE batch query up front (a real
+    editor save can touch a dozen+ lines/vendors) instead of a ``db.get()`` per entry.
+
+    Gated by :func:`can_edit_buy_plan_lines`. Auto-completes at service depth via
+    :func:`check_completion` after recalc/flush (mirrors ``verify_po`` in
+    ``buyplan_po.py``) — removing the last open line can leave every remaining line
+    terminal, so this prevents an ACTIVE plan getting stranded short of COMPLETED.
+    Caller commits; a mid-loop ValueError leaves nothing committed (the router never
+    calls db.commit() after an exception).
     """
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
     if not plan:
@@ -665,7 +674,24 @@ def bulk_edit_buy_plan_lines(
 
     existing_by_id = {ln.id: ln for ln in plan.lines}
     seen_ids: set[int] = set()
-    touched = 0
+
+    # One batch query for every offer any entry references, instead of a db.get() per
+    # entry — a real editor save can touch a dozen+ lines/vendors in one POST.
+    offer_ids: set[int] = set()
+    for entry in lines_payload:
+        if isinstance(entry, dict) and entry.get("offer_id") is not None:
+            try:
+                offer_ids.add(int(entry["offer_id"]))
+            except (TypeError, ValueError):
+                pass  # not a valid id — the per-entry lookup below raises the real error
+    offer_lookup: dict[int, Offer] = {}
+    if offer_ids:
+        offer_lookup = {
+            o.id: o
+            for o in db.execute(
+                select(Offer).options(joinedload(Offer.vendor_card)).where(Offer.id.in_(offer_ids))
+            ).scalars()
+        }
 
     for entry in lines_payload:
         if not isinstance(entry, dict):
@@ -680,83 +706,30 @@ def bulk_edit_buy_plan_lines(
                 seen_ids.add(line_id)
 
                 offer_id = entry.get("offer_id")
-                if offer_id is not None:
-                    offer_id_int = int(offer_id)
-                    if offer_id_int != line.offer_id:
-                        if _has_cut_po(line):
-                            raise ValueError("Cannot change the vendor after a PO is cut on this line.")
-                        offer = db.get(Offer, offer_id_int)
-                        if not offer:
-                            raise ValueError(f"Offer {offer_id} not found")
-                        _ensure_offer_on_requisition(offer, plan.requisition_id)
-                        line.offer_id = offer.id
-                        line.unit_cost = float(offer.unit_price) if offer.unit_price else None
-                        buyer, reason = assign_buyer(offer, offer.vendor_card, db)
-                        line.buyer_id = buyer.id if buyer else None
-                        line.assignment_reason = reason
-
-                raw_quantity = entry.get("quantity")
-                if raw_quantity is not None:
-                    quantity = _require_int_quantity(raw_quantity)
-                    if quantity != line.quantity:
-                        if _has_cut_po(line):
-                            raise ValueError("Cannot change the quantity after a PO is cut on this line.")
-                        if quantity <= 0:
-                            raise ValueError("Quantity must be a positive whole number.")
-                        line.quantity = quantity
-
-                # Key-presence semantics: absent -> unchanged; present + null -> clear;
-                # present + number -> set. (Unlike offer/quantity, sell is never gated
-                # by _has_cut_po — it never touches the PO.)
-                if "unit_sell" in entry:
-                    raw_sell = entry.get("unit_sell")
-                    line.unit_sell = float(raw_sell) if raw_sell is not None else None
-
-                line.margin_pct = _line_margin_pct(
-                    float(line.unit_sell) if line.unit_sell is not None else None,
-                    float(line.unit_cost) if line.unit_cost is not None else None,
+                quantity = entry.get("quantity")
+                unit_sell = entry.get("unit_sell") if "unit_sell" in entry else _UNSET
+                _apply_line_edit(
+                    line,
+                    plan,
+                    db,
+                    offer_id=offer_id if offer_id is not None else _UNSET,
+                    quantity=quantity if quantity is not None else _UNSET,
+                    unit_sell=unit_sell,
+                    offer_lookup=offer_lookup,
                 )
             else:
-                requirement_id = entry.get("requirement_id")
-                offer_id = entry.get("offer_id")
-                raw_quantity = entry.get("quantity")
-                quantity = _require_int_quantity(raw_quantity) if raw_quantity is not None else 0
-                if quantity <= 0:
-                    raise ValueError("Quantity must be a positive whole number.")
-
-                requirement = db.get(Requirement, int(requirement_id)) if requirement_id is not None else None
-                if not requirement or requirement.requisition_id != plan.requisition_id:
-                    raise ValueError("That part is not on this plan's requisition.")
-
-                offer = db.get(Offer, int(offer_id)) if offer_id is not None else None
-                if not offer:
-                    raise ValueError(f"Offer {offer_id} not found")
-                _ensure_offer_on_requisition(offer, plan.requisition_id)
-
-                unit_sell = entry.get("unit_sell")
-                unit_cost = float(offer.unit_price) if offer.unit_price else None
-                resolved_sell = (
-                    float(unit_sell)
-                    if unit_sell is not None
-                    else (float(requirement.target_price) if requirement.target_price else None)
-                )
-                buyer, reason = assign_buyer(offer, offer.vendor_card, db)
-                new_line = BuyPlanLine(
-                    requirement_id=requirement.id,
-                    offer_id=offer.id,
-                    quantity=quantity,
-                    unit_cost=unit_cost,
-                    unit_sell=resolved_sell,
-                    margin_pct=_line_margin_pct(resolved_sell, unit_cost),
-                    ai_score=score_offer(offer, requirement, offer.vendor_card),
-                    buyer_id=buyer.id if buyer else None,
-                    assignment_reason=reason,
-                    status=BuyPlanLineStatus.AWAITING_PO.value,
+                new_line = _build_new_line(
+                    plan,
+                    entry.get("requirement_id"),
+                    entry.get("offer_id"),
+                    entry.get("quantity"),
+                    entry.get("unit_sell"),
+                    db,
+                    offer_lookup=offer_lookup,
                 )
                 plan.lines.append(new_line)
         except (TypeError, KeyError) as e:
             raise ValueError(f"Malformed line payload: {e}") from e
-        touched += 1
 
     # Removal by omission: an existing, non-PO-cut line not referenced by line_id in the
     # payload is dropped — UNLESS known_line_ids was given and the line's id isn't in
@@ -773,11 +746,15 @@ def bulk_edit_buy_plan_lines(
 
     _recalculate_financials(plan)
     db.flush()
+    # Auto-complete at service depth (mirrors verify_po in buyplan_po.py): removing the
+    # last open line can leave every remaining line terminal, so this prevents an ACTIVE
+    # plan getting stranded short of COMPLETED.
+    check_completion(plan_id, db)
     logger.info(
-        "Buy plan {} bulk-saved by {} ({} line(s) touched, {} total)",
+        "Buy plan {} bulk-saved by {} ({} line(s), {} total after save)",
         plan_id,
         user.email,
-        touched,
+        len(lines_payload),
         len(plan.lines),
     )
     return plan
@@ -787,7 +764,10 @@ def remove_buy_plan_line(plan_id: int, line_id: int, user: User, db: Session) ->
     """Remove a line and recompute the header rollups.
 
     Gated by :func:`can_edit_buy_plan_lines`. A line with a cut PO cannot be removed (it must
-    be re-sourced / cancelled through the PO lifecycle). Caller commits.
+    be re-sourced / cancelled through the PO lifecycle). Auto-completes at service depth
+    afterward (mirrors ``verify_po`` in ``buyplan_po.py``) — removing the plan's last
+    open line can leave every remaining line terminal, so this prevents an ACTIVE plan
+    getting stranded short of COMPLETED. Caller commits.
     """
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
     if not plan:
@@ -803,6 +783,7 @@ def remove_buy_plan_line(plan_id: int, line_id: int, user: User, db: Session) ->
     plan.lines.remove(line)
     _recalculate_financials(plan)
     db.flush()
+    check_completion(plan_id, db)
     logger.info("Buy plan {} line {} removed by {}", plan_id, line_id, user.email)
     return plan
 

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -9,8 +9,8 @@ the Sales Order number editor (epic J).
 
 Called by: routers/htmx/buy_plans.py, services/buyplan_service.py, services/buyplan_hub.py
 Depends on: buyplan_scoring (assign_buyer, score_offer), buyplan_approval
-    (_recalculate_financials, _cancel_open_prepayment_requests_for_plan, _can_halt),
-    po_cancellation_service
+    (_recalculate_financials, _cancel_open_prepayment_requests_for_plan, _can_halt,
+    check_completion), po_cancellation_service, constants.OfferStatus
 """
 
 from datetime import UTC, datetime

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -20,7 +20,7 @@ from loguru import logger
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session, joinedload
 
-from ...constants import UserRole
+from ...constants import OfferStatus, UserRole
 from ...models import Offer, Requirement, User
 from ...models.buy_plan import BuyPlan, BuyPlanLine, BuyPlanLineStatus, BuyPlanStatus
 from ..buyplan_scoring import assign_buyer, score_offer
@@ -388,17 +388,31 @@ def _has_cut_po(line: BuyPlanLine) -> bool:
     return line.has_cut_po
 
 
-def _ensure_offer_on_requisition(offer: Offer, requisition_id: int | None) -> None:
-    """Reject an offer that isn't scoped to the plan's requisition.
+def _ensure_offer_attachable(offer: Offer, plan: BuyPlan, requirement_id: int | None) -> None:
+    """Reject an offer that isn't in the exact universe the vendor picker/add-form ever
+    shows for *requirement_id* on *plan*.
 
-    Mirrors the detail-render's vendor-picker filter (``Offer.requisition_id ==
-    bp.requisition_id`` in ``buy_plan_detail_partial``, app/routers/htmx/buy_plans.py)
-    so the server enforces the exact same universe the picker/add-form ever shows — an
-    offer from a different requisition (or an unsolicited inbound offer with no
-    requisition at all) is refused, not just hidden from the UI.
+    Mirrors ALL THREE filters ``buy_plan_detail_partial`` applies (app/routers/htmx/
+    buy_plans.py): same requisition (``Offer.requisition_id == bp.requisition_id``),
+    same part (the picker groups active offers into ``offers_by_requirement[
+    off.requirement_id]``, so an offer never appears under a requirement it isn't
+    ``requirement_id``-tagged for), and ACTIVE status (``Offer.status ==
+    OfferStatus.ACTIVE.value`` — the picker query filters this explicitly). An offer
+    from a different requisition/part, or one that has since gone SOLD/EXPIRED/etc., is
+    refused, not just hidden from the UI.
+
+    Only call this when an offer is being ATTACHED — a new line (:func:`_build_new_line`)
+    or an ACTUAL offer CHANGE on an existing line (:func:`_apply_line_edit`'s "changed"
+    branch). NEVER call it for a no-op resend of a line's CURRENT offer_id — that offer
+    may have legitimately gone SOLD since the line was cut, and re-sending the SAME
+    unchanged offer_id must stay a no-op regardless (both callers already gate this way).
     """
-    if offer.requisition_id != requisition_id:
+    if offer.requisition_id != plan.requisition_id:
         raise ValueError("That offer is not on this plan's requisition.")
+    if offer.requirement_id != requirement_id:
+        raise ValueError("That offer is not for this line's part.")
+    if offer.status != OfferStatus.ACTIVE.value:
+        raise ValueError(f"That offer is not active (status: {offer.status}).")
 
 
 def _require_int_quantity(value: object) -> int:
@@ -449,13 +463,14 @@ def _apply_line_edit(
     ``None``, so ``unit_sell=None`` is distinguishable from "not passed" — the only way
     to express "clear the sell price":
       - ``offer_id`` / ``quantity``: a value EQUAL to the line's CURRENT value is always
-        a no-op that never trips :func:`_has_cut_po` (so a resend of an untouched row
-        can't 400 the whole save just because a PO was cut on it between form-load and
-        save). An ACTUAL change is refused once :func:`_has_cut_po` is true; otherwise
-        an offer change re-derives ``unit_cost``/buyer via
-        :func:`_ensure_offer_on_requisition` + :func:`assign_buyer`, and a quantity
-        change is validated via :func:`_require_int_quantity` (rejects fractional
-        values) and must be positive.
+        a no-op that never trips :func:`_has_cut_po` NOR :func:`_ensure_offer_attachable`
+        (so a resend of an untouched row can't 400 the whole save just because a PO was
+        cut on it — or the attached offer went SOLD — between form-load and save). An
+        ACTUAL change is refused once :func:`_has_cut_po` is true; otherwise an offer
+        change re-derives ``unit_cost``/``ai_score``/buyer via
+        :func:`_ensure_offer_attachable` + :func:`score_offer` + :func:`assign_buyer`,
+        and a quantity change is validated via :func:`_require_int_quantity` (rejects
+        fractional values) and must be positive.
       - ``unit_sell``: never gated by :func:`_has_cut_po` (it never touches the PO).
         ``None`` clears it; any other value sets it.
     Recomputes ``line.margin_pct`` at the end. No commit/flush/recalc — caller's job.
@@ -468,9 +483,13 @@ def _apply_line_edit(
             offer = _resolve_offer(db, offer_id_int, offer_lookup)
             if not offer:
                 raise ValueError(f"Offer {offer_id} not found")
-            _ensure_offer_on_requisition(offer, plan.requisition_id)
+            _ensure_offer_attachable(offer, plan, line.requirement_id)
             line.offer_id = offer.id
-            line.unit_cost = float(offer.unit_price) if offer.unit_price else None
+            line.unit_cost = float(offer.unit_price) if offer.unit_price is not None else None
+            # Stale-score fix: an offer swap must re-score the line against the NEW
+            # offer, same as a fresh add via _build_new_line — otherwise ai_score keeps
+            # scoring the line against a vendor it no longer points at.
+            line.ai_score = score_offer(offer, line.requirement, offer.vendor_card)
             buyer, reason = assign_buyer(offer, offer.vendor_card, db)
             line.buyer_id = buyer.id if buyer else None
             line.assignment_reason = reason
@@ -509,9 +528,10 @@ def _build_new_line(
 
     Quantity goes through :func:`_require_int_quantity` (rejects a fractional value
     like ``3.5`` instead of truncating it) and must be positive. The requirement must
-    belong to *plan*'s requisition; the offer must exist AND belong to the same
-    requisition (:func:`_ensure_offer_on_requisition`). Sell falls back to the
-    requirement's ``target_price`` when *unit_sell* is ``None``.
+    belong to *plan*'s requisition; the offer must exist AND be attachable to it
+    (:func:`_ensure_offer_attachable` — same requisition, same requirement/part, ACTIVE
+    status). Sell falls back to the requirement's ``target_price`` when *unit_sell* is
+    ``None``.
     """
     quantity_int = _require_int_quantity(quantity) if quantity is not None else 0
     if quantity_int <= 0:
@@ -524,9 +544,9 @@ def _build_new_line(
     offer = _resolve_offer(db, int(offer_id), offer_lookup) if offer_id is not None else None
     if not offer:
         raise ValueError(f"Offer {offer_id} not found")
-    _ensure_offer_on_requisition(offer, plan.requisition_id)
+    _ensure_offer_attachable(offer, plan, requirement.id)
 
-    unit_cost = float(offer.unit_price) if offer.unit_price else None
+    unit_cost = float(offer.unit_price) if offer.unit_price is not None else None
     resolved_sell = (
         float(unit_sell)
         if unit_sell is not None

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -436,7 +436,9 @@ def _coerce_known_line_ids(known_line_ids: list[int] | None) -> set[int] | None:
     ``set[int]`` for an O(1) membership check on every removal-by-omission candidate,
     rejecting any non-int element — INCLUDING bools, since ``bool`` is a subclass of
     ``int`` in Python and a bare ``isinstance(x, int)`` would silently accept ``True``/
-    ``False`` as line ids. This function is the service's contract for the shape of
+    ``False`` as line ids.
+
+    This function is the service's contract for the shape of
     ``known_line_ids``; the route only checks it's a list (or absent) before handing it
     off here.
     """

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -431,6 +431,25 @@ def _require_int_quantity(value: object) -> int:
     return int(as_float)
 
 
+def _coerce_known_line_ids(known_line_ids: list[int] | None) -> set[int] | None:
+    """Coerce ``bulk_edit_buy_plan_lines``'s optional ``known_line_ids`` to a
+    ``set[int]`` for an O(1) membership check on every removal-by-omission candidate,
+    rejecting any non-int element — INCLUDING bools, since ``bool`` is a subclass of
+    ``int`` in Python and a bare ``isinstance(x, int)`` would silently accept ``True``/
+    ``False`` as line ids. This function is the service's contract for the shape of
+    ``known_line_ids``; the route only checks it's a list (or absent) before handing it
+    off here.
+    """
+    if known_line_ids is None:
+        return None
+    coerced: set[int] = set()
+    for raw_id in known_line_ids:
+        if isinstance(raw_id, bool) or not isinstance(raw_id, int):
+            raise ValueError("known_line_ids must contain only whole-number line ids.")
+        coerced.add(raw_id)
+    return coerced
+
+
 # Sentinel distinguishing "kwarg not passed" (field untouched) from "kwarg passed as
 # None" (field explicitly cleared) — plain ``None`` defaults can't express both, which
 # is exactly the bug that let ``unit_sell`` never be clearable pre-refactor.
@@ -654,19 +673,27 @@ def bulk_edit_buy_plan_lines(
     :func:`_apply_line_edit` helper (also used by :func:`edit_buy_plan_line`) and new-
     line validation/construction lives in :func:`_build_new_line` (also used by
     :func:`add_buy_plan_line`), so there is exactly one place each rule is encoded:
-      - an entry with ``line_id`` edits that existing line. Vendor/qty changes are
-        refused once :func:`_has_cut_po` is true — UNLESS the submitted value equals the
-        line's current value, which is always a no-op (never trips the guard); this
-        keeps a resend of an untouched row from 400ing the whole save just because a PO
-        was cut on it between form-load and save. An actual offer change re-derives
-        unit_cost and re-runs :func:`assign_buyer`; the new offer must belong to the
-        plan's requisition (:func:`_ensure_offer_on_requisition`). Sell price uses
-        key-presence semantics: ``"unit_sell"`` absent from the entry leaves it
-        unchanged; present with JSON ``null`` clears it; present with a number sets it.
+      - an entry with ``line_id`` edits that existing line. ``offer_id`` and ``quantity``
+        use KEY-PRESENCE semantics like ``unit_sell``: the key absent leaves the field
+        unchanged; the key present maps its value straight through to
+        :func:`_apply_line_edit` — EXCEPT an explicit JSON ``null`` for ``offer_id`` or
+        ``quantity`` specifically, which is always a ValueError ("must not be null")
+        rather than being silently treated as unchanged (the current frontend never
+        sends this; it exists to fail loudly on a malformed/future client instead of
+        quietly no-op'ing a field the caller clearly meant to touch). Vendor/qty changes
+        are refused once :func:`_has_cut_po` is true — UNLESS the submitted value equals
+        the line's current value, which is always a no-op (never trips the guard, and
+        never re-validates the attached offer either — see
+        :func:`_ensure_offer_attachable`'s docstring); this keeps a resend of an
+        untouched row from 400ing the whole save just because a PO was cut on it (or its
+        offer went SOLD) between form-load and save. Sell price keeps its own
+        already-key-presence semantics: ``"unit_sell"`` absent leaves it unchanged;
+        present with JSON ``null`` clears it; present with a number sets it.
       - an entry without ``line_id`` adds a new line (requirement must belong to the
-        plan's requisition; offer must exist AND belong to the same requisition; qty
-        must be a positive whole number — a fractional qty like ``3.5`` is rejected, not
-        truncated), same as :func:`add_buy_plan_line`;
+        plan's requisition; offer must exist AND be attachable to it — same requisition,
+        same requirement/part, ACTIVE status; qty must be a positive whole number — a
+        fractional qty like ``3.5`` is rejected, not truncated), same as
+        :func:`add_buy_plan_line`;
       - any existing, non-PO-cut line whose id does NOT appear in the payload is
         removed (same PO-cut guard as :func:`remove_buy_plan_line`, applied by omission
         instead of an explicit call) — a PO-cut line left out of the payload is simply
@@ -676,6 +703,9 @@ def bulk_edit_buy_plan_lines(
         *known_line_ids*) is left untouched instead of being silently deleted.
         *known_line_ids* omitted (``None``) falls back to the legacy behavior above (the
         route always sends it; this is a backward-compat contract, not a UI choice).
+        Coerced to ``set[int]`` up front (bools rejected — ``bool`` is a subclass of
+        ``int`` in Python) so every element is type-safe and membership checks are O(1);
+        this function owns that validation contract, not the route.
 
     Every offer any entry references is preloaded in ONE batch query up front (a real
     editor save can touch a dozen+ lines/vendors) instead of a ``db.get()`` per entry.
@@ -683,14 +713,18 @@ def bulk_edit_buy_plan_lines(
     Gated by :func:`can_edit_buy_plan_lines`. Auto-completes at service depth via
     :func:`check_completion` after recalc/flush (mirrors ``verify_po`` in
     ``buyplan_po.py``) — removing the last open line can leave every remaining line
-    terminal, so this prevents an ACTIVE plan getting stranded short of COMPLETED.
-    Caller commits; a mid-loop ValueError leaves nothing committed (the router never
-    calls db.commit() after an exception).
+    terminal, so this prevents an ACTIVE plan getting stranded short of COMPLETED. The
+    caller reads the RETURNED plan's ``.status`` (before its own commit) to learn
+    whether THIS call completed it, rather than re-deriving that fact with a second
+    ``check_completion`` scan. Caller commits; a mid-loop ValueError leaves nothing
+    committed (the router never calls db.commit() after an exception).
     """
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
     if not plan:
         raise ValueError(f"Buy plan {plan_id} not found")
     _ensure_can_edit_lines(user, plan)
+
+    known_ids = _coerce_known_line_ids(known_line_ids)
 
     existing_by_id = {ln.id: ln for ln in plan.lines}
     seen_ids: set[int] = set()
@@ -725,16 +759,32 @@ def bulk_edit_buy_plan_lines(
                     raise ValueError(f"Line {line_id} not found in plan {plan_id}")
                 seen_ids.add(line_id)
 
-                offer_id = entry.get("offer_id")
-                quantity = entry.get("quantity")
-                unit_sell = entry.get("unit_sell") if "unit_sell" in entry else _UNSET
+                # Key-presence semantics for offer_id/quantity (matching unit_sell):
+                # absent -> _UNSET (unchanged); present -> pass the value through UNLESS
+                # it's an explicit null, which is a hard error (never silently-unchanged
+                # — that was the whole point of introducing the _UNSET sentinel).
+                if "offer_id" in entry:
+                    if entry["offer_id"] is None:
+                        raise ValueError("offer_id must not be null.")
+                    offer_id_kw: Any = entry["offer_id"]
+                else:
+                    offer_id_kw = _UNSET
+
+                if "quantity" in entry:
+                    if entry["quantity"] is None:
+                        raise ValueError("quantity must not be null.")
+                    quantity_kw: Any = entry["quantity"]
+                else:
+                    quantity_kw = _UNSET
+
+                unit_sell_kw = entry.get("unit_sell") if "unit_sell" in entry else _UNSET
                 _apply_line_edit(
                     line,
                     plan,
                     db,
-                    offer_id=offer_id if offer_id is not None else _UNSET,
-                    quantity=quantity if quantity is not None else _UNSET,
-                    unit_sell=unit_sell,
+                    offer_id=offer_id_kw,
+                    quantity=quantity_kw,
+                    unit_sell=unit_sell_kw,
                     offer_lookup=offer_lookup,
                 )
             else:
@@ -752,15 +802,15 @@ def bulk_edit_buy_plan_lines(
             raise ValueError(f"Malformed line payload: {e}") from e
 
     # Removal by omission: an existing, non-PO-cut line not referenced by line_id in the
-    # payload is dropped — UNLESS known_line_ids was given and the line's id isn't in
-    # it, meaning the client never saw this line (added concurrently by someone else
-    # after the form loaded) and it must be left alone. A PO-cut line omitted from the
-    # payload is always left alone regardless — it can only leave the plan via the
-    # explicit re-source / PO-cancellation flow.
+    # payload is dropped — UNLESS known_ids was given and the line's id isn't in it,
+    # meaning the client never saw this line (added concurrently by someone else after
+    # the form loaded) and it must be left alone. A PO-cut line omitted from the payload
+    # is always left alone regardless — it can only leave the plan via the explicit
+    # re-source / PO-cancellation flow.
     for line in list(existing_by_id.values()):
         if line.id in seen_ids or _has_cut_po(line):
             continue
-        if known_line_ids is not None and line.id not in known_line_ids:
+        if known_ids is not None and line.id not in known_ids:
             continue
         plan.lines.remove(line)
 

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -14,16 +14,22 @@ Depends on: buyplan_scoring (assign_buyer, score_offer), buyplan_approval
 """
 
 from datetime import UTC, datetime
+from typing import Any
 
 from loguru import logger
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session, joinedload
 
 from ...constants import UserRole
 from ...models import Offer, Requirement, User
 from ...models.buy_plan import BuyPlan, BuyPlanLine, BuyPlanLineStatus, BuyPlanStatus
 from ..buyplan_scoring import assign_buyer, score_offer
-from .buyplan_approval import _can_halt, _cancel_open_prepayment_requests_for_plan, _recalculate_financials
+from .buyplan_approval import (
+    _can_halt,
+    _cancel_open_prepayment_requests_for_plan,
+    _recalculate_financials,
+    check_completion,
+)
 
 # ── Workflow: Re-source (PO cancelled → open claim pool) ─────────────
 
@@ -377,14 +383,9 @@ def _line_margin_pct(unit_sell: float | None, unit_cost: float | None) -> float 
 
 
 def _has_cut_po(line: BuyPlanLine) -> bool:
-    """True once a line has left AWAITING_PO (a PO is cut / verified / flagged /
-    cancelled).
-
-    Vendor/qty/removal edits on such a line would corrupt live purchasing state, so they
-    are refused (the header sell price can still be corrected — it does not touch the
-    PO).
-    """
-    return line.po_confirmed_at is not None or line.status != BuyPlanLineStatus.AWAITING_PO.value
+    """Delegate to :attr:`BuyPlanLine.has_cut_po` — the model owns the single source of
+    truth (also read directly by the whole-plan-editor template's locked-row seed)."""
+    return line.has_cut_po
 
 
 def _ensure_offer_on_requisition(offer: Offer, requisition_id: int | None) -> None:
@@ -408,12 +409,142 @@ def _require_int_quantity(value: object) -> int:
     if isinstance(value, int):
         return value
     try:
-        as_float = float(value)  # type: ignore[arg-type]
+        as_float = float(value)
     except (TypeError, ValueError) as e:
         raise ValueError("Quantity must be a whole number.") from e
     if not as_float.is_integer():
         raise ValueError("Quantity must be a whole number.")
     return int(as_float)
+
+
+# Sentinel distinguishing "kwarg not passed" (field untouched) from "kwarg passed as
+# None" (field explicitly cleared) — plain ``None`` defaults can't express both, which
+# is exactly the bug that let ``unit_sell`` never be clearable pre-refactor.
+_UNSET: Any = object()
+
+
+def _resolve_offer(db: Session, offer_id: int, offer_lookup: dict[int, Offer] | None) -> Offer | None:
+    """Look up an offer by id — via a pre-batched dict when the caller supplies one
+    (bulk save's one-query offer preload), else a plain ``db.get`` (single-line
+    callers)."""
+    if offer_lookup is not None:
+        return offer_lookup.get(offer_id)
+    return db.get(Offer, offer_id)
+
+
+def _apply_line_edit(
+    line: BuyPlanLine,
+    plan: BuyPlan,
+    db: Session,
+    *,
+    offer_id: Any = _UNSET,
+    quantity: Any = _UNSET,
+    unit_sell: Any = _UNSET,
+    offer_lookup: dict[int, Offer] | None = None,
+) -> None:
+    """Apply qty/offer/sell edits to *line*, shared by :func:`edit_buy_plan_line` and
+    the bulk "save all" edit path.
+
+    Each kwarg defaults to the ``_UNSET`` sentinel (field untouched) rather than
+    ``None``, so ``unit_sell=None`` is distinguishable from "not passed" — the only way
+    to express "clear the sell price":
+      - ``offer_id`` / ``quantity``: a value EQUAL to the line's CURRENT value is always
+        a no-op that never trips :func:`_has_cut_po` (so a resend of an untouched row
+        can't 400 the whole save just because a PO was cut on it between form-load and
+        save). An ACTUAL change is refused once :func:`_has_cut_po` is true; otherwise
+        an offer change re-derives ``unit_cost``/buyer via
+        :func:`_ensure_offer_on_requisition` + :func:`assign_buyer`, and a quantity
+        change is validated via :func:`_require_int_quantity` (rejects fractional
+        values) and must be positive.
+      - ``unit_sell``: never gated by :func:`_has_cut_po` (it never touches the PO).
+        ``None`` clears it; any other value sets it.
+    Recomputes ``line.margin_pct`` at the end. No commit/flush/recalc — caller's job.
+    """
+    if offer_id is not _UNSET:
+        offer_id_int = int(offer_id)
+        if offer_id_int != line.offer_id:
+            if _has_cut_po(line):
+                raise ValueError("Cannot change the vendor after a PO is cut on this line.")
+            offer = _resolve_offer(db, offer_id_int, offer_lookup)
+            if not offer:
+                raise ValueError(f"Offer {offer_id} not found")
+            _ensure_offer_on_requisition(offer, plan.requisition_id)
+            line.offer_id = offer.id
+            line.unit_cost = float(offer.unit_price) if offer.unit_price else None
+            buyer, reason = assign_buyer(offer, offer.vendor_card, db)
+            line.buyer_id = buyer.id if buyer else None
+            line.assignment_reason = reason
+
+    if quantity is not _UNSET:
+        quantity_int = _require_int_quantity(quantity)
+        if quantity_int != line.quantity:
+            if _has_cut_po(line):
+                raise ValueError("Cannot change the quantity after a PO is cut on this line.")
+            if quantity_int <= 0:
+                raise ValueError("Quantity must be a positive whole number.")
+            line.quantity = quantity_int
+
+    if unit_sell is not _UNSET:
+        line.unit_sell = float(unit_sell) if unit_sell is not None else None
+
+    line.margin_pct = _line_margin_pct(
+        float(line.unit_sell) if line.unit_sell is not None else None,
+        float(line.unit_cost) if line.unit_cost is not None else None,
+    )
+
+
+def _build_new_line(
+    plan: BuyPlan,
+    requirement_id: object,
+    offer_id: object,
+    quantity: object,
+    unit_sell: object,
+    db: Session,
+    *,
+    offer_lookup: dict[int, Offer] | None = None,
+) -> BuyPlanLine:
+    """Validate + construct a new AWAITING_PO line — no gating, no ``plan.lines``
+    append, no recalc (caller's job). Shared by :func:`add_buy_plan_line` and the bulk
+    "save all" add path.
+
+    Quantity goes through :func:`_require_int_quantity` (rejects a fractional value
+    like ``3.5`` instead of truncating it) and must be positive. The requirement must
+    belong to *plan*'s requisition; the offer must exist AND belong to the same
+    requisition (:func:`_ensure_offer_on_requisition`). Sell falls back to the
+    requirement's ``target_price`` when *unit_sell* is ``None``.
+    """
+    quantity_int = _require_int_quantity(quantity) if quantity is not None else 0
+    if quantity_int <= 0:
+        raise ValueError("Quantity must be a positive whole number.")
+
+    requirement = db.get(Requirement, int(requirement_id)) if requirement_id is not None else None
+    if not requirement or requirement.requisition_id != plan.requisition_id:
+        raise ValueError("That part is not on this plan's requisition.")
+
+    offer = _resolve_offer(db, int(offer_id), offer_lookup) if offer_id is not None else None
+    if not offer:
+        raise ValueError(f"Offer {offer_id} not found")
+    _ensure_offer_on_requisition(offer, plan.requisition_id)
+
+    unit_cost = float(offer.unit_price) if offer.unit_price else None
+    resolved_sell = (
+        float(unit_sell)  # type: ignore[arg-type]
+        if unit_sell is not None
+        else (float(requirement.target_price) if requirement.target_price else None)
+    )
+    buyer, reason = assign_buyer(offer, offer.vendor_card, db)
+    return BuyPlanLine(
+        requirement_id=requirement.id,
+        offer_id=offer.id,
+        quantity=quantity_int,
+        unit_cost=unit_cost,
+        unit_sell=resolved_sell,
+        margin_pct=_line_margin_pct(resolved_sell, unit_cost),
+        ai_score=score_offer(offer, requirement, offer.vendor_card),
+        buyer_id=buyer.id if buyer else None,
+        assignment_reason=reason,
+        status=BuyPlanLineStatus.AWAITING_PO.value,
+    )
 
 
 def add_buy_plan_line(
@@ -428,49 +559,15 @@ def add_buy_plan_line(
 ) -> BuyPlan:
     """Add a new line (vendor offer + qty + sell) and recompute the header rollups.
 
-    Gated by :func:`can_edit_buy_plan_lines`. The requirement must belong to the plan's
-    requisition and the offer must exist AND belong to the same requisition. Caller
-    commits.
+    Gated by :func:`can_edit_buy_plan_lines`; validation + construction delegate to
+    :func:`_build_new_line` (shared with the bulk "save all" add path). Caller commits.
     """
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
     if not plan:
         raise ValueError(f"Buy plan {plan_id} not found")
     _ensure_can_edit_lines(user, plan)
 
-    if not quantity or quantity <= 0:
-        raise ValueError("Quantity must be a positive whole number.")
-
-    requirement = db.get(Requirement, requirement_id)
-    if not requirement or requirement.requisition_id != plan.requisition_id:
-        raise ValueError("That part is not on this plan's requisition.")
-
-    offer = db.get(Offer, offer_id)
-    if not offer:
-        raise ValueError(f"Offer {offer_id} not found")
-    _ensure_offer_on_requisition(offer, plan.requisition_id)
-
-    unit_cost = float(offer.unit_price) if offer.unit_price else None
-    resolved_sell = (
-        float(unit_sell)
-        if unit_sell is not None
-        else (float(requirement.target_price) if requirement.target_price else None)
-    )
-    buyer, reason = assign_buyer(offer, offer.vendor_card, db)
-
-    plan.lines.append(
-        BuyPlanLine(
-            requirement_id=requirement.id,
-            offer_id=offer.id,
-            quantity=quantity,
-            unit_cost=unit_cost,
-            unit_sell=resolved_sell,
-            margin_pct=_line_margin_pct(resolved_sell, unit_cost),
-            ai_score=score_offer(offer, requirement, offer.vendor_card),
-            buyer_id=buyer.id if buyer else None,
-            assignment_reason=reason,
-            status=BuyPlanLineStatus.AWAITING_PO.value,
-        )
-    )
+    plan.lines.append(_build_new_line(plan, requirement_id, offer_id, quantity, unit_sell, db))
     _recalculate_financials(plan)
     db.flush()
     logger.info("Buy plan {} line added by {} (req {}, offer {})", plan_id, user.email, requirement_id, offer_id)
@@ -489,9 +586,15 @@ def edit_buy_plan_line(
 ) -> BuyPlan:
     """Edit a line's qty / sell price / vendor(offer) and recompute the header rollups.
 
-    Gated by :func:`can_edit_buy_plan_lines`. Vendor and qty changes are refused once a PO
-    is cut on the line (would corrupt live purchasing); the sell price stays editable. Caller
-    commits.
+    Gated by :func:`can_edit_buy_plan_lines`; the per-field rules delegate to
+    :func:`_apply_line_edit` (shared with the bulk "save all" edit path), which upgrades
+    this function to the SAME no-op-before-guard semantics as bulk: resending a line's
+    CURRENT qty/offer is always a no-op that never trips the cut-PO guard (previously
+    ANY non-None qty/offer 400'd once a PO was cut, even a resend of the unchanged
+    value). Signature stays backward-compatible for existing callers: ``None`` still
+    means "unchanged" for all three kwargs (mapped internally to the "field untouched"
+    sentinel), so this legacy entry point still can't CLEAR unit_sell — only bulk's JSON
+    key-presence contract can do that. Caller commits.
     """
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
     if not plan:
@@ -502,32 +605,13 @@ def edit_buy_plan_line(
     if not line:
         raise ValueError(f"Line {line_id} not found in plan {plan_id}")
 
-    if offer_id is not None:
-        if _has_cut_po(line):
-            raise ValueError("Cannot change the vendor after a PO is cut on this line.")
-        offer = db.get(Offer, offer_id)
-        if not offer:
-            raise ValueError(f"Offer {offer_id} not found")
-        _ensure_offer_on_requisition(offer, plan.requisition_id)
-        line.offer_id = offer.id
-        line.unit_cost = float(offer.unit_price) if offer.unit_price else None
-        buyer, reason = assign_buyer(offer, offer.vendor_card, db)
-        line.buyer_id = buyer.id if buyer else None
-        line.assignment_reason = reason
-
-    if quantity is not None:
-        if _has_cut_po(line):
-            raise ValueError("Cannot change the quantity after a PO is cut on this line.")
-        if quantity <= 0:
-            raise ValueError("Quantity must be a positive whole number.")
-        line.quantity = quantity
-
-    if unit_sell is not None:
-        line.unit_sell = float(unit_sell)
-
-    line.margin_pct = _line_margin_pct(
-        float(line.unit_sell) if line.unit_sell is not None else None,
-        float(line.unit_cost) if line.unit_cost is not None else None,
+    _apply_line_edit(
+        line,
+        plan,
+        db,
+        offer_id=offer_id if offer_id is not None else _UNSET,
+        quantity=quantity if quantity is not None else _UNSET,
+        unit_sell=unit_sell if unit_sell is not None else _UNSET,
     )
     _recalculate_financials(plan)
     db.flush()

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -387,6 +387,35 @@ def _has_cut_po(line: BuyPlanLine) -> bool:
     return line.po_confirmed_at is not None or line.status != BuyPlanLineStatus.AWAITING_PO.value
 
 
+def _ensure_offer_on_requisition(offer: Offer, requisition_id: int | None) -> None:
+    """Reject an offer that isn't scoped to the plan's requisition.
+
+    Mirrors the detail-render's vendor-picker filter (``Offer.requisition_id ==
+    bp.requisition_id`` in ``buy_plan_detail_partial``, app/routers/htmx/buy_plans.py)
+    so the server enforces the exact same universe the picker/add-form ever shows — an
+    offer from a different requisition (or an unsolicited inbound offer with no
+    requisition at all) is refused, not just hidden from the UI.
+    """
+    if offer.requisition_id != requisition_id:
+        raise ValueError("That offer is not on this plan's requisition.")
+
+
+def _require_int_quantity(value: object) -> int:
+    """Coerce a JSON quantity value to a whole number, rejecting a fractional value
+    (e.g. ``3.5``) instead of silently truncating it via ``int()``."""
+    if isinstance(value, bool):
+        raise ValueError("Quantity must be a whole number.")
+    if isinstance(value, int):
+        return value
+    try:
+        as_float = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as e:
+        raise ValueError("Quantity must be a whole number.") from e
+    if not as_float.is_integer():
+        raise ValueError("Quantity must be a whole number.")
+    return int(as_float)
+
+
 def add_buy_plan_line(
     plan_id: int,
     requirement_id: int,
@@ -400,7 +429,8 @@ def add_buy_plan_line(
     """Add a new line (vendor offer + qty + sell) and recompute the header rollups.
 
     Gated by :func:`can_edit_buy_plan_lines`. The requirement must belong to the plan's
-    requisition and the offer must exist. Caller commits.
+    requisition and the offer must exist AND belong to the same requisition. Caller
+    commits.
     """
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
     if not plan:
@@ -417,6 +447,7 @@ def add_buy_plan_line(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise ValueError(f"Offer {offer_id} not found")
+    _ensure_offer_on_requisition(offer, plan.requisition_id)
 
     unit_cost = float(offer.unit_price) if offer.unit_price else None
     resolved_sell = (
@@ -477,6 +508,7 @@ def edit_buy_plan_line(
         offer = db.get(Offer, offer_id)
         if not offer:
             raise ValueError(f"Offer {offer_id} not found")
+        _ensure_offer_on_requisition(offer, plan.requisition_id)
         line.offer_id = offer.id
         line.unit_cost = float(offer.unit_price) if offer.unit_price else None
         buyer, reason = assign_buyer(offer, offer.vendor_card, db)
@@ -503,22 +535,41 @@ def edit_buy_plan_line(
     return plan
 
 
-def bulk_edit_buy_plan_lines(plan_id: int, lines_payload: list[dict], user: User, db: Session) -> BuyPlan:
+def bulk_edit_buy_plan_lines(
+    plan_id: int,
+    lines_payload: list[dict],
+    user: User,
+    db: Session,
+    *,
+    known_line_ids: list[int] | None = None,
+) -> BuyPlan:
     """Save an entire plan's lines in one shot — edits, adds, and removal-by-omission.
 
     The "save all" counterpart to :func:`add_buy_plan_line` / :func:`edit_buy_plan_line` /
     :func:`remove_buy_plan_line`, reusing their exact per-field rules rather than
     duplicating them:
-      - an entry with ``line_id`` edits that existing line (qty/offer refused once
-        :func:`_has_cut_po`; sell always editable; an offer change re-derives unit_cost
-        and re-runs :func:`assign_buyer`, same as :func:`edit_buy_plan_line`);
+      - an entry with ``line_id`` edits that existing line. Vendor/qty changes are
+        refused once :func:`_has_cut_po` is true — UNLESS the submitted value equals the
+        line's current value, which is always a no-op (never trips the guard); this
+        keeps a resend of an untouched row from 400ing the whole save just because a PO
+        was cut on it between form-load and save. An actual offer change re-derives
+        unit_cost and re-runs :func:`assign_buyer`; the new offer must belong to the
+        plan's requisition (:func:`_ensure_offer_on_requisition`). Sell price uses
+        key-presence semantics: ``"unit_sell"`` absent from the entry leaves it
+        unchanged; present with JSON ``null`` clears it; present with a number sets it.
       - an entry without ``line_id`` adds a new line (requirement must belong to the
-        plan's requisition; offer must exist; qty must be positive), same as
-        :func:`add_buy_plan_line`;
+        plan's requisition; offer must exist AND belong to the same requisition; qty
+        must be a positive whole number — a fractional qty like ``3.5`` is rejected, not
+        truncated), same as :func:`add_buy_plan_line`;
       - any existing, non-PO-cut line whose id does NOT appear in the payload is
         removed (same PO-cut guard as :func:`remove_buy_plan_line`, applied by omission
         instead of an explicit call) — a PO-cut line left out of the payload is simply
-        left untouched, never implicitly removed.
+        left untouched, never implicitly removed. When *known_line_ids* is given,
+        removal-by-omission is further scoped to ids IN that set: a line added by
+        someone else after the client's form loaded (present on the plan, but never in
+        *known_line_ids*) is left untouched instead of being silently deleted.
+        *known_line_ids* omitted (``None``) falls back to the legacy behavior above (the
+        route always sends it; this is a backward-compat contract, not a UI choice).
 
     Gated by :func:`can_edit_buy_plan_lines`. Caller commits; a mid-loop ValueError
     leaves nothing committed (the router never calls db.commit() after an exception).
@@ -546,29 +597,36 @@ def bulk_edit_buy_plan_lines(plan_id: int, lines_payload: list[dict], user: User
 
                 offer_id = entry.get("offer_id")
                 if offer_id is not None:
-                    if _has_cut_po(line):
-                        raise ValueError("Cannot change the vendor after a PO is cut on this line.")
-                    offer = db.get(Offer, int(offer_id))
-                    if not offer:
-                        raise ValueError(f"Offer {offer_id} not found")
-                    line.offer_id = offer.id
-                    line.unit_cost = float(offer.unit_price) if offer.unit_price else None
-                    buyer, reason = assign_buyer(offer, offer.vendor_card, db)
-                    line.buyer_id = buyer.id if buyer else None
-                    line.assignment_reason = reason
+                    offer_id_int = int(offer_id)
+                    if offer_id_int != line.offer_id:
+                        if _has_cut_po(line):
+                            raise ValueError("Cannot change the vendor after a PO is cut on this line.")
+                        offer = db.get(Offer, offer_id_int)
+                        if not offer:
+                            raise ValueError(f"Offer {offer_id} not found")
+                        _ensure_offer_on_requisition(offer, plan.requisition_id)
+                        line.offer_id = offer.id
+                        line.unit_cost = float(offer.unit_price) if offer.unit_price else None
+                        buyer, reason = assign_buyer(offer, offer.vendor_card, db)
+                        line.buyer_id = buyer.id if buyer else None
+                        line.assignment_reason = reason
 
-                quantity = entry.get("quantity")
-                if quantity is not None:
-                    if _has_cut_po(line):
-                        raise ValueError("Cannot change the quantity after a PO is cut on this line.")
-                    quantity = int(quantity)
-                    if quantity <= 0:
-                        raise ValueError("Quantity must be a positive whole number.")
-                    line.quantity = quantity
+                raw_quantity = entry.get("quantity")
+                if raw_quantity is not None:
+                    quantity = _require_int_quantity(raw_quantity)
+                    if quantity != line.quantity:
+                        if _has_cut_po(line):
+                            raise ValueError("Cannot change the quantity after a PO is cut on this line.")
+                        if quantity <= 0:
+                            raise ValueError("Quantity must be a positive whole number.")
+                        line.quantity = quantity
 
-                unit_sell = entry.get("unit_sell")
-                if unit_sell is not None:
-                    line.unit_sell = float(unit_sell)
+                # Key-presence semantics: absent -> unchanged; present + null -> clear;
+                # present + number -> set. (Unlike offer/quantity, sell is never gated
+                # by _has_cut_po — it never touches the PO.)
+                if "unit_sell" in entry:
+                    raw_sell = entry.get("unit_sell")
+                    line.unit_sell = float(raw_sell) if raw_sell is not None else None
 
                 line.margin_pct = _line_margin_pct(
                     float(line.unit_sell) if line.unit_sell is not None else None,
@@ -577,7 +635,8 @@ def bulk_edit_buy_plan_lines(plan_id: int, lines_payload: list[dict], user: User
             else:
                 requirement_id = entry.get("requirement_id")
                 offer_id = entry.get("offer_id")
-                quantity = int(entry.get("quantity") or 0)
+                raw_quantity = entry.get("quantity")
+                quantity = _require_int_quantity(raw_quantity) if raw_quantity is not None else 0
                 if quantity <= 0:
                     raise ValueError("Quantity must be a positive whole number.")
 
@@ -588,6 +647,7 @@ def bulk_edit_buy_plan_lines(plan_id: int, lines_payload: list[dict], user: User
                 offer = db.get(Offer, int(offer_id)) if offer_id is not None else None
                 if not offer:
                     raise ValueError(f"Offer {offer_id} not found")
+                _ensure_offer_on_requisition(offer, plan.requisition_id)
 
                 unit_sell = entry.get("unit_sell")
                 unit_cost = float(offer.unit_price) if offer.unit_price else None
@@ -615,11 +675,17 @@ def bulk_edit_buy_plan_lines(plan_id: int, lines_payload: list[dict], user: User
         touched += 1
 
     # Removal by omission: an existing, non-PO-cut line not referenced by line_id in the
-    # payload is dropped. A PO-cut line omitted from the payload is left alone — it can
-    # only leave the plan via the explicit re-source / PO-cancellation flow.
+    # payload is dropped — UNLESS known_line_ids was given and the line's id isn't in
+    # it, meaning the client never saw this line (added concurrently by someone else
+    # after the form loaded) and it must be left alone. A PO-cut line omitted from the
+    # payload is always left alone regardless — it can only leave the plan via the
+    # explicit re-source / PO-cancellation flow.
     for line in list(existing_by_id.values()):
-        if line.id not in seen_ids and not _has_cut_po(line):
-            plan.lines.remove(line)
+        if line.id in seen_ids or _has_cut_po(line):
+            continue
+        if known_line_ids is not None and line.id not in known_line_ids:
+            continue
+        plan.lines.remove(line)
 
     _recalculate_financials(plan)
     db.flush()

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -4,7 +4,8 @@ Split from the former monolithic `buyplan_workflow.py` (P4.3) along the "line
 management" seam: the re-source → open-claim-pool pipeline (``resource_line`` /
 ``claim_line``), buyer issue flagging (``flag_line_issue`` / ``resolve_line_issue``),
 the role×status edit gate, and the salesperson/manager line add/edit/remove API
-(epic I) plus the Sales Order number editor (epic J).
+(epic I) — plus its bulk "save all" counterpart (``bulk_edit_buy_plan_lines``) — and
+the Sales Order number editor (epic J).
 
 Called by: routers/htmx/buy_plans.py, services/buyplan_service.py, services/buyplan_hub.py
 Depends on: buyplan_scoring (assign_buyer, score_offer), buyplan_approval
@@ -499,6 +500,136 @@ def edit_buy_plan_line(
     _recalculate_financials(plan)
     db.flush()
     logger.info("Buy plan {} line {} edited by {}", plan_id, line_id, user.email)
+    return plan
+
+
+def bulk_edit_buy_plan_lines(plan_id: int, lines_payload: list[dict], user: User, db: Session) -> BuyPlan:
+    """Save an entire plan's lines in one shot — edits, adds, and removal-by-omission.
+
+    The "save all" counterpart to :func:`add_buy_plan_line` / :func:`edit_buy_plan_line` /
+    :func:`remove_buy_plan_line`, reusing their exact per-field rules rather than
+    duplicating them:
+      - an entry with ``line_id`` edits that existing line (qty/offer refused once
+        :func:`_has_cut_po`; sell always editable; an offer change re-derives unit_cost
+        and re-runs :func:`assign_buyer`, same as :func:`edit_buy_plan_line`);
+      - an entry without ``line_id`` adds a new line (requirement must belong to the
+        plan's requisition; offer must exist; qty must be positive), same as
+        :func:`add_buy_plan_line`;
+      - any existing, non-PO-cut line whose id does NOT appear in the payload is
+        removed (same PO-cut guard as :func:`remove_buy_plan_line`, applied by omission
+        instead of an explicit call) — a PO-cut line left out of the payload is simply
+        left untouched, never implicitly removed.
+
+    Gated by :func:`can_edit_buy_plan_lines`. Caller commits; a mid-loop ValueError
+    leaves nothing committed (the router never calls db.commit() after an exception).
+    """
+    plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition)])
+    if not plan:
+        raise ValueError(f"Buy plan {plan_id} not found")
+    _ensure_can_edit_lines(user, plan)
+
+    existing_by_id = {ln.id: ln for ln in plan.lines}
+    seen_ids: set[int] = set()
+    touched = 0
+
+    for entry in lines_payload:
+        if not isinstance(entry, dict):
+            raise ValueError("Each line in the payload must be a JSON object.")
+        try:
+            raw_line_id = entry.get("line_id")
+            if raw_line_id is not None:
+                line_id = int(raw_line_id)
+                line = existing_by_id.get(line_id)
+                if not line:
+                    raise ValueError(f"Line {line_id} not found in plan {plan_id}")
+                seen_ids.add(line_id)
+
+                offer_id = entry.get("offer_id")
+                if offer_id is not None:
+                    if _has_cut_po(line):
+                        raise ValueError("Cannot change the vendor after a PO is cut on this line.")
+                    offer = db.get(Offer, int(offer_id))
+                    if not offer:
+                        raise ValueError(f"Offer {offer_id} not found")
+                    line.offer_id = offer.id
+                    line.unit_cost = float(offer.unit_price) if offer.unit_price else None
+                    buyer, reason = assign_buyer(offer, offer.vendor_card, db)
+                    line.buyer_id = buyer.id if buyer else None
+                    line.assignment_reason = reason
+
+                quantity = entry.get("quantity")
+                if quantity is not None:
+                    if _has_cut_po(line):
+                        raise ValueError("Cannot change the quantity after a PO is cut on this line.")
+                    quantity = int(quantity)
+                    if quantity <= 0:
+                        raise ValueError("Quantity must be a positive whole number.")
+                    line.quantity = quantity
+
+                unit_sell = entry.get("unit_sell")
+                if unit_sell is not None:
+                    line.unit_sell = float(unit_sell)
+
+                line.margin_pct = _line_margin_pct(
+                    float(line.unit_sell) if line.unit_sell is not None else None,
+                    float(line.unit_cost) if line.unit_cost is not None else None,
+                )
+            else:
+                requirement_id = entry.get("requirement_id")
+                offer_id = entry.get("offer_id")
+                quantity = int(entry.get("quantity") or 0)
+                if quantity <= 0:
+                    raise ValueError("Quantity must be a positive whole number.")
+
+                requirement = db.get(Requirement, int(requirement_id)) if requirement_id is not None else None
+                if not requirement or requirement.requisition_id != plan.requisition_id:
+                    raise ValueError("That part is not on this plan's requisition.")
+
+                offer = db.get(Offer, int(offer_id)) if offer_id is not None else None
+                if not offer:
+                    raise ValueError(f"Offer {offer_id} not found")
+
+                unit_sell = entry.get("unit_sell")
+                unit_cost = float(offer.unit_price) if offer.unit_price else None
+                resolved_sell = (
+                    float(unit_sell)
+                    if unit_sell is not None
+                    else (float(requirement.target_price) if requirement.target_price else None)
+                )
+                buyer, reason = assign_buyer(offer, offer.vendor_card, db)
+                new_line = BuyPlanLine(
+                    requirement_id=requirement.id,
+                    offer_id=offer.id,
+                    quantity=quantity,
+                    unit_cost=unit_cost,
+                    unit_sell=resolved_sell,
+                    margin_pct=_line_margin_pct(resolved_sell, unit_cost),
+                    ai_score=score_offer(offer, requirement, offer.vendor_card),
+                    buyer_id=buyer.id if buyer else None,
+                    assignment_reason=reason,
+                    status=BuyPlanLineStatus.AWAITING_PO.value,
+                )
+                plan.lines.append(new_line)
+        except (TypeError, KeyError) as e:
+            raise ValueError(f"Malformed line payload: {e}") from e
+        touched += 1
+
+    # Removal by omission: an existing, non-PO-cut line not referenced by line_id in the
+    # payload is dropped. A PO-cut line omitted from the payload is left alone — it can
+    # only leave the plan via the explicit re-source / PO-cancellation flow.
+    for line in list(existing_by_id.values()):
+        if line.id not in seen_ids and not _has_cut_po(line):
+            plan.lines.remove(line)
+
+    _recalculate_financials(plan)
+    db.flush()
+    logger.info(
+        "Buy plan {} bulk-saved by {} ({} line(s) touched, {} total)",
+        plan_id,
+        user.email,
+        touched,
+        len(plan.lines),
+    )
     return plan
 
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -3268,8 +3268,13 @@ Alpine.data('avatarCropper', (postUrl, maxBytes) => ({
  * Depends on: Alpine.js, htmx (htmx.ajax posts the bulk payload).
  *
  * `rows` entries: { _uid, lineId, requirementId, mpn, description, offerId,
- * vendorName, qty, sell, locked, removed }. `lineId === null` marks a
- * not-yet-saved new line (split-vendor add or the bottom part picker).
+ * vendorName, unitCost, qty, sell, locked, removed }. `lineId === null` marks a
+ * not-yet-saved new line (split-vendor add or the bottom part picker). `vendorName`/
+ * `unitCost` are the row's CURRENT offer display data (from the server line at mount)
+ * — used as a fallback when that offer isn't in the ACTIVE `offersByReq` map (a
+ * locked/PO-cut row, or a non-locked row whose offer went stale/sold-out): the vendor
+ * select renders it as an extra "(no longer active)" option instead of blanking out,
+ * and `unitCostFor` falls back to it instead of showing '-' for a real stored cost.
  * `locked` mirrors the server's PO-cut gate (po_confirmed_at set or status !=
  * 'awaiting_po') — locked rows only allow editing `sell`.
  *
@@ -3324,9 +3329,13 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
 
   offersFor(reqId) { return this.offersByReq[reqId] || []; },
 
+  // Falls back to the row's own seeded unitCost when the row's offer isn't in the
+  // ACTIVE offers map (locked/PO-cut rows, or a stale/sold-out offer still selected on
+  // a non-locked row) — otherwise a real stored cost silently renders as '-'/null.
   unitCostFor(row) {
     const offer = this.offersFor(row.requirementId).find((o) => String(o.id) === String(row.offerId));
-    return offer ? offer.unitPrice : null;
+    if (offer) return offer.unitPrice;
+    return row.unitCost !== undefined ? row.unitCost : null;
   },
 
   fmtMoney(v) {
@@ -3344,6 +3353,7 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
       description,
       offerId: '',
       vendorName: null,
+      unitCost: null,
       qty: '',
       sell: '',
       locked: false,
@@ -3351,13 +3361,10 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
     });
   },
 
-  // Bottom "+ Add line" part picker — mirrors the old grouped optgroup select,
-  // reading the requirement id off the chosen <option>'s data-req attribute.
-  onPickerOfferChange(event) {
-    const opt = event.target.selectedOptions[0];
-    this.newPart.reqId = opt ? (opt.dataset.req || '') : '';
-  },
-
+  // Bottom "+ Add line" part picker (#5 — single offer-render path): a part <select>
+  // (x-model="newPart.reqId") followed by an offer <select> over offersFor(newPart.reqId)
+  // — the SAME client-side addableParts/offersFor the inline "+ Add vendor" affordance
+  // reads, so there is only one place the addable universe is computed.
   addLineFromPicker() {
     if (!this.newPart.offerId || !this.newPart.reqId || !this.newPart.qty) return;
     const part = this.addableParts.find((p) => String(p.id) === String(this.newPart.reqId));
@@ -3370,6 +3377,7 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
       description: part ? part.description : '',
       offerId: this.newPart.offerId,
       vendorName: null,
+      unitCost: null,
       qty: this.newPart.qty,
       sell: this.newPart.sell,
       locked: false,
@@ -3395,14 +3403,17 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
   // Single definition of "complete" vs "skippable scratch" for a row — consumed by
   // both `invalidRows` (Save-enablement) and `buildPayload` (what actually gets
   // posted), so the two can never disagree about which rows count.
-  //   - complete: has both an offer and qty >= 1 (locked rows don't need this —
-  //     callers gate on `r.locked` themselves before checking it).
+  //   - complete: has both an offer and a whole-number qty >= 1 (locked rows don't
+  //     need this — callers gate on `r.locked` themselves before checking it).
   //   - skip: an untouched new scratch row (freshly pushed by "+ Add vendor"/the
   //     bottom picker, not yet filled in) — silently ignored rather than invalid.
   rowState(r) {
     const isNew = !r.lineId;
     const hasOffer = r.offerId !== '' && r.offerId !== null && r.offerId !== undefined;
-    const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1;
+    // A fractional qty (e.g. 2.5) must invalidate the row client-side rather than
+    // 400ing the whole bulk save server-side — the server keeps its own guard as the
+    // backstop (the error-toast path still covers any client/server disagreement).
+    const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1 && Number.isInteger(Number(r.qty));
     return { isNew, hasOffer, hasQty, complete: hasOffer && hasQty, skip: isNew && !hasOffer && !hasQty };
   },
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -3274,9 +3274,12 @@ Alpine.data('avatarCropper', (postUrl, maxBytes) => ({
  * 'awaiting_po') — locked rows only allow editing `sell`.
  *
  * Save posts POST /v2/partials/buy-plans/{bpId}/lines/bulk with
- * {payload: JSON.stringify({lines: [...]})}. Removed rows are simply omitted
- * (removal-by-omission); locked rows send only {line_id, unit_sell} so the
- * server never sees a forbidden field on a cut-PO line.
+ * {payload: JSON.stringify({lines: [...], known_line_ids: [...]})}. Removed rows are
+ * simply omitted from `lines` (removal-by-omission, scoped to `known_line_ids` — see
+ * `knownLineIds` below); locked rows send only {line_id, unit_sell} so the server
+ * never sees a forbidden field on a cut-PO line. `unit_sell` is always sent (null
+ * when the Sell input is blank) since the server treats a present-but-null value as
+ * "clear it" and an absent key as "leave unchanged".
  */
 Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) => ({
   bpId,
@@ -3405,6 +3408,16 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
 
   get canSave() { return !this.saving && this.invalidRows.length === 0; },
 
+  // known_line_ids echoes every existing line id the form had AT MOUNT (from the
+  // untouched origRows snapshot, not the live/edited `rows` array) — including
+  // locked lines and lines the user soft-removed in this session. The server only
+  // removes-by-omission a line whose id appears in known_line_ids, so a line another
+  // user added concurrently (never in this snapshot, so never "known") can't be
+  // silently deleted by this save.
+  get knownLineIds() {
+    return this.origRows.filter((r) => r.lineId !== null && r.lineId !== undefined).map((r) => r.lineId);
+  },
+
   buildPayload() {
     const lines = [];
     for (const r of this.rows) {
@@ -3413,6 +3426,9 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
       const hasOffer = r.offerId !== '' && r.offerId !== null && r.offerId !== undefined;
       const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1;
       if (isNew && !hasOffer && !hasQty) continue; // untouched scratch row
+      // unit_sell uses key-presence semantics server-side (key present + null =
+      // clear the sell; key absent = leave unchanged) — always send the key, with
+      // null when the input is blank, so blanking Sell explicitly clears it.
       const sellVal = (r.sell === '' || r.sell === null || r.sell === undefined) ? null : Number(r.sell);
       if (r.locked) {
         lines.push({ line_id: r.lineId, unit_sell: sellVal });
@@ -3422,9 +3438,19 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
         lines.push({ line_id: r.lineId, quantity: Number(r.qty), unit_sell: sellVal, offer_id: Number(r.offerId) });
       }
     }
-    return { lines };
+    return { lines, known_line_ids: this.knownLineIds };
   },
 
+  // Double-submit guard: `canSave` folds in `!this.saving`, so setting `saving = true`
+  // BEFORE the htmx.ajax call synchronously flips `canSave` to false — a rapid second
+  // click re-invokes saveAll() (click events are processed one at a time, not
+  // concurrently) and is turned away by the guard below regardless of whether the
+  // DOM's `:disabled="!canSave"` binding has repainted yet. `data-loading-disable`
+  // (htmx-ext-loading-states) only disables elements tied to the request's triggering
+  // element; a plain-object htmx.ajax() call like this one has no such element, so it
+  // is NOT relied on here — this explicit `saving` flag is the real guard. Reset in
+  // .finally() so a failed (e.g. 400) response doesn't strand the button disabled; a
+  // successful save re-renders #main-content, which discards this component entirely.
   saveAll() {
     if (!this.canSave) return;
     this.saving = true;

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -3456,7 +3456,7 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
   // concurrently) and is turned away by the guard below regardless of whether the
   // DOM's `:disabled="!canSave"` binding has repainted yet. `data-loading-disable`
   // (htmx-ext-loading-states) only disables elements tied to the request's triggering
-  // element; a plain-object htmx.ajax() call like this one has no such element, so it
+  // element; a programmatic ajax call like this one has no such element, so it
   // is NOT relied on here — this explicit `saving` flag is the real guard. Reset in
   // .finally() so a failed (e.g. 400) response doesn't strand the button disabled; a
   // successful save re-renders #main-content, which discards this component entirely.

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -3392,17 +3392,28 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
 
   undoRemove(row) { row.removed = false; },
 
+  // Single definition of "complete" vs "skippable scratch" for a row — consumed by
+  // both `invalidRows` (Save-enablement) and `buildPayload` (what actually gets
+  // posted), so the two can never disagree about which rows count.
+  //   - complete: has both an offer and qty >= 1 (locked rows don't need this —
+  //     callers gate on `r.locked` themselves before checking it).
+  //   - skip: an untouched new scratch row (freshly pushed by "+ Add vendor"/the
+  //     bottom picker, not yet filled in) — silently ignored rather than invalid.
+  rowState(r) {
+    const isNew = !r.lineId;
+    const hasOffer = r.offerId !== '' && r.offerId !== null && r.offerId !== undefined;
+    const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1;
+    return { isNew, hasOffer, hasQty, complete: hasOffer && hasQty, skip: isNew && !hasOffer && !hasQty };
+  },
+
   // Non-removed, non-locked rows must carry both an offer and qty >= 1 before
-  // Save is allowed — EXCEPT an untouched blank scratch row (freshly pushed by
-  // "+ Add vendor", not yet filled in), which is silently skipped instead.
+  // Save is allowed — EXCEPT an untouched blank scratch row, which is silently
+  // skipped instead (see `rowState`).
   get invalidRows() {
     return this.rows.filter((r) => {
       if (r.removed || r.locked) return false;
-      const hasOffer = r.offerId !== '' && r.offerId !== null && r.offerId !== undefined;
-      const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1;
-      const isNew = !r.lineId;
-      if (isNew && !hasOffer && !hasQty) return false;
-      return !(hasOffer && hasQty);
+      const { skip, complete } = this.rowState(r);
+      return !skip && !complete;
     });
   },
 
@@ -3422,10 +3433,8 @@ Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) =>
     const lines = [];
     for (const r of this.rows) {
       if (r.removed) continue;
-      const isNew = !r.lineId;
-      const hasOffer = r.offerId !== '' && r.offerId !== null && r.offerId !== undefined;
-      const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1;
-      if (isNew && !hasOffer && !hasQty) continue; // untouched scratch row
+      const { isNew, skip } = this.rowState(r);
+      if (skip) continue;
       // unit_sell uses key-presence semantics server-side (key present + null =
       // clear the sell; key absent = leave unchanged) — always send the key, with
       // null when the input is blank, so blanking Sell explicitly clears it.

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -3258,6 +3258,185 @@ Alpine.data('avatarCropper', (postUrl, maxBytes) => ({
   },
 }));
 
+/**
+ * buyPlanLinesEditor — whole-table "Edit plan" mode for the buy-plan line-items
+ * table. Replaces the old per-row Edit/Remove toggles + bottom Add-line panel
+ * with one editMode flag, a client-side `rows` array (seeded from the server),
+ * and a single "Save all" POST.
+ *
+ * Called by: partials/buy_plans/_detail_lines.html (x-data on the Line Items card).
+ * Depends on: Alpine.js, htmx (htmx.ajax posts the bulk payload).
+ *
+ * `rows` entries: { _uid, lineId, requirementId, mpn, description, offerId,
+ * vendorName, qty, sell, locked, removed }. `lineId === null` marks a
+ * not-yet-saved new line (split-vendor add or the bottom part picker).
+ * `locked` mirrors the server's PO-cut gate (po_confirmed_at set or status !=
+ * 'awaiting_po') — locked rows only allow editing `sell`.
+ *
+ * Save posts POST /v2/partials/buy-plans/{bpId}/lines/bulk with
+ * {payload: JSON.stringify({lines: [...]})}. Removed rows are simply omitted
+ * (removal-by-omission); locked rows send only {line_id, unit_sell} so the
+ * server never sees a forbidden field on a cut-PO line.
+ */
+Alpine.data('buyPlanLinesEditor', (bpId, seedRows, offersByReq, addableParts) => ({
+  bpId,
+  offersByReq: offersByReq || {},
+  addableParts: addableParts || [],
+  rows: seedRows || [],
+  origRows: [],
+  editMode: false,
+  saving: false,
+  showAddLine: false,
+  newPart: { reqId: '', offerId: '', qty: '', sell: '' },
+  _uidCounter: 0,
+
+  init() {
+    this._uidCounter = this.rows.length;
+    this.origRows = JSON.parse(JSON.stringify(this.rows));
+  },
+
+  enterEdit() { this.editMode = true; },
+
+  cancelEdit() {
+    this.rows = JSON.parse(JSON.stringify(this.origRows));
+    this.newPart = { reqId: '', offerId: '', qty: '', sell: '' };
+    this.showAddLine = false;
+    this.editMode = false;
+  },
+
+  // Rows grouped by requirement, in first-appearance order — drives the
+  // per-part "+ Add vendor" affordance after each part's row block.
+  get groupedRows() {
+    const order = [];
+    const map = {};
+    for (const r of this.rows) {
+      if (!map[r.requirementId]) {
+        map[r.requirementId] = { requirementId: r.requirementId, mpn: r.mpn, description: r.description, rows: [] };
+        order.push(map[r.requirementId]);
+      }
+      map[r.requirementId].rows.push(r);
+    }
+    return order;
+  },
+
+  offersFor(reqId) { return this.offersByReq[reqId] || []; },
+
+  unitCostFor(row) {
+    const offer = this.offersFor(row.requirementId).find((o) => String(o.id) === String(row.offerId));
+    return offer ? offer.unitPrice : null;
+  },
+
+  fmtMoney(v) {
+    if (v === null || v === undefined || v === '') return '-';
+    return '$' + Number(v).toLocaleString('en-US', { minimumFractionDigits: 4, maximumFractionDigits: 4 });
+  },
+
+  addVendorRow(reqId, mpn, description) {
+    this._uidCounter += 1;
+    this.rows.push({
+      _uid: 'new-' + this._uidCounter,
+      lineId: null,
+      requirementId: reqId,
+      mpn,
+      description,
+      offerId: '',
+      vendorName: null,
+      qty: '',
+      sell: '',
+      locked: false,
+      removed: false,
+    });
+  },
+
+  // Bottom "+ Add line" part picker — mirrors the old grouped optgroup select,
+  // reading the requirement id off the chosen <option>'s data-req attribute.
+  onPickerOfferChange(event) {
+    const opt = event.target.selectedOptions[0];
+    this.newPart.reqId = opt ? (opt.dataset.req || '') : '';
+  },
+
+  addLineFromPicker() {
+    if (!this.newPart.offerId || !this.newPart.reqId || !this.newPart.qty) return;
+    const part = this.addableParts.find((p) => String(p.id) === String(this.newPart.reqId));
+    this._uidCounter += 1;
+    this.rows.push({
+      _uid: 'new-' + this._uidCounter,
+      lineId: null,
+      requirementId: Number(this.newPart.reqId),
+      mpn: part ? part.mpn : null,
+      description: part ? part.description : '',
+      offerId: this.newPart.offerId,
+      vendorName: null,
+      qty: this.newPart.qty,
+      sell: this.newPart.sell,
+      locked: false,
+      removed: false,
+    });
+    this.newPart = { reqId: '', offerId: '', qty: '', sell: '' };
+    this.showAddLine = false;
+  },
+
+  removeRow(row) {
+    // An unsaved new row has no server-side line to preserve — drop it outright.
+    // A persisted row is soft-removed (kept, struck-through, Undo-able) so Save
+    // can omit it by id instead of racing a separate delete request.
+    if (!row.lineId) {
+      this.rows = this.rows.filter((r) => r !== row);
+    } else {
+      row.removed = true;
+    }
+  },
+
+  undoRemove(row) { row.removed = false; },
+
+  // Non-removed, non-locked rows must carry both an offer and qty >= 1 before
+  // Save is allowed — EXCEPT an untouched blank scratch row (freshly pushed by
+  // "+ Add vendor", not yet filled in), which is silently skipped instead.
+  get invalidRows() {
+    return this.rows.filter((r) => {
+      if (r.removed || r.locked) return false;
+      const hasOffer = r.offerId !== '' && r.offerId !== null && r.offerId !== undefined;
+      const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1;
+      const isNew = !r.lineId;
+      if (isNew && !hasOffer && !hasQty) return false;
+      return !(hasOffer && hasQty);
+    });
+  },
+
+  get canSave() { return !this.saving && this.invalidRows.length === 0; },
+
+  buildPayload() {
+    const lines = [];
+    for (const r of this.rows) {
+      if (r.removed) continue;
+      const isNew = !r.lineId;
+      const hasOffer = r.offerId !== '' && r.offerId !== null && r.offerId !== undefined;
+      const hasQty = r.qty !== '' && r.qty !== null && Number(r.qty) >= 1;
+      if (isNew && !hasOffer && !hasQty) continue; // untouched scratch row
+      const sellVal = (r.sell === '' || r.sell === null || r.sell === undefined) ? null : Number(r.sell);
+      if (r.locked) {
+        lines.push({ line_id: r.lineId, unit_sell: sellVal });
+      } else if (isNew) {
+        lines.push({ requirement_id: r.requirementId, offer_id: Number(r.offerId), quantity: Number(r.qty), unit_sell: sellVal });
+      } else {
+        lines.push({ line_id: r.lineId, quantity: Number(r.qty), unit_sell: sellVal, offer_id: Number(r.offerId) });
+      }
+    }
+    return { lines };
+  },
+
+  saveAll() {
+    if (!this.canSave) return;
+    this.saving = true;
+    htmx.ajax('POST', `/v2/partials/buy-plans/${this.bpId}/lines/bulk`, {
+      target: '#main-content',
+      swap: 'innerHTML',
+      indicator: '#main-content',
+      values: { payload: JSON.stringify(this.buildPayload()) },
+    }).finally(() => { this.saving = false; });
+  },
+}));
+
 /* ────────────────────────────────────────────────────────────────────────
    Cross-app tab alerts — in-tab spotlight for new / actionable rows.
 

--- a/app/templates/htmx/partials/buy_plans/_detail_lines.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_lines.html
@@ -63,7 +63,7 @@
       'vendorName': line.offer.vendor_name if line.offer else None,
       'qty': line.quantity,
       'sell': (line.unit_sell|float) if line.unit_sell is not none else None,
-      'locked': (line.po_confirmed_at is not none) or (line.status != 'awaiting_po'),
+      'locked': line.has_cut_po,
       'removed': False,
     }) %}
   {% endfor %}
@@ -78,8 +78,12 @@
       }) %}
     {% endfor %}
   {% endfor %}
+  {# Requirements that have at least one active offer — the single "addable" universe,
+     computed once and reused by both the addable_parts seed (below) and the bottom
+     "+ Add line" part picker (its own {% if can_edit_lines %} block further down). #}
+  {% set reqs_with_offers = plan_requirements | selectattr('id', 'in', offers_by_requirement.keys()) | list %}
   {% set addable_parts = [] %}
-  {% for req in plan_requirements if req.id in offers_by_requirement %}
+  {% for req in reqs_with_offers %}
     {% set req_desc = req|part_description if req else '' %}
     {% set _ = addable_parts.append({'id': req.id, 'mpn': req.primary_mpn, 'description': req_desc}) %}
   {% endfor %}
@@ -359,14 +363,13 @@
     <div class="px-4 py-3 border-t border-line-base bg-gray-50" x-show="editMode" x-cloak>
       <button type="button" x-show="!showAddLine" @click="showAddLine = true" class="btn btn-secondary btn-sm">+ Add line</button>
       <div x-show="showAddLine" x-cloak>
-        {% set _addable = plan_requirements | selectattr('id', 'in', offers_by_requirement.keys()) | list %}
-        {% if _addable %}
+        {% if reqs_with_offers %}
         <div class="flex flex-wrap items-end gap-2">
           <div>
             <label class="block text-xs text-gray-500 mb-0.5">Part · vendor offer</label>
             <select x-model="newPart.offerId" @change="onPickerOfferChange($event)" class="input input-sm w-64">
               <option value="">Select an offer…</option>
-              {% for req in _addable %}
+              {% for req in reqs_with_offers %}
               <optgroup label="{{ req.primary_mpn or ('REQ ' ~ req.id) }}">
                 {% for o in offers_by_requirement.get(req.id, []) %}
                 <option value="{{ o.id }}" data-req="{{ req.id }}">{{ o.vendor_name }} — ${{ '{:,.4f}'.format(o.unit_price|float) if o.unit_price else '0.0000' }}</option>

--- a/app/templates/htmx/partials/buy_plans/_detail_lines.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_lines.html
@@ -61,6 +61,7 @@
       'description': desc,
       'offerId': line.offer_id,
       'vendorName': line.offer.vendor_name if line.offer else None,
+      'unitCost': (line.unit_cost|float) if line.unit_cost is not none else None,
       'qty': line.quantity,
       'sell': (line.unit_sell|float) if line.unit_sell is not none else None,
       'locked': line.has_cut_po,
@@ -78,9 +79,10 @@
       }) %}
     {% endfor %}
   {% endfor %}
-  {# Requirements that have at least one active offer — the single "addable" universe,
-     computed once and reused by both the addable_parts seed (below) and the bottom
-     "+ Add line" part picker (its own {% if can_edit_lines %} block further down). #}
+  {# Requirements that have at least one active offer — feeds the addable_parts seed
+     below, which is the SINGLE addable universe both the inline "+ Add vendor" and the
+     bottom "+ Add line" picker read client-side via addableParts/offersFor (#5 — no
+     more server-rendered optgroups duplicating this list). #}
   {% set reqs_with_offers = plan_requirements | selectattr('id', 'in', offers_by_requirement.keys()) | list %}
   {% set addable_parts = [] %}
   {% for req in reqs_with_offers %}
@@ -154,10 +156,12 @@
             </td>
             {# Qty #}
             <td class="text-right text-gray-600">{{ '{:,}'.format(line.quantity) }}</td>
-            {# Unit Cost — derived from the offer (read-only; changes with the vendor) #}
-            <td class="text-right text-gray-600">${{ '{:,.4f}'.format(line.unit_cost|float) if line.unit_cost else '-' }}</td>
-            {# Sell #}
-            <td class="text-right text-gray-600">${{ '{:,.4f}'.format(line.unit_sell|float) if line.unit_sell else '-' }}</td>
+            {# Unit Cost — derived from the offer (read-only; changes with the vendor).
+               `is not none` (not truthiness) so a real stored 0.0 renders as $0.0000,
+               not '-' (falsy-zero display bug — a raw 0.0 is a legitimate value). #}
+            <td class="text-right text-gray-600">${{ '{:,.4f}'.format(line.unit_cost|float) if line.unit_cost is not none else '-' }}</td>
+            {# Sell — same `is not none` fix as Unit Cost above. #}
+            <td class="text-right text-gray-600">${{ '{:,.4f}'.format(line.unit_sell|float) if line.unit_sell is not none else '-' }}</td>
             {# Status + PO# + prepayment badge (#11) #}
             <td>
               {{ line_status_pill(line) }}
@@ -308,6 +312,14 @@
                     <select x-model="row.offerId" aria-label="Vendor offer" :disabled="row.removed"
                             class="input input-sm w-full max-w-[180px]">
                       <option value="">Select vendor…</option>
+                      {# The row's CURRENT offer may no longer be in the active offers list (sold
+                         out / superseded) — render it as a truthful extra option so the select
+                         never silently blanks out. x-model matches it by value, so it's selected
+                         automatically; leaving it untouched still posts the SAME (unchanged)
+                         offer id, which the server tolerates by design (no-op resend). #}
+                      <template x-if="row.offerId && !offersFor(row.requirementId).some((o) => String(o.id) === String(row.offerId))">
+                        <option :value="row.offerId" x-text="(row.vendorName || 'Unknown vendor') + ' — ' + fmtMoney(row.unitCost) + ' (no longer active)'"></option>
+                      </template>
                       <template x-for="o in offersFor(row.requirementId)" :key="o.id">
                         <option :value="o.id" x-text="o.vendorName + ' — ' + fmtMoney(o.unitPrice)"></option>
                       </template>
@@ -357,41 +369,50 @@
         {% endif %}
       </table>
     </div>
-    {# Bottom "+ Add line" — whole new part via a grouped optgroup select (mirrors the
-       old add-line panel), only in edit mode. #}
+    {# Bottom "+ Add line" — whole new part via a part select + an offer select, only in
+       edit mode. Single offer-render path (#5): both this picker and the inline
+       "+ Add vendor" affordance now read the SAME client-side addableParts/offersFor —
+       no more server-rendered optgroups + data-req/onPickerOfferChange round-trip that
+       could drift from the Alpine-driven vendor selects elsewhere in this table. #}
     {% if can_edit_lines %}
     <div class="px-4 py-3 border-t border-line-base bg-gray-50" x-show="editMode" x-cloak>
       <button type="button" x-show="!showAddLine" @click="showAddLine = true" class="btn btn-secondary btn-sm">+ Add line</button>
       <div x-show="showAddLine" x-cloak>
-        {% if reqs_with_offers %}
-        <div class="flex flex-wrap items-end gap-2">
-          <div>
-            <label class="block text-xs text-gray-500 mb-0.5">Part · vendor offer</label>
-            <select x-model="newPart.offerId" @change="onPickerOfferChange($event)" class="input input-sm w-64">
-              <option value="">Select an offer…</option>
-              {% for req in reqs_with_offers %}
-              <optgroup label="{{ req.primary_mpn or ('REQ ' ~ req.id) }}">
-                {% for o in offers_by_requirement.get(req.id, []) %}
-                <option value="{{ o.id }}" data-req="{{ req.id }}">{{ o.vendor_name }} — ${{ '{:,.4f}'.format(o.unit_price|float) if o.unit_price else '0.0000' }}</option>
-                {% endfor %}
-              </optgroup>
-              {% endfor %}
-            </select>
+        <template x-if="addableParts.length > 0">
+          <div class="flex flex-wrap items-end gap-2">
+            <div>
+              <label class="block text-xs text-gray-500 mb-0.5">Part</label>
+              <select x-model="newPart.reqId" @change="newPart.offerId = ''" class="input input-sm w-48">
+                <option value="">Select a part…</option>
+                <template x-for="p in addableParts" :key="p.id">
+                  <option :value="p.id" x-text="p.mpn || ('REQ ' + p.id)"></option>
+                </template>
+              </select>
+            </div>
+            <div>
+              <label class="block text-xs text-gray-500 mb-0.5">Vendor offer</label>
+              <select x-model="newPart.offerId" :disabled="!newPart.reqId" class="input input-sm w-56">
+                <option value="">Select an offer…</option>
+                <template x-for="o in offersFor(newPart.reqId)" :key="o.id">
+                  <option :value="o.id" x-text="o.vendorName + ' — ' + fmtMoney(o.unitPrice)"></option>
+                </template>
+              </select>
+            </div>
+            <div>
+              <label class="block text-xs text-gray-500 mb-0.5">Qty</label>
+              <input x-model.number="newPart.qty" type="number" min="1" class="input input-sm w-24 text-right">
+            </div>
+            <div>
+              <label class="block text-xs text-gray-500 mb-0.5">Sell</label>
+              <input x-model.number="newPart.sell" type="number" step="any" min="0" placeholder="Sell" class="input input-sm w-24 text-right">
+            </div>
+            <button type="button" @click="addLineFromPicker()" class="btn btn-primary btn-sm">Add</button>
+            <button type="button" @click="showAddLine = false; newPart = { reqId: '', offerId: '', qty: '', sell: '' }" class="btn btn-secondary btn-sm">Cancel</button>
           </div>
-          <div>
-            <label class="block text-xs text-gray-500 mb-0.5">Qty</label>
-            <input x-model.number="newPart.qty" type="number" min="1" class="input input-sm w-24 text-right">
-          </div>
-          <div>
-            <label class="block text-xs text-gray-500 mb-0.5">Sell</label>
-            <input x-model.number="newPart.sell" type="number" step="any" min="0" placeholder="Sell" class="input input-sm w-24 text-right">
-          </div>
-          <button type="button" @click="addLineFromPicker()" class="btn btn-primary btn-sm">Add</button>
-          <button type="button" @click="showAddLine = false; newPart = { reqId: '', offerId: '', qty: '', sell: '' }" class="btn btn-secondary btn-sm">Cancel</button>
-        </div>
-        {% else %}
-        <p class="text-sm text-gray-500">No parts with active vendor offers are available to add.</p>
-        {% endif %}
+        </template>
+        <template x-if="addableParts.length === 0">
+          <p class="text-sm text-gray-500">No parts with active vendor offers are available to add.</p>
+        </template>
       </div>
     </div>
     {% endif %}

--- a/app/templates/htmx/partials/buy_plans/_detail_lines.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_lines.html
@@ -1,11 +1,29 @@
 {#
-  _detail_lines.html — Buy-plan simplified line-items table (Part · Description · Vendor · Qty ·
-  Unit Cost · Status · Action) with the per-line PO/verify/re-source/reject/claim affordances.
-  Included by: htmx/partials/buy_plans/detail.html (in place of the old "SIMPLIFIED LINE ITEMS
-  TABLE" section).
-  Inherits context (default `with context` include): reads `lines`, `bp`, `user`, `can_resource`
-  (context), `can_approve_purchase_orders` (Jinja global), and the `part_description` filter.
-  Imports `status_badge`, `user_avatar` from shared/_macros.html; defines a local
+  _detail_lines.html — Buy-plan line-items table (Part · Description · Vendor · Qty ·
+  Unit Cost · Sell · Status · Action) with the per-line PO/verify/re-source/reject/claim
+  affordances, PLUS a whole-table "Edit plan" mode.
+
+  Two renderings share the card:
+  - Display mode (default): the original server-rendered Jinja loop over `lines` — status
+    pills, PO/verify/re-source/reject/claim/prepayment affordances, empty state — unchanged.
+    Hidden (x-show) while editMode is active when can_edit_lines.
+  - Edit mode: a single Alpine component (`buyPlanLinesEditor`, registered in
+    htmx_app.js) drives a client-side `rows` array seeded from the server. Vendor/qty/sell
+    become editable per non-locked (non-PO-cut) row; locked rows show vendor+qty read-only
+    with a "PO cut" hint and only allow editing sell. Rows are grouped by part with a
+    "+ Add vendor" affordance per group (split-vendor lines) plus a bottom "+ Add line"
+    part picker. Remove soft-deletes existing lines (struck + Undo) and hard-deletes
+    unsaved new rows. "Save all" posts the whole `rows` array in one bulk request;
+    "Cancel" re-seeds from the untouched server snapshot. Replaces the old per-row
+    Edit/Remove/Save/Cancel buttons and the old bottom Add-line collapsible panel.
+
+  Included by: htmx/partials/buy_plans/detail.html (in place of the old "SIMPLIFIED LINE
+  ITEMS TABLE" section).
+  Inherits context (default `with context` include): reads `lines`, `bp`, `user`,
+  `can_edit_lines`, `offers_by_requirement`, `plan_requirements`, `prepay_state`,
+  `can_resource`, `can_supervise`, `can_verify_po_line`, `can_request_prepayment`
+  (context), `can_approve_purchase_orders` (Jinja global), and the `part_description`
+  filter. Imports `status_badge`, `user_avatar` from shared/_macros.html; defines a local
   `line_status_pill(line)` macro for the Status cell.
 #}
 {% from "htmx/partials/shared/_macros.html" import status_badge, user_avatar %}
@@ -27,13 +45,71 @@
               {% endif %}
 {% endmacro %}
 
-  {# ═══ 4. SIMPLIFIED LINE ITEMS TABLE ═══ #}
+  {# ── Edit-mode seeds (only built when the viewer can actually edit lines) ──
+     `seed_rows` mirrors the `rows` shape the Alpine component owns; `offers_map` and
+     `addable_parts` are read-only lookups it never mutates. Built here (once) instead of
+     inline in the x-data attribute so the |tojson calls stay simple expressions. #}
+  {% if can_edit_lines %}
+  {% set seed_rows = [] %}
+  {% for line in lines %}
+    {% set desc = line.requirement|part_description if line.requirement else '' %}
+    {% set _ = seed_rows.append({
+      '_uid': 'line-' ~ line.id,
+      'lineId': line.id,
+      'requirementId': line.requirement_id,
+      'mpn': line.requirement.primary_mpn if line.requirement else None,
+      'description': desc,
+      'offerId': line.offer_id,
+      'vendorName': line.offer.vendor_name if line.offer else None,
+      'qty': line.quantity,
+      'sell': (line.unit_sell|float) if line.unit_sell is not none else None,
+      'locked': (line.po_confirmed_at is not none) or (line.status != 'awaiting_po'),
+      'removed': False,
+    }) %}
+  {% endfor %}
+  {% set offers_map = {} %}
+  {% for req_id, req_offers in offers_by_requirement.items() %}
+    {% set _ = offers_map.update({ req_id: [] }) %}
+    {% for o in req_offers %}
+      {% set _ = offers_map[req_id].append({
+        'id': o.id,
+        'vendorName': o.vendor_name,
+        'unitPrice': (o.unit_price|float) if o.unit_price is not none else None,
+      }) %}
+    {% endfor %}
+  {% endfor %}
+  {% set addable_parts = [] %}
+  {% for req in plan_requirements if req.id in offers_by_requirement %}
+    {% set req_desc = req|part_description if req else '' %}
+    {% set _ = addable_parts.append({'id': req.id, 'mpn': req.primary_mpn, 'description': req_desc}) %}
+  {% endfor %}
+  {% endif %}
+
   {# Finding #1: convert to data-table, drop per-cell px-4 py-3 and per-th font-medium text-gray-500 uppercase #}
-  <div class="bg-white rounded-lg shadow-card overflow-hidden border border-line-base mb-6">
-    <div class="px-4 py-3 bg-gray-50 border-b border-line-base">
+  <div class="bg-white rounded-lg shadow-card overflow-hidden border border-line-base mb-6"
+       {% if can_edit_lines %}
+       x-data='buyPlanLinesEditor({{ bp.id }}, {{ seed_rows|tojson }}, {{ offers_map|tojson }}, {{ addable_parts|tojson }})'
+       {% endif %}>
+    <div class="px-4 py-3 bg-gray-50 border-b border-line-base flex items-center justify-between flex-wrap gap-2">
       <h2 class="h2">Line Items
         <span class="ml-1 text-sm font-normal text-gray-600">({{ lines|length }})</span>
       </h2>
+      {# Whole-table edit toggle (replaces the old per-row Edit buttons + bottom Add-line
+         panel). Save all/Cancel appear only while editMode is active. #}
+      {% if can_edit_lines %}
+      <div class="flex items-center gap-2">
+        <button type="button" x-show="!editMode" @click="enterEdit()" class="btn btn-secondary btn-sm">Edit plan</button>
+        <template x-if="editMode">
+          <div class="flex items-center gap-2">
+            <span x-show="invalidRows.length > 0" x-cloak class="text-xs text-rose-600">Fill vendor + qty on every row before saving.</span>
+            <button type="button" @click="cancelEdit()" class="btn btn-secondary btn-sm">Cancel</button>
+            <button type="button" :disabled="!canSave" data-loading-disable
+                    @click="saveAll()"
+                    class="btn btn-primary btn-sm disabled:opacity-50 disabled:cursor-not-allowed">Save all</button>
+          </div>
+        </template>
+      </div>
+      {% endif %}
     </div>
     <div class="overflow-x-auto">
       <table class="data-table w-full">
@@ -49,12 +125,10 @@
             <th class="text-left">Action</th>
           </tr>
         </thead>
-        <tbody>
+        {# ── DISPLAY tbody — unchanged rendering, hidden while editMode is on ── #}
+        <tbody {% if can_edit_lines %}x-show="!editMode"{% endif %}>
           {% for line in lines %}
-          {# ``editing`` (epic I) toggles the per-line inline editors (vendor/qty/sell) + the
-             Save/Cancel controls; $refs on the row's inputs are read by Save. Only meaningful
-             when can_edit_lines — the inputs render only then. #}
-          <tr id="bp-line-{{ line.id }}" class="transition-colors" x-data="{ editing: false }">
+          <tr id="bp-line-{{ line.id }}" class="transition-colors">
             {# Part (MPN) #}
             <td class="font-mono font-medium text-gray-900">
               {{ line.requirement.primary_mpn if line.requirement else '-' }}
@@ -64,45 +138,22 @@
             <td class="text-gray-600 truncate max-w-[200px]" title="{{ desc }}">
               {{ desc or '-' }}
             </td>
-            {# Vendor + buyer (assignee) below — editable offer picker when in edit mode #}
+            {# Vendor + buyer (assignee) below #}
             <td>
-              <div x-show="!editing">
-                <div class="text-gray-900">{{ line.offer.vendor_name if line.offer else '-' }}</div>
-                {% if line.buyer %}
-                <div class="flex items-center gap-1.5 mt-0.5">
-                  {{ user_avatar(line.buyer) }}
-                  <span class="text-secondary">{{ line.buyer.name }}</span>
-                </div>
-                {% endif %}
+              <div class="text-gray-900">{{ line.offer.vendor_name if line.offer else '-' }}</div>
+              {% if line.buyer %}
+              <div class="flex items-center gap-1.5 mt-0.5">
+                {{ user_avatar(line.buyer) }}
+                <span class="text-secondary">{{ line.buyer.name }}</span>
               </div>
-              {% if can_edit_lines %}
-              <select x-show="editing" x-cloak x-ref="offer" aria-label="Vendor offer"
-                      class="input input-sm w-full max-w-[180px]">
-                <option value="">— keep {{ line.offer.vendor_name if line.offer else 'current' }} —</option>
-                {% for o in offers_by_requirement.get(line.requirement_id, []) %}
-                <option value="{{ o.id }}">{{ o.vendor_name }} — ${{ '{:,.4f}'.format(o.unit_price|float) if o.unit_price else '0.0000' }}</option>
-                {% endfor %}
-              </select>
               {% endif %}
             </td>
-            {# Qty — editable when in edit mode #}
-            <td class="text-right text-gray-600">
-              <span x-show="!editing">{{ '{:,}'.format(line.quantity) }}</span>
-              {% if can_edit_lines %}
-              <input x-show="editing" x-cloak x-ref="qty" aria-label="Quantity" type="number" min="1"
-                     value="{{ line.quantity }}" class="input input-sm w-20 text-right">
-              {% endif %}
-            </td>
+            {# Qty #}
+            <td class="text-right text-gray-600">{{ '{:,}'.format(line.quantity) }}</td>
             {# Unit Cost — derived from the offer (read-only; changes with the vendor) #}
             <td class="text-right text-gray-600">${{ '{:,.4f}'.format(line.unit_cost|float) if line.unit_cost else '-' }}</td>
-            {# Sell — editable when in edit mode #}
-            <td class="text-right text-gray-600">
-              <span x-show="!editing">${{ '{:,.4f}'.format(line.unit_sell|float) if line.unit_sell else '-' }}</span>
-              {% if can_edit_lines %}
-              <input x-show="editing" x-cloak x-ref="sell" aria-label="Unit sell" type="number" step="any" min="0"
-                     value="{{ line.unit_sell|float if line.unit_sell is not none else '' }}" class="input input-sm w-24 text-right">
-              {% endif %}
-            </td>
+            {# Sell #}
+            <td class="text-right text-gray-600">${{ '{:,.4f}'.format(line.unit_sell|float) if line.unit_sell else '-' }}</td>
             {# Status + PO# + prepayment badge (#11) #}
             <td>
               {{ line_status_pill(line) }}
@@ -111,24 +162,6 @@
             </td>
             {# Action — Finding #4: bespoke bg-emerald/rose buttons → .btn family #}
             <td>
-              {# Line editing (epic I): Edit/Remove when idle, Save/Cancel while editing. Save
-                 posts only the three editable fields; the server re-gates + recomputes header
-                 totals. Gated by can_edit_lines (the SAME server predicate the POSTs enforce). #}
-              {% if can_edit_lines %}
-              <div class="mb-1.5 flex flex-wrap gap-1">
-                <button type="button" x-show="!editing" @click="editing = true" class="btn btn-secondary btn-sm">Edit</button>
-                <button type="button" x-show="!editing"
-                        hx-post="/v2/partials/buy-plans/{{ bp.id }}/lines/{{ line.id }}/remove"
-                        hx-target="#main-content" hx-swap="innerHTML"
-                        hx-confirm="Remove this line from the plan?"
-                        data-loading-disable
-                        class="btn btn-danger btn-sm">Remove</button>
-                <button type="button" x-show="editing" x-cloak data-loading-disable
-                        @click="htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/lines/{{ line.id }}/edit', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {quantity: $refs.qty.value, unit_sell: $refs.sell.value, offer_id: $refs.offer.value}}); editing = false"
-                        class="btn btn-primary btn-sm">Save</button>
-                <button type="button" x-show="editing" x-cloak @click="editing = false" class="btn btn-secondary btn-sm">Cancel</button>
-              </div>
-              {% endif %}
               {% if bp.status == 'active' %}
                 {% if line.status == 'awaiting_po' %}
                   <div x-data="{ showPo: false, poNum: '', shipDate: '' }">
@@ -250,24 +283,88 @@
           </tr>
           {% endif %}
         </tbody>
+        {# ── EDIT tbody — whole-plan edit mode (epic I rework). Entirely Alpine-driven:
+           rows come from the `rows` array, grouped by part so a "+ Add vendor" row can
+           follow each part's block (split-vendor lines). ── #}
+        {% if can_edit_lines %}
+        <tbody x-show="editMode" x-cloak>
+          <template x-for="group in groupedRows" :key="group.requirementId">
+            <template x-for="row in group.rows" :key="row._uid">
+              <tr :class="row.removed && 'opacity-40'">
+                <td class="font-mono font-medium text-gray-900" x-text="row.mpn || '-'"></td>
+                <td class="text-gray-600 truncate max-w-[200px]" x-text="row.description || '-'"></td>
+                <td>
+                  <template x-if="row.locked">
+                    <div>
+                      <div class="text-gray-900" x-text="row.vendorName || '-'"></div>
+                      <div class="text-xs text-amber-600 font-medium mt-0.5">PO cut</div>
+                    </div>
+                  </template>
+                  <template x-if="!row.locked">
+                    <select x-model="row.offerId" aria-label="Vendor offer" :disabled="row.removed"
+                            class="input input-sm w-full max-w-[180px]">
+                      <option value="">Select vendor…</option>
+                      <template x-for="o in offersFor(row.requirementId)" :key="o.id">
+                        <option :value="o.id" x-text="o.vendorName + ' — ' + fmtMoney(o.unitPrice)"></option>
+                      </template>
+                    </select>
+                  </template>
+                </td>
+                <td class="text-right text-gray-600">
+                  <template x-if="row.locked">
+                    <span x-text="row.qty"></span>
+                  </template>
+                  <template x-if="!row.locked">
+                    <input type="number" min="1" x-model.number="row.qty" :disabled="row.removed"
+                           aria-label="Quantity" class="input input-sm w-20 text-right">
+                  </template>
+                </td>
+                <td class="text-right text-gray-600" x-text="fmtMoney(unitCostFor(row))"></td>
+                <td class="text-right text-gray-600">
+                  <input type="number" step="any" min="0" x-model.number="row.sell" :disabled="row.removed"
+                         aria-label="Unit sell" class="input input-sm w-24 text-right">
+                </td>
+                <td class="text-xs text-gray-500">
+                  <span x-show="row.locked">Locked (PO cut)</span>
+                  <span x-show="row.removed" x-cloak class="text-rose-500">Removed</span>
+                </td>
+                <td>
+                  <template x-if="row.removed">
+                    <button type="button" @click="undoRemove(row)" class="btn btn-secondary btn-sm">Undo</button>
+                  </template>
+                  <template x-if="!row.removed && !row.locked">
+                    <button type="button" @click="removeRow(row)" class="btn btn-danger btn-sm">Remove</button>
+                  </template>
+                </td>
+              </tr>
+            </template>
+          </template>
+          {# One "+ Add vendor" row per part group — split-vendor sourcing. #}
+          <template x-for="group in groupedRows" :key="'add-' + group.requirementId">
+            <tr x-show="offersFor(group.requirementId).length > 0" x-cloak>
+              <td colspan="8" class="py-1.5">
+                <button type="button"
+                        @click="addVendorRow(group.requirementId, group.mpn, group.description)"
+                        class="text-xs text-brand-500 hover:text-brand-600 font-medium">+ Add vendor</button>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+        {% endif %}
       </table>
     </div>
-    {# Add line (epic I) — pick a part's active vendor offer + qty + sell. The offer's option
-       carries data-req so the requirement id is set without a dependent second select. The
-       server re-gates + recomputes the header totals. #}
+    {# Bottom "+ Add line" — whole new part via a grouped optgroup select (mirrors the
+       old add-line panel), only in edit mode. #}
     {% if can_edit_lines %}
-    <div class="px-4 py-3 border-t border-line-base bg-gray-50"
-         x-data="{ open: false, reqId: '', offerId: '', qty: '', sell: '' }">
-      <button type="button" x-show="!open" @click="open = true" class="btn btn-secondary btn-sm">+ Add line</button>
-      <div x-show="open" x-cloak>
+    <div class="px-4 py-3 border-t border-line-base bg-gray-50" x-show="editMode" x-cloak>
+      <button type="button" x-show="!showAddLine" @click="showAddLine = true" class="btn btn-secondary btn-sm">+ Add line</button>
+      <div x-show="showAddLine" x-cloak>
         {% set _addable = plan_requirements | selectattr('id', 'in', offers_by_requirement.keys()) | list %}
         {% if _addable %}
         <div class="flex flex-wrap items-end gap-2">
           <div>
             <label class="block text-xs text-gray-500 mb-0.5">Part · vendor offer</label>
-            <select x-model="offerId"
-                    @change="reqId = ($event.target.selectedOptions[0] && $event.target.selectedOptions[0].dataset.req) || ''"
-                    class="input input-sm w-64">
+            <select x-model="newPart.offerId" @change="onPickerOfferChange($event)" class="input input-sm w-64">
               <option value="">Select an offer…</option>
               {% for req in _addable %}
               <optgroup label="{{ req.primary_mpn or ('REQ ' ~ req.id) }}">
@@ -280,16 +377,14 @@
           </div>
           <div>
             <label class="block text-xs text-gray-500 mb-0.5">Qty</label>
-            <input x-model="qty" type="number" min="1" class="input input-sm w-24 text-right">
+            <input x-model.number="newPart.qty" type="number" min="1" class="input input-sm w-24 text-right">
           </div>
           <div>
             <label class="block text-xs text-gray-500 mb-0.5">Sell</label>
-            <input x-model="sell" type="number" step="any" min="0" placeholder="Sell" class="input input-sm w-24 text-right">
+            <input x-model.number="newPart.sell" type="number" step="any" min="0" placeholder="Sell" class="input input-sm w-24 text-right">
           </div>
-          <button type="button" data-loading-disable
-                  @click="offerId && reqId && qty && (htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/lines/add', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {requirement_id: reqId, offer_id: offerId, quantity: qty, unit_sell: sell}}), open = false)"
-                  class="btn btn-primary btn-sm">Add</button>
-          <button type="button" @click="open = false" class="btn btn-secondary btn-sm">Cancel</button>
+          <button type="button" @click="addLineFromPicker()" class="btn btn-primary btn-sm">Add</button>
+          <button type="button" @click="showAddLine = false; newPart = { reqId: '', offerId: '', qty: '', sell: '' }" class="btn btn-secondary btn-sm">Cancel</button>
         </div>
         {% else %}
         <p class="text-sm text-gray-500">No parts with active vendor offers are available to add.</p>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1759,25 +1759,46 @@ buyplan_workflow/ (state machine — package: buyplan_approval.py owns submit/ap
 mutating call, NOT just the template): draft/pending → plan owner (via `Requisition
 .created_by`) or a manager; active/inbound/halted → manager-only (sales locked out
 post-approval); completed/cancelled → locked for everyone. `add_buy_plan_line` (POST
-`.../lines/add`) requires the requirement to belong to the plan's requisition and derives
-`unit_cost`/buyer via `assign_buyer`. `edit_buy_plan_line` (POST `.../lines/{id}/edit`)
-and `remove_buy_plan_line` (POST `.../lines/{id}/remove`) both refuse a vendor/qty
-change or removal once `_has_cut_po(line)` is true (PO confirmed or status has left
-`awaiting_po`) — the sell price stays editable regardless (it never touches the PO).
-Each mutator recomputes the header rollups via `_recalculate_financials` and returns the
-refreshed `buy_plan_detail_partial` into `#main-content`.
+`.../lines/add`) requires the requirement to belong to the plan's requisition, the offer
+to belong to the SAME requisition (`_ensure_offer_on_requisition` — mirrors the detail-
+render's vendor-picker filter, `Offer.requisition_id == bp.requisition_id`, so nothing
+outside the picker's own universe can be posted), and derives `unit_cost`/buyer via
+`assign_buyer`. `edit_buy_plan_line` (POST `.../lines/{id}/edit`) and
+`remove_buy_plan_line` (POST `.../lines/{id}/remove`) both refuse a vendor/qty change or
+removal once `_has_cut_po(line)` is true (PO confirmed or status has left
+`awaiting_po`) — the sell price stays editable regardless (it never touches the PO). Each
+mutator recomputes the header rollups via `_recalculate_financials` and returns the
+refreshed `buy_plan_detail_partial` into `#main-content`; `remove_buy_plan_line`'s route
+also runs `check_completion` right after commit (removing the plan's last open line can
+leave every remaining line terminal — same auto-complete call the verify-po route makes).
 
 `bulk_edit_buy_plan_lines` (POST `.../lines/bulk`) is the "save all" counterpart driving
 the whole-table Alpine editor (`buyPlanLinesEditor`, `htmx_app.js`; "Edit plan" toggle →
 per-row inline edit/add/remove → "Save all"). Form field `payload` is JSON
-`{"lines": [...]}`: an entry with `line_id` edits that line (same per-field cut-PO
-guard as `edit_buy_plan_line`); an entry without `line_id` adds a new line (same
-validation as `add_buy_plan_line`); any existing, non-PO-cut line whose id is NOT in the
-payload is removed (removal-by-omission — the same guard as `remove_buy_plan_line`,
-applied implicitly instead of an explicit call); a PO-cut line simply omitted from the
-payload is left untouched, never implicitly removed. Same role×status gate, same
-recompute-and-re-render tail. Malformed JSON or a wrong shape (`{"lines": [...]}`
-required) → 400 before the service is even called.
+`{"lines": [...], "known_line_ids": [...]}`:
+  - an entry with `line_id` edits that line — offer/qty changes are refused once
+    `_has_cut_po(line)` is true UNLESS the submitted value equals the line's CURRENT
+    value (a no-op resend never trips the guard, so a PO cut on an untouched row between
+    form-load and save can't 400 the whole save); an actual offer change re-derives
+    `unit_cost`/buyer and must pass `_ensure_offer_on_requisition`; `unit_sell` uses
+    key-presence semantics (`"unit_sell"` absent → unchanged; present + JSON `null` →
+    cleared; present + a number → set);
+  - an entry without `line_id` adds a new line — same validation as `add_buy_plan_line`,
+    plus qty must be a whole number (a fractional value like `3.5` is rejected, not
+    truncated);
+  - any existing, non-PO-cut line whose id is NOT in the payload is removed (removal-by-
+    omission — the same guard as `remove_buy_plan_line`, applied implicitly). When
+    `known_line_ids` (every line id the client's form actually rendered) is given,
+    removal-by-omission is further scoped to ids IN that set, so a line another user
+    added after the form loaded — present on the plan but never in `known_line_ids` — is
+    left untouched instead of silently deleted; `known_line_ids` omitted falls back to
+    the unscoped legacy behavior (a route backward-compat contract; the UI always sends
+    it). A PO-cut line omitted from the payload is always left untouched regardless.
+
+Same role×status gate, same recompute-and-re-render tail, same post-commit
+`check_completion` call as the single-line remove route. Malformed JSON, a wrong shape
+(`{"lines": [...]}` required), or a non-list-of-ints `known_line_ids` → 400 before the
+service is even called.
 
 ### 6e. Re-source (fall-down → open claim pool → urgent buyer backfill)
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1754,6 +1754,31 @@ buyplan_workflow/ (state machine — package: buyplan_approval.py owns submit/ap
             ops (PO unverified >2h) until lines advance; idempotent via buy_plan_lines.last_nudge_at
 ```
 
+**Line editing (epic I — add/edit/remove, `buyplan_lines.py`).** Role×status gate
+(`can_edit_buy_plan_lines`, enforced server-side by `_ensure_can_edit_lines` in every
+mutating call, NOT just the template): draft/pending → plan owner (via `Requisition
+.created_by`) or a manager; active/inbound/halted → manager-only (sales locked out
+post-approval); completed/cancelled → locked for everyone. `add_buy_plan_line` (POST
+`.../lines/add`) requires the requirement to belong to the plan's requisition and derives
+`unit_cost`/buyer via `assign_buyer`. `edit_buy_plan_line` (POST `.../lines/{id}/edit`)
+and `remove_buy_plan_line` (POST `.../lines/{id}/remove`) both refuse a vendor/qty
+change or removal once `_has_cut_po(line)` is true (PO confirmed or status has left
+`awaiting_po`) — the sell price stays editable regardless (it never touches the PO).
+Each mutator recomputes the header rollups via `_recalculate_financials` and returns the
+refreshed `buy_plan_detail_partial` into `#main-content`.
+
+`bulk_edit_buy_plan_lines` (POST `.../lines/bulk`) is the "save all" counterpart driving
+the whole-table Alpine editor (`buyPlanLinesEditor`, `htmx_app.js`; "Edit plan" toggle →
+per-row inline edit/add/remove → "Save all"). Form field `payload` is JSON
+`{"lines": [...]}`: an entry with `line_id` edits that line (same per-field cut-PO
+guard as `edit_buy_plan_line`); an entry without `line_id` adds a new line (same
+validation as `add_buy_plan_line`); any existing, non-PO-cut line whose id is NOT in the
+payload is removed (removal-by-omission — the same guard as `remove_buy_plan_line`,
+applied implicitly instead of an explicit call); a PO-cut line simply omitted from the
+payload is left untouched, never implicitly removed. Same role×status gate, same
+recompute-and-re-render tail. Malformed JSON or a wrong shape (`{"lines": [...]}`
+required) → 400 before the service is even called.
+
 ### 6e. Re-source (fall-down → open claim pool → urgent buyer backfill)
 
 `buyplan_workflow.resource_line` (`app/services/buyplan_workflow/buyplan_lines.py`) is the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -819,6 +819,109 @@ def test_offer(
     return o
 
 
+# ── Buy-plan line-editing factories (shared by test_buy_plan_epic.py and
+#    test_buyplan_bulk_edit.py — plain callables, not fixtures, since every test needs
+#    several differently-parameterized instances rather than one injected value) ──────
+
+
+def _buyplan_req(db: Session, owner: User, *, customer: str = "Acme Electronics") -> Requisition:
+    """A requisition (owned by *owner*) with one requirement."""
+    req = Requisition(
+        name="REQ-EPIC",
+        customer_name=customer,
+        status="open",
+        created_by=owner.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(req)
+    db.flush()
+    db.add(
+        Requirement(
+            requisition_id=req.id,
+            primary_mpn="LM317T",
+            target_qty=1000,
+            target_price=0.75,
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+    db.refresh(req)
+    return req
+
+
+def _buyplan_requirement_of(db: Session, req: Requisition) -> Requirement:
+    """The single Requirement :func:`_buyplan_req` created for *req*."""
+    return db.query(Requirement).filter(Requirement.requisition_id == req.id).first()
+
+
+def _buyplan_plan(db: Session, req: Requisition, *, status: str | None = None, **overrides):  # -> BuyPlan
+    """A BuyPlan on *req* (local import; type annotation omitted to satisfy ruff
+    F821)."""
+    from app.constants import BuyPlanStatus
+    from app.models.buy_plan import BuyPlan
+
+    defaults = dict(
+        requisition_id=req.id,
+        status=status or BuyPlanStatus.DRAFT.value,
+        so_status="pending",
+        total_cost=100.00,
+        total_revenue=200.00,
+        total_margin_pct=50.00,
+        ai_flags=[],
+        created_at=datetime.now(UTC),
+    )
+    defaults.update(overrides)
+    plan = BuyPlan(**defaults)
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return plan
+
+
+def _buyplan_line(db: Session, plan, **overrides):  # plan: BuyPlan -> BuyPlanLine
+    """A BuyPlanLine on *plan* (local import; type annotations omitted to satisfy ruff
+    F821)."""
+    from app.constants import BuyPlanLineStatus
+    from app.models.buy_plan import BuyPlanLine
+
+    defaults = dict(
+        buy_plan_id=plan.id,
+        quantity=100,
+        unit_cost=1.00,
+        unit_sell=2.00,
+        status=BuyPlanLineStatus.AWAITING_PO.value,
+    )
+    defaults.update(overrides)
+    line = BuyPlanLine(**defaults)
+    db.add(line)
+    db.commit()
+    db.refresh(line)
+    return line
+
+
+def _buyplan_offer(db: Session, requisition: Requisition, entered_by: User, **overrides) -> Offer:
+    """An ADDITIONAL offer scoped to *requisition* — distinct from the ``test_offer``
+    fixture (always scoped to ``test_requisition``), for cross-requisition / cross-
+    status attach-rejection scenarios that need an offer NOT on the plan-under-test's
+    requisition."""
+    defaults = dict(
+        requisition_id=requisition.id,
+        vendor_name="Secondary Vendor",
+        mpn="LM317T",
+        qty_available=1000,
+        unit_price=0.40,
+        entered_by_id=entered_by.id,
+        status="active",
+        created_at=datetime.now(UTC),
+    )
+    defaults.update(overrides)
+    offer = Offer(**defaults)
+    db.add(offer)
+    db.commit()
+    db.refresh(offer)
+    return offer
+
+
 @pytest.fixture()
 def test_vendor_contact(db_session: Session, test_vendor_card: VendorCard) -> VendorContact:
     """A structured vendor contact linked to the test vendor card."""

--- a/tests/frontend/buy-plan-lines-editor.test.ts
+++ b/tests/frontend/buy-plan-lines-editor.test.ts
@@ -61,6 +61,7 @@ function row(overrides: Record<string, any> = {}) {
     description: 'Resistor 10k',
     offerId: '',
     vendorName: null,
+    unitCost: null,
     qty: '',
     sell: '',
     locked: false,
@@ -121,6 +122,46 @@ describe('buyPlanLinesEditor (real factory)', () => {
       expect(m.rowState(row({ lineId: null, offerId: '1', qty: '0' })).hasQty).toBe(false);
       expect(m.rowState(row({ lineId: null, offerId: '1', qty: '-1' })).hasQty).toBe(false);
     });
+
+    it('a fractional qty (e.g. 2.5) on an otherwise-complete row is invalid, not complete', () => {
+      const m = makeEditor();
+      const state = m.rowState(row({ lineId: 4, offerId: '9', qty: '2.5' }));
+      expect(state.hasQty).toBe(false);
+      expect(state.hasOffer).toBe(true);
+      expect(state.complete).toBe(false);
+      expect(state.skip).toBe(false); // has an offer, so it's not an untouched scratch row
+    });
+
+    it('a whole-number qty passed as a numeric (not string) value is still valid', () => {
+      const m = makeEditor();
+      expect(m.rowState(row({ lineId: 4, offerId: '9', qty: 3 })).hasQty).toBe(true);
+    });
+
+    it("a row whose CURRENT offer id is stale (not in the active offers map) still classifies as complete — rowState doesn't consult offersByReq", () => {
+      const m = makeEditor(1, [], { 100: [{ id: 77, vendorName: 'New Vendor', unitPrice: 1.5 }] });
+      const staleRow = row({ lineId: 9, requirementId: 100, offerId: '55', qty: '4', vendorName: 'Old Vendor', unitCost: 2.75 });
+      expect(m.rowState(staleRow)).toMatchObject({ hasOffer: true, hasQty: true, complete: true, skip: false });
+    });
+  });
+
+  describe('unitCostFor() — falls back to the row seed when the offer is not in the active map', () => {
+    it('prefers the ACTIVE offer price when the row offer is in offersByReq', () => {
+      const m = makeEditor(1, [], { 100: [{ id: 77, vendorName: 'Vendor A', unitPrice: 1.25 }] });
+      const r = row({ requirementId: 100, offerId: '77', unitCost: 9.99 });
+      expect(m.unitCostFor(r)).toBe(1.25);
+    });
+
+    it('falls back to row.unitCost when the offer id has no match in offersByReq (locked or stale offer)', () => {
+      const m = makeEditor(1, [], { 100: [{ id: 77, vendorName: 'Vendor A', unitPrice: 1.25 }] });
+      const lockedRow = row({ requirementId: 100, offerId: '999', locked: true, unitCost: 4.5 });
+      expect(m.unitCostFor(lockedRow)).toBe(4.5);
+    });
+
+    it('returns null when neither the active map nor the row seed has a cost', () => {
+      const m = makeEditor(1, [], {});
+      const r = row({ requirementId: 100, offerId: '999', unitCost: null });
+      expect(m.unitCostFor(r)).toBeNull();
+    });
   });
 
   describe('invalidRows / canSave gating', () => {
@@ -132,6 +173,12 @@ describe('buyPlanLinesEditor (real factory)', () => {
 
     it('flags a non-locked row with qty < 1 as invalid', () => {
       const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '0' })]);
+      expect(m.invalidRows).toHaveLength(1);
+      expect(m.canSave).toBe(false);
+    });
+
+    it('flags a non-locked row with a fractional qty as invalid — client-side, before any 400 round-trip', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '2.5' })]);
       expect(m.invalidRows).toHaveLength(1);
       expect(m.canSave).toBe(false);
     });
@@ -209,6 +256,14 @@ describe('buyPlanLinesEditor (real factory)', () => {
       expect(payload.lines[0]).not.toHaveProperty('line_id');
     });
 
+    it('a row whose current offer is stale (not in the active offers map) still posts that SAME unchanged offer id — a no-op resend, never dropped or blanked', () => {
+      const m = makeEditor(1, [
+        row({ lineId: 9, requirementId: 100, offerId: '55', qty: '4', vendorName: 'Old Vendor', unitCost: 2.75 }),
+      ], { 100: [{ id: 77, vendorName: 'New Vendor', unitPrice: 1.5 }] });
+      const payload = m.buildPayload();
+      expect(payload.lines).toEqual([{ line_id: 9, quantity: 4, unit_sell: null, offer_id: 55 }]);
+    });
+
     it('known_line_ids equals the mount-snapshot ids — including a later soft-removed line and a locked line — and ignores a new unsaved row', () => {
       const m = makeEditor(1, [
         row({ lineId: 1, offerId: '9', qty: '5' }),
@@ -248,16 +303,21 @@ describe('buyPlanLinesEditor (real factory)', () => {
     });
   });
 
-  describe('addVendorRow / addLineFromPicker', () => {
+  describe('addVendorRow / addLineFromPicker (single offer-render path — #5)', () => {
     it('addVendorRow pushes a correctly-shaped blank scratch row for the given part', () => {
       const m = makeEditor(1, []);
       m.addVendorRow(300, 'XYZ999', 'Capacitor');
       expect(m.rows).toHaveLength(1);
       expect(m.rows[0]).toMatchObject({
         lineId: null, requirementId: 300, mpn: 'XYZ999', description: 'Capacitor',
-        offerId: '', qty: '', sell: '', locked: false, removed: false,
+        offerId: '', unitCost: null, qty: '', sell: '', locked: false, removed: false,
       });
       expect(m.rows[0]._uid).toBeTruthy();
+    });
+
+    it('the old dataset-driven onPickerOfferChange handler is gone — the bottom picker is now a plain part-select driving newPart.reqId directly', () => {
+      const m = makeEditor(1, []);
+      expect(m.onPickerOfferChange).toBeUndefined();
     });
 
     it('addLineFromPicker no-ops when offer, requirement, or qty is missing', () => {
@@ -267,15 +327,24 @@ describe('buyPlanLinesEditor (real factory)', () => {
       expect(m.rows).toHaveLength(0);
     });
 
-    it('addLineFromPicker pushes a fully-shaped new row from the addableParts lookup and resets the picker', () => {
-      const m = makeEditor(1, [], {}, [{ id: 300, mpn: 'XYZ999', description: 'Capacitor' }]);
+    it('addLineFromPicker pushes a fully-shaped new row from newPart.reqId set directly by the part <select> (x-model), via the addableParts lookup, and resets the picker', () => {
+      // Mirrors the new template flow: the part <select x-model="newPart.reqId"> sets
+      // reqId directly (no dataset extraction), then the offer <select> sourced from
+      // offersFor(newPart.reqId) sets newPart.offerId.
+      const m = makeEditor(1, [], { 300: [{ id: 11, vendorName: 'Vendor A', unitPrice: 1.1 }] }, [
+        { id: 300, mpn: 'XYZ999', description: 'Capacitor' },
+      ]);
       m.showAddLine = true;
-      m.newPart = { reqId: '300', offerId: '11', qty: '5', sell: '2.5' };
+      m.newPart.reqId = '300'; // set by the part <select>'s x-model
+      expect(m.offersFor(m.newPart.reqId)).toEqual([{ id: 11, vendorName: 'Vendor A', unitPrice: 1.1 }]);
+      m.newPart.offerId = '11'; // set by the offer <select>'s x-model
+      m.newPart.qty = '5';
+      m.newPart.sell = '2.5';
       m.addLineFromPicker();
       expect(m.rows).toHaveLength(1);
       expect(m.rows[0]).toMatchObject({
         lineId: null, requirementId: 300, mpn: 'XYZ999', description: 'Capacitor',
-        offerId: '11', qty: '5', sell: '2.5', locked: false, removed: false,
+        offerId: '11', unitCost: null, qty: '5', sell: '2.5', locked: false, removed: false,
       });
       expect(m.newPart).toEqual({ reqId: '', offerId: '', qty: '', sell: '' });
       expect(m.showAddLine).toBe(false);

--- a/tests/frontend/buy-plan-lines-editor.test.ts
+++ b/tests/frontend/buy-plan-lines-editor.test.ts
@@ -1,0 +1,359 @@
+/**
+ * buy-plan-lines-editor.test.ts — Vitest unit tests for the REAL buyPlanLinesEditor
+ * Alpine factory in app/static/htmx_app.js (whole-plan "Edit plan" mode for the
+ * buy-plan line-items table).
+ *
+ * Imports app/static/htmx_app.js (htmx/Alpine mocked) and pulls the actual
+ * Alpine.data('buyPlanLinesEditor', ...) factory from the captured registry, so
+ * rowState/invalidRows/buildPayload/known_line_ids/removeRow/cancelEdit/saveAll are
+ * exercised against the shipped component, not a hand-copied mirror.
+ *
+ * Called by: npx vitest run
+ * Depends on: vitest, jsdom, app/static/htmx_app.js
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let registry: Record<string, any> = {};
+
+// Mock htmx and all Alpine plugins so htmx_app.js imports cleanly in jsdom.
+vi.mock('htmx.org', () => ({
+  default: {
+    on: vi.fn(), off: vi.fn(), ajax: vi.fn(), process: vi.fn(),
+    defineExtension: vi.fn(), createExtension: vi.fn(), config: {},
+  },
+}));
+
+const alpineMock = {
+  data: (n: string, f: any) => { registry[n] = f; },
+  store: vi.fn(),
+  plugin: vi.fn(), start: vi.fn(), directive: vi.fn(), magic: vi.fn(),
+};
+
+vi.mock('alpinejs', () => ({ default: alpineMock }));
+vi.mock('@alpinejs/focus', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/persist', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/intersect', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/collapse', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/morph', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/mask', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/sort', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/anchor', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/resize', () => ({ default: vi.fn() }));
+vi.mock('htmx-ext-alpine-morph', () => ({}));
+vi.mock('htmx-ext-response-targets', () => ({}));
+vi.mock('htmx-ext-sse', () => ({}));
+vi.mock('htmx-ext-json-enc', () => ({}));
+vi.mock('htmx-ext-preload', () => ({}));
+vi.mock('htmx-ext-loading-states', () => ({}));
+vi.mock('htmx-ext-path-params', () => ({}));
+vi.mock('htmx-ext-remove-me', () => ({}));
+
+import htmx from 'htmx.org';
+
+// ── Row / seed helpers ──────────────────────────────────────────────────
+function row(overrides: Record<string, any> = {}) {
+  return {
+    _uid: 'line-1',
+    lineId: 1,
+    requirementId: 100,
+    mpn: 'ABC123',
+    description: 'Resistor 10k',
+    offerId: '',
+    vendorName: null,
+    qty: '',
+    sell: '',
+    locked: false,
+    removed: false,
+    ...overrides,
+  };
+}
+
+function makeEditor(
+  bpId = 1,
+  seedRows: any[] = [],
+  offersByReq: Record<string, any[]> = {},
+  addableParts: any[] = [],
+) {
+  const inst = registry['buyPlanLinesEditor'](bpId, seedRows, offersByReq, addableParts);
+  inst.init();
+  return inst;
+}
+
+beforeEach(async () => {
+  registry = {};
+  (htmx.ajax as any).mockReset();
+  (htmx.ajax as any).mockResolvedValue(undefined);
+  vi.resetModules();
+  await import('../../app/static/htmx_app.js');
+});
+
+describe('buyPlanLinesEditor (real factory)', () => {
+  describe('rowState()', () => {
+    it('classifies an existing, fully-filled row as complete', () => {
+      const m = makeEditor();
+      const r = row({ lineId: 5, offerId: '9', qty: '3' });
+      expect(m.rowState(r)).toMatchObject({ isNew: false, hasOffer: true, hasQty: true, complete: true, skip: false });
+    });
+
+    it('classifies a locked row via its own offer/qty (isNew stays false since lineId is set)', () => {
+      const m = makeEditor();
+      const r = row({ lineId: 7, locked: true, offerId: '2', qty: '10' });
+      const state = m.rowState(r);
+      expect(state.isNew).toBe(false);
+      expect(state.complete).toBe(true);
+    });
+
+    it('marks an untouched new scratch row (no lineId, no offer, no qty) as skip', () => {
+      const m = makeEditor();
+      const r = row({ lineId: null, offerId: '', qty: '' });
+      expect(m.rowState(r)).toMatchObject({ isNew: true, hasOffer: false, hasQty: false, complete: false, skip: true });
+    });
+
+    it('marks a partially-filled new row (offer set, qty blank) as invalid, not skip', () => {
+      const m = makeEditor();
+      const r = row({ lineId: null, offerId: '4', qty: '' });
+      expect(m.rowState(r)).toMatchObject({ isNew: true, hasOffer: true, hasQty: false, complete: false, skip: false });
+    });
+
+    it('treats qty 0 or negative as not having a qty', () => {
+      const m = makeEditor();
+      expect(m.rowState(row({ lineId: null, offerId: '1', qty: '0' })).hasQty).toBe(false);
+      expect(m.rowState(row({ lineId: null, offerId: '1', qty: '-1' })).hasQty).toBe(false);
+    });
+  });
+
+  describe('invalidRows / canSave gating', () => {
+    it('flags a non-locked row missing an offer as invalid', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '', qty: '5' })]);
+      expect(m.invalidRows).toHaveLength(1);
+      expect(m.canSave).toBe(false);
+    });
+
+    it('flags a non-locked row with qty < 1 as invalid', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '0' })]);
+      expect(m.invalidRows).toHaveLength(1);
+      expect(m.canSave).toBe(false);
+    });
+
+    it('does not flag a removed row, a locked row, or an untouched scratch row', () => {
+      const m = makeEditor(1, [
+        row({ lineId: 1, offerId: '', qty: '', removed: true }),
+        row({ lineId: 2, locked: true, offerId: '', qty: '' }),
+        row({ lineId: null, offerId: '', qty: '' }),
+      ]);
+      expect(m.invalidRows).toHaveLength(0);
+      expect(m.canSave).toBe(true);
+    });
+
+    it('canSave is true when every row is complete or skippable', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '5' })]);
+      expect(m.canSave).toBe(true);
+    });
+
+    it('the saving flag forces canSave false even with zero invalid rows', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '5' })]);
+      expect(m.canSave).toBe(true);
+      m.saving = true;
+      expect(m.invalidRows).toHaveLength(0);
+      expect(m.canSave).toBe(false);
+    });
+  });
+
+  describe('buildPayload()', () => {
+    it('locked rows emit ONLY {line_id, unit_sell} — no quantity/offer_id keys', () => {
+      const m = makeEditor(1, [row({ lineId: 3, locked: true, offerId: '9', qty: '20', sell: '5.5' })]);
+      const payload = m.buildPayload();
+      expect(payload.lines).toEqual([{ line_id: 3, unit_sell: 5.5 }]);
+    });
+
+    it('non-locked existing rows emit line_id/quantity/unit_sell/offer_id with number coercion', () => {
+      // qty/offerId arrive as strings (select/number-input values) — must coerce.
+      const m = makeEditor(1, [row({ lineId: 4, offerId: '42', qty: '7', sell: '3.25' })]);
+      const payload = m.buildPayload();
+      expect(payload.lines).toEqual([{ line_id: 4, quantity: 7, unit_sell: 3.25, offer_id: 42 }]);
+      expect(payload.lines[0].quantity).toBe(7);
+      expect(typeof payload.lines[0].quantity).toBe('number');
+      expect(typeof payload.lines[0].offer_id).toBe('number');
+    });
+
+    it('blank sell coerces to null (key-presence "clear" semantics), never an empty string', () => {
+      const m = makeEditor(1, [row({ lineId: 4, offerId: '42', qty: '7', sell: '' })]);
+      expect(m.buildPayload().lines[0].unit_sell).toBeNull();
+    });
+
+    it('removed rows are omitted from the payload entirely', () => {
+      const m = makeEditor(1, [
+        row({ lineId: 4, offerId: '42', qty: '7', sell: '1', removed: true }),
+        row({ lineId: 5, offerId: '9', qty: '2' }),
+      ]);
+      const payload = m.buildPayload();
+      expect(payload.lines).toHaveLength(1);
+      expect(payload.lines[0].line_id).toBe(5);
+    });
+
+    it('untouched new scratch rows are omitted from the payload', () => {
+      const m = makeEditor(1, [
+        row({ lineId: null, offerId: '', qty: '' }),
+        row({ lineId: 5, offerId: '9', qty: '2' }),
+      ]);
+      const payload = m.buildPayload();
+      expect(payload.lines).toHaveLength(1);
+      expect(payload.lines[0].line_id).toBe(5);
+    });
+
+    it('new (unsaved) rows emit requirement_id/offer_id/quantity/unit_sell — no line_id key', () => {
+      const m = makeEditor(1, [row({ lineId: null, requirementId: 200, offerId: '11', qty: '3', sell: '' })]);
+      const payload = m.buildPayload();
+      expect(payload.lines).toEqual([{ requirement_id: 200, offer_id: 11, quantity: 3, unit_sell: null }]);
+      expect(payload.lines[0]).not.toHaveProperty('line_id');
+    });
+
+    it('known_line_ids equals the mount-snapshot ids — including a later soft-removed line and a locked line — and ignores a new unsaved row', () => {
+      const m = makeEditor(1, [
+        row({ lineId: 1, offerId: '9', qty: '5' }),
+        row({ lineId: 2, locked: true, offerId: '9', qty: '1' }),
+        row({ lineId: null, offerId: '', qty: '' }),
+      ]);
+      // Soft-remove line 1 AFTER mount — origRows (the snapshot) must be unaffected.
+      m.removeRow(m.rows[0]);
+      // Add a brand-new row after mount — must never appear in known_line_ids.
+      m.addVendorRow(100, 'ABC', 'desc');
+
+      const payload = m.buildPayload();
+      expect(payload.known_line_ids.slice().sort()).toEqual([1, 2]);
+    });
+  });
+
+  describe('removeRow / undoRemove', () => {
+    it('soft-removes a persisted row (kept in rows, removed=true)', () => {
+      const m = makeEditor(1, [row({ lineId: 1 })]);
+      m.removeRow(m.rows[0]);
+      expect(m.rows).toHaveLength(1);
+      expect(m.rows[0].removed).toBe(true);
+    });
+
+    it('hard-deletes an unsaved scratch row (spliced out of rows)', () => {
+      const m = makeEditor(1, [row({ lineId: null, _uid: 'new-1' })]);
+      m.removeRow(m.rows[0]);
+      expect(m.rows).toHaveLength(0);
+    });
+
+    it('undoRemove clears the removed flag on a soft-removed row', () => {
+      const m = makeEditor(1, [row({ lineId: 1 })]);
+      m.removeRow(m.rows[0]);
+      expect(m.rows[0].removed).toBe(true);
+      m.undoRemove(m.rows[0]);
+      expect(m.rows[0].removed).toBe(false);
+    });
+  });
+
+  describe('addVendorRow / addLineFromPicker', () => {
+    it('addVendorRow pushes a correctly-shaped blank scratch row for the given part', () => {
+      const m = makeEditor(1, []);
+      m.addVendorRow(300, 'XYZ999', 'Capacitor');
+      expect(m.rows).toHaveLength(1);
+      expect(m.rows[0]).toMatchObject({
+        lineId: null, requirementId: 300, mpn: 'XYZ999', description: 'Capacitor',
+        offerId: '', qty: '', sell: '', locked: false, removed: false,
+      });
+      expect(m.rows[0]._uid).toBeTruthy();
+    });
+
+    it('addLineFromPicker no-ops when offer, requirement, or qty is missing', () => {
+      const m = makeEditor(1, [], {}, [{ id: 300, mpn: 'XYZ999', description: 'Capacitor' }]);
+      m.newPart = { reqId: '', offerId: '11', qty: '5', sell: '' };
+      m.addLineFromPicker();
+      expect(m.rows).toHaveLength(0);
+    });
+
+    it('addLineFromPicker pushes a fully-shaped new row from the addableParts lookup and resets the picker', () => {
+      const m = makeEditor(1, [], {}, [{ id: 300, mpn: 'XYZ999', description: 'Capacitor' }]);
+      m.showAddLine = true;
+      m.newPart = { reqId: '300', offerId: '11', qty: '5', sell: '2.5' };
+      m.addLineFromPicker();
+      expect(m.rows).toHaveLength(1);
+      expect(m.rows[0]).toMatchObject({
+        lineId: null, requirementId: 300, mpn: 'XYZ999', description: 'Capacitor',
+        offerId: '11', qty: '5', sell: '2.5', locked: false, removed: false,
+      });
+      expect(m.newPart).toEqual({ reqId: '', offerId: '', qty: '', sell: '' });
+      expect(m.showAddLine).toBe(false);
+    });
+  });
+
+  describe('cancelEdit — restores the untouched mount snapshot (deep copy)', () => {
+    it('reverts an in-place row mutation back to the seeded value', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '5', sell: '1.5' })]);
+      m.enterEdit();
+      expect(m.editMode).toBe(true);
+
+      m.rows[0].qty = 999;
+      m.rows[0].sell = 777;
+      m.rows[0].offerId = 'mutated';
+
+      m.cancelEdit();
+
+      expect(m.editMode).toBe(false);
+      expect(m.rows[0]).toMatchObject({ qty: '5', sell: '1.5', offerId: '9' });
+    });
+
+    it('mutating a live row never leaks back into origRows (proves the snapshot is a deep copy)', () => {
+      const m = makeEditor(1, [row({ lineId: 1, qty: '5' })]);
+      m.rows[0].qty = 999;
+      expect(m.origRows[0].qty).toBe('5');
+    });
+
+    it('discards rows added after mount and restores soft-removed rows on cancel', () => {
+      const m = makeEditor(1, [row({ lineId: 1 })]);
+      m.addVendorRow(100, 'ABC', 'desc');
+      m.removeRow(m.rows[0]);
+      expect(m.rows).toHaveLength(2);
+
+      m.cancelEdit();
+
+      expect(m.rows).toHaveLength(1);
+      expect(m.rows[0].lineId).toBe(1);
+      expect(m.rows[0].removed).toBe(false);
+    });
+  });
+
+  describe('saveAll — double-submit guard + saving reset', () => {
+    it('a second synchronous call while saving does not trigger a second htmx.ajax', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '5' })]);
+      m.saveAll();
+      m.saveAll();
+      expect((htmx.ajax as any).mock.calls).toHaveLength(1);
+    });
+
+    it('posts to the bulk endpoint with the JSON payload string and resets saving on success', async () => {
+      const m = makeEditor(7, [row({ lineId: 1, offerId: '9', qty: '5', sell: '2' })]);
+      m.saveAll();
+      expect(m.saving).toBe(true);
+      const [method, url, opts] = (htmx.ajax as any).mock.calls[0];
+      expect(method).toBe('POST');
+      expect(url).toBe('/v2/partials/buy-plans/7/lines/bulk');
+      expect(opts.target).toBe('#main-content');
+      const sent = JSON.parse(opts.values.payload);
+      expect(sent.lines).toEqual([{ line_id: 1, quantity: 5, unit_sell: 2, offer_id: 9 }]);
+      expect(sent.known_line_ids).toEqual([1]);
+
+      await vi.waitFor(() => expect(m.saving).toBe(false));
+    });
+
+    it('resets saving when the htmx.ajax promise rejects (e.g. a 400)', async () => {
+      (htmx.ajax as any).mockRejectedValueOnce(new Error('bad request'));
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '5' })]);
+      m.saveAll();
+      expect(m.saving).toBe(true);
+      await vi.waitFor(() => expect(m.saving).toBe(false));
+    });
+
+    it('does nothing when canSave is false (invalid row present)', () => {
+      const m = makeEditor(1, [row({ lineId: 1, offerId: '', qty: '5' })]);
+      m.saveAll();
+      expect(htmx.ajax).not.toHaveBeenCalled();
+      expect(m.saving).toBe(false);
+    });
+  });
+});

--- a/tests/frontend/buy-plan-lines-editor.test.ts
+++ b/tests/frontend/buy-plan-lines-editor.test.ts
@@ -342,11 +342,26 @@ describe('buyPlanLinesEditor (real factory)', () => {
     });
 
     it('resets saving when the htmx.ajax promise rejects (e.g. a 400)', async () => {
-      (htmx.ajax as any).mockRejectedValueOnce(new Error('bad request'));
-      const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '5' })]);
-      m.saveAll();
-      expect(m.saving).toBe(true);
-      await vi.waitFor(() => expect(m.saving).toBe(false));
+      // saveAll() intentionally only chains `.finally()` (fire-and-forget, same as every
+      // other imperative htmx.ajax() call site in this codebase) — it never swallows the
+      // rejection, so `.finally()`'s own derived promise is left unconsumed by design
+      // (nothing awaits saveAll() from the template either). That's expected in
+      // production (the browser just logs it) but Node's test runner reports it as an
+      // "unhandled rejection" — swallow that ONE expected rejection here so it doesn't
+      // pollute the test run, without touching saveAll() itself.
+      const swallowExpectedRejection = (err: unknown) => {
+        if (!(err instanceof Error) || err.message !== 'bad request') throw err;
+      };
+      process.once('unhandledRejection', swallowExpectedRejection);
+      try {
+        (htmx.ajax as any).mockRejectedValueOnce(new Error('bad request'));
+        const m = makeEditor(1, [row({ lineId: 1, offerId: '9', qty: '5' })]);
+        m.saveAll();
+        expect(m.saving).toBe(true);
+        await vi.waitFor(() => expect(m.saving).toBe(false));
+      } finally {
+        process.removeListener('unhandledRejection', swallowExpectedRejection);
+      }
     });
 
     it('does nothing when canSave is false (invalid row present)', () => {

--- a/tests/test_buy_plan_epic.py
+++ b/tests/test_buy_plan_epic.py
@@ -13,7 +13,9 @@ Covers the money-governing buy-plan/sales-order workflow additions:
 
 Called by: pytest
 Depends on: conftest fixtures (client, test_user, sales_user, manager_user, admin_user,
-    test_requisition, test_offer), FastAPI TestClient.
+    test_requisition, test_offer, and the shared buy-plan line-editing factories
+    _buyplan_req/_buyplan_requirement_of/_buyplan_plan/_buyplan_line — also consumed by
+    test_buyplan_bulk_edit.py), FastAPI TestClient.
 """
 
 import os
@@ -25,13 +27,16 @@ from datetime import UTC, datetime
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
 
 from app.constants import BuyPlanLineStatus, BuyPlanStatus
 from app.dependencies import require_user
 from app.main import app
-from app.models import Requirement, Requisition, User
+from app.models import User
 from app.models.buy_plan import BuyPlan, BuyPlanLine
+from tests.conftest import _buyplan_line as _line
+from tests.conftest import _buyplan_plan as _plan
+from tests.conftest import _buyplan_req as _req
+from tests.conftest import _buyplan_requirement_of as _requirement_of
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -48,70 +53,6 @@ def _acting_as(user: User):
             app.dependency_overrides[require_user] = prior
         else:
             app.dependency_overrides.pop(require_user, None)
-
-
-def _req(db: Session, owner: User, *, customer: str = "Acme Electronics") -> Requisition:
-    """A requisition (owned by *owner*) with one requirement."""
-    req = Requisition(
-        name="REQ-EPIC",
-        customer_name=customer,
-        status="open",
-        created_by=owner.id,
-        created_at=datetime.now(UTC),
-    )
-    db.add(req)
-    db.flush()
-    db.add(
-        Requirement(
-            requisition_id=req.id,
-            primary_mpn="LM317T",
-            target_qty=1000,
-            target_price=0.75,
-            created_at=datetime.now(UTC),
-        )
-    )
-    db.commit()
-    db.refresh(req)
-    return req
-
-
-def _requirement_of(db: Session, req: Requisition) -> Requirement:
-    return db.query(Requirement).filter(Requirement.requisition_id == req.id).first()
-
-
-def _plan(db: Session, req: Requisition, *, status=BuyPlanStatus.DRAFT.value, **ov) -> BuyPlan:
-    defaults = dict(
-        requisition_id=req.id,
-        status=status,
-        so_status="pending",
-        total_cost=100.00,
-        total_revenue=200.00,
-        total_margin_pct=50.00,
-        ai_flags=[],
-        created_at=datetime.now(UTC),
-    )
-    defaults.update(ov)
-    plan = BuyPlan(**defaults)
-    db.add(plan)
-    db.commit()
-    db.refresh(plan)
-    return plan
-
-
-def _line(db: Session, plan: BuyPlan, **ov) -> BuyPlanLine:
-    defaults = dict(
-        buy_plan_id=plan.id,
-        quantity=100,
-        unit_cost=1.00,
-        unit_sell=2.00,
-        status=BuyPlanLineStatus.AWAITING_PO.value,
-    )
-    defaults.update(ov)
-    line = BuyPlanLine(**defaults)
-    db.add(line)
-    db.commit()
-    db.refresh(line)
-    return line
 
 
 # ══ G — list fields ══════════════════════════════════════════════════
@@ -216,6 +157,10 @@ def test_add_line_recomputes_header(db_session, test_user, test_requisition, tes
     plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
     _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)  # cost 100, rev 200
     requirement = _requirement_of(db_session, test_requisition)
+    # Attaching an offer now also validates requirement_id + ACTIVE status (mirrors the
+    # vendor picker) — anchor test_offer to the target requirement.
+    test_offer.requirement_id = requirement.id
+    db_session.commit()
 
     # test_offer: unit_price 0.50; add 1000 @ sell 0.50 → cost 500, rev 500.
     add_buy_plan_line(plan.id, requirement.id, test_offer.id, 1000, test_user, db_session, unit_sell=0.50)

--- a/tests/test_buy_plan_epic.py
+++ b/tests/test_buy_plan_epic.py
@@ -326,8 +326,9 @@ def test_edit_endpoint_terminal_forbidden(client, db_session, sales_user, manage
 
 
 def test_detail_renders_editable_line_ui_for_editor(client, db_session, manager_user, test_requisition, test_offer):
-    """Manager viewing an ACTIVE plan sees the editable line UI (cells, vendor picker,
-    add form) render end-to-end without a Jinja error."""
+    """Manager viewing an ACTIVE plan sees the whole-plan editable line UI (Edit plan
+    toggle, the bulk-save endpoint reference, add-line/add-vendor affordances) render
+    end-to-end without a Jinja error."""
     # Anchor the offer to the plan's requirement so it appears in the vendor picker + add form.
     requirement = _requirement_of(db_session, test_requisition)
     test_offer.requirement_id = requirement.id
@@ -340,9 +341,11 @@ def test_detail_renders_editable_line_ui_for_editor(client, db_session, manager_
         resp = client.get(f"/v2/partials/buy-plans/{plan.id}")
     assert resp.status_code == 200
     body = resp.text
-    assert f"/v2/partials/buy-plans/{plan.id}/lines/add" in body  # add-line form present
+    assert f"buyPlanLinesEditor({plan.id}," in body  # whole-plan editor seeded with this plan id
+    assert "Edit plan" in body  # whole-table edit toggle (replaces per-row Edit)
+    assert "Save all" in body
     assert "+ Add line" in body
-    assert "/remove" in body  # per-line remove control
+    assert "+ Add vendor" in body  # split-vendor add, one per part group
     assert test_offer.vendor_name in body  # offer surfaced in the vendor picker
 
 

--- a/tests/test_buy_plans_router_gaps.py
+++ b/tests/test_buy_plans_router_gaps.py
@@ -477,24 +477,25 @@ def test_resource_missing_reason_code(client, buy_plan):
 
 
 def test_verify_po_completion_triggers_notify(po_approver_client, buy_plan):
-    """check_completion returns COMPLETED plan → commit + notify_completed (lines
-    881-884)."""
+    """verify_po's own internal (approve-only) check_completion call already decides
+    completion by the time it returns the line — the route reads that off
+    ``line.buy_plan.status`` (an identity-map hit, not a second completion scan) to
+    decide whether to notify (lines 881-884)."""
     from app.constants import BuyPlanStatus
 
-    completed_plan = MagicMock()
-    completed_plan.status = BuyPlanStatus.COMPLETED
+    completed_line = MagicMock()
+    completed_line.buy_plan.status = BuyPlanStatus.COMPLETED.value
 
-    with patch("app.services.buyplan_workflow.verify_po"):
-        with patch("app.services.buyplan_workflow.check_completion", return_value=completed_plan):
-            with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()) as mock_notify:
-                with patch(
-                    "app.routers.htmx.buy_plans.buy_plan_detail_partial",
-                    new=AsyncMock(return_value=_ok_html()),
-                ):
-                    resp = po_approver_client.post(
-                        f"/v2/partials/buy-plans/{buy_plan.id}/lines/1/verify-po",
-                        data={"action": "approve"},
-                    )
+    with patch("app.services.buyplan_workflow.verify_po", return_value=completed_line):
+        with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()) as mock_notify:
+            with patch(
+                "app.routers.htmx.buy_plans.buy_plan_detail_partial",
+                new=AsyncMock(return_value=_ok_html()),
+            ):
+                resp = po_approver_client.post(
+                    f"/v2/partials/buy-plans/{buy_plan.id}/lines/1/verify-po",
+                    data={"action": "approve"},
+                )
     assert resp.status_code == 200
     mock_notify.assert_called()
 

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -1,0 +1,346 @@
+"""tests/test_buyplan_bulk_edit.py — Buy-Plan bulk "save all" line editing.
+
+Covers ``bulk_edit_buy_plan_lines`` (app/services/buyplan_workflow/buyplan_lines.py)
+and its route (POST /v2/partials/buy-plans/{plan_id}/lines/bulk in
+app/routers/htmx/buy_plans.py): editing multiple lines' qty/sell/vendor, adding new
+lines, removing lines by omission, the PO-cut guard, and the role×status edit gate —
+all in a single POST.
+
+Called by: pytest
+Depends on: conftest fixtures (client, test_user, sales_user, manager_user,
+    test_requisition, test_offer), FastAPI TestClient.
+"""
+
+import json
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import BuyPlanLineStatus, BuyPlanStatus
+from app.dependencies import require_user
+from app.main import app
+from app.models import Requirement, Requisition, User
+from app.models.buy_plan import BuyPlan, BuyPlanLine
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def _acting_as(user: User):
+    """Temporarily route require_user to *user* (restore prior override on exit)."""
+    prior = app.dependency_overrides.get(require_user)
+    app.dependency_overrides[require_user] = lambda: user
+    try:
+        yield
+    finally:
+        if prior is not None:
+            app.dependency_overrides[require_user] = prior
+        else:
+            app.dependency_overrides.pop(require_user, None)
+
+
+def _req(db: Session, owner: User, *, customer: str = "Acme Electronics") -> Requisition:
+    req = Requisition(
+        name="REQ-BULK",
+        customer_name=customer,
+        status="open",
+        created_by=owner.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(req)
+    db.flush()
+    db.add(
+        Requirement(
+            requisition_id=req.id,
+            primary_mpn="LM317T",
+            target_qty=1000,
+            target_price=0.75,
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.commit()
+    db.refresh(req)
+    return req
+
+
+def _requirement_of(db: Session, req: Requisition) -> Requirement:
+    return db.query(Requirement).filter(Requirement.requisition_id == req.id).first()
+
+
+def _plan(db: Session, req: Requisition, *, status=BuyPlanStatus.DRAFT.value, **ov) -> BuyPlan:
+    defaults = dict(
+        requisition_id=req.id,
+        status=status,
+        so_status="pending",
+        total_cost=100.00,
+        total_revenue=200.00,
+        total_margin_pct=50.00,
+        ai_flags=[],
+        created_at=datetime.now(UTC),
+    )
+    defaults.update(ov)
+    plan = BuyPlan(**defaults)
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return plan
+
+
+def _line(db: Session, plan: BuyPlan, **ov) -> BuyPlanLine:
+    defaults = dict(
+        buy_plan_id=plan.id,
+        quantity=100,
+        unit_cost=1.00,
+        unit_sell=2.00,
+        status=BuyPlanLineStatus.AWAITING_PO.value,
+    )
+    defaults.update(ov)
+    line = BuyPlanLine(**defaults)
+    db.add(line)
+    db.commit()
+    db.refresh(line)
+    return line
+
+
+# ══ Service-level ══════════════════════════════════════════════════════
+
+
+def test_bulk_edit_multiple_lines_recomputes_header(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    a = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)  # cost 100 rev 200
+    b = _line(db_session, plan, quantity=50, unit_cost=4.00, unit_sell=6.00)  # cost 200 rev 300
+
+    payload = [
+        {"line_id": a.id, "quantity": 200, "unit_sell": 3.00},  # cost 200 rev 600
+        {"line_id": b.id, "unit_sell": 8.00},  # cost 200 rev 400
+    ]
+    bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+    db_session.commit()
+    db_session.refresh(plan)
+    db_session.refresh(a)
+    db_session.refresh(b)
+
+    assert a.quantity == 200
+    assert float(a.unit_sell) == 3.00
+    assert float(b.unit_sell) == 8.00
+    assert float(plan.total_cost) == 400.0
+    assert float(plan.total_revenue) == 1000.0
+
+
+def test_bulk_edit_vendor_change_recomputes_cost(db_session, test_user, test_requisition, test_offer):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+
+    bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "offer_id": test_offer.id}], test_user, db_session)
+    db_session.commit()
+    db_session.refresh(line)
+
+    assert line.offer_id == test_offer.id
+    assert float(line.unit_cost) == 0.50  # test_offer.unit_price
+    assert line.buyer_id == test_user.id  # vendor_ownership cascade (test_offer.entered_by_id)
+
+
+def test_bulk_edit_adds_new_line_with_buyer_assignment(db_session, test_user, test_requisition, test_offer):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+
+    payload = [
+        {"requirement_id": requirement.id, "offer_id": test_offer.id, "quantity": 1000, "unit_sell": 0.60},
+    ]
+    plan = bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+    db_session.commit()
+    db_session.refresh(plan)
+
+    assert len(plan.lines) == 1
+    new_line = plan.lines[0]
+    assert new_line.quantity == 1000
+    assert float(new_line.unit_sell) == 0.60
+    assert float(new_line.unit_cost) == 0.50
+    assert new_line.buyer_id == test_user.id  # assign_buyer vendor_ownership cascade
+
+
+def test_bulk_edit_omitted_editable_line_is_removed(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    keep = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+    drop = _line(db_session, plan, quantity=50, unit_cost=4.00, unit_sell=6.00)
+
+    payload = [{"line_id": keep.id, "unit_sell": 2.00}]
+    plan = bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+    db_session.commit()
+    db_session.refresh(plan)
+
+    assert [ln.id for ln in plan.lines] == [keep.id]
+    assert drop.id not in [ln.id for ln in plan.lines]
+
+
+def test_bulk_edit_omitted_po_cut_line_untouched(db_session, manager_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+    kept_editable = _line(db_session, plan, quantity=10, unit_cost=1.00, unit_sell=2.00)
+    po_cut = _line(
+        db_session,
+        plan,
+        quantity=50,
+        unit_cost=4.00,
+        unit_sell=6.00,
+        status=BuyPlanLineStatus.PENDING_VERIFY.value,
+    )
+
+    # Only the editable line is submitted; the PO-cut line is omitted entirely.
+    payload = [{"line_id": kept_editable.id, "unit_sell": 3.00}]
+    plan = bulk_edit_buy_plan_lines(plan.id, payload, manager_user, db_session)
+    db_session.commit()
+    db_session.refresh(plan)
+
+    line_ids = {ln.id for ln in plan.lines}
+    assert kept_editable.id in line_ids
+    assert po_cut.id in line_ids  # left untouched, NOT removed
+
+
+def test_bulk_edit_qty_change_on_po_cut_line_rejected(db_session, manager_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db_session, plan, status=BuyPlanLineStatus.PENDING_VERIFY.value)
+
+    with pytest.raises(ValueError, match="quantity"):
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "quantity": 999}], manager_user, db_session)
+
+
+def test_bulk_edit_vendor_change_on_po_cut_line_rejected(db_session, manager_user, test_requisition, test_offer):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db_session, plan, status=BuyPlanLineStatus.PENDING_VERIFY.value)
+
+    with pytest.raises(ValueError, match="vendor"):
+        bulk_edit_buy_plan_lines(
+            plan.id, [{"line_id": line.id, "offer_id": test_offer.id}], manager_user, db_session
+        )
+
+
+def test_bulk_edit_qty_zero_rejected(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan)
+
+    with pytest.raises(ValueError, match="positive"):
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "quantity": 0}], test_user, db_session)
+
+
+def test_bulk_edit_new_line_foreign_requirement_rejected(db_session, test_user, test_requisition, test_offer):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    other = _req(db_session, test_user)
+    foreign_req = _requirement_of(db_session, other)
+
+    payload = [{"requirement_id": foreign_req.id, "offer_id": test_offer.id, "quantity": 10}]
+    with pytest.raises(ValueError, match="requisition"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+def test_bulk_edit_unknown_offer_rejected(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+
+    payload = [{"requirement_id": requirement.id, "offer_id": 999999, "quantity": 10}]
+    with pytest.raises(ValueError, match="Offer"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+def test_bulk_edit_unknown_line_id_rejected(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+
+    with pytest.raises(ValueError, match="Line"):
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": 999999, "unit_sell": 1.0}], test_user, db_session)
+
+
+# ══ Route-level ══════════════════════════════════════════════════════
+
+
+def test_route_bulk_edit_happy_path_returns_200(client: TestClient, db_session, test_user, test_requisition):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+
+    payload = {"lines": [{"line_id": line.id, "quantity": 150, "unit_sell": 2.50}]}
+    resp = client.post(
+        f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+        data={"payload": json.dumps(payload)},
+    )
+    assert resp.status_code == 200
+    db_session.expire_all()
+    assert db_session.get(BuyPlanLine, line.id).quantity == 150
+
+
+def test_route_bulk_edit_malformed_json_400(client: TestClient, db_session, test_requisition):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+
+    resp = client.post(
+        f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+        data={"payload": "{not valid json"},
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.json()
+
+
+def test_route_bulk_edit_wrong_shape_400(client: TestClient, db_session, test_requisition):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+
+    resp = client.post(
+        f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+        data={"payload": json.dumps({"not_lines": []})},
+    )
+    assert resp.status_code == 400
+
+
+def test_route_bulk_edit_non_owner_sales_draft_403(client: TestClient, db_session, sales_user, test_user):
+    req = _req(db_session, sales_user)
+    plan = _plan(db_session, req, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan)
+
+    # Default client acts as test_user, a buyer (non-restricted role, so the router's
+    # per-record ownership check does not 404 it) who is neither the plan owner nor a
+    # manager on a pre-approval DRAFT plan → the service gate rejects with 403.
+    payload = {"lines": [{"line_id": line.id, "unit_sell": 9.0}]}
+    resp = client.post(
+        f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+        data={"payload": json.dumps(payload)},
+    )
+    assert resp.status_code == 403
+
+
+def test_route_bulk_edit_sales_on_active_plan_403(client: TestClient, db_session, sales_user):
+    # Plan owned by sales_user (passes the router's per-record ownership check) but
+    # ACTIVE — post-approval line edits are manager-only, so the service gate rejects.
+    req = _req(db_session, sales_user)
+    plan = _plan(db_session, req, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db_session, plan)
+
+    payload = {"lines": [{"line_id": line.id, "unit_sell": 9.0}]}
+    with _acting_as(sales_user):
+        resp = client.post(
+            f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+            data={"payload": json.dumps(payload)},
+        )
+    assert resp.status_code == 403

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -8,7 +8,9 @@ all in a single POST.
 
 Called by: pytest
 Depends on: conftest fixtures (client, test_user, sales_user, manager_user,
-    test_requisition, test_offer), FastAPI TestClient.
+    test_requisition, test_offer, and the shared buy-plan line-editing factories
+    _buyplan_req/_buyplan_requirement_of/_buyplan_plan/_buyplan_line/_buyplan_offer —
+    also consumed by test_buy_plan_epic.py), FastAPI TestClient.
 """
 
 import json
@@ -17,17 +19,20 @@ import os
 os.environ["TESTING"] = "1"
 
 from contextlib import contextmanager
-from datetime import UTC, datetime
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
 
-from app.constants import BuyPlanLineStatus, BuyPlanStatus
+from app.constants import BuyPlanLineStatus, BuyPlanStatus, OfferStatus
 from app.dependencies import require_user
 from app.main import app
-from app.models import Offer, Requirement, Requisition, User
+from app.models import User
 from app.models.buy_plan import BuyPlan, BuyPlanLine
+from tests.conftest import _buyplan_line as _line
+from tests.conftest import _buyplan_offer as _offer
+from tests.conftest import _buyplan_plan as _plan
+from tests.conftest import _buyplan_req as _req
+from tests.conftest import _buyplan_requirement_of as _requirement_of
 
 
 @contextmanager
@@ -42,88 +47,6 @@ def _acting_as(user: User):
             app.dependency_overrides[require_user] = prior
         else:
             app.dependency_overrides.pop(require_user, None)
-
-
-def _req(db: Session, owner: User, *, customer: str = "Acme Electronics") -> Requisition:
-    req = Requisition(
-        name="REQ-BULK",
-        customer_name=customer,
-        status="open",
-        created_by=owner.id,
-        created_at=datetime.now(UTC),
-    )
-    db.add(req)
-    db.flush()
-    db.add(
-        Requirement(
-            requisition_id=req.id,
-            primary_mpn="LM317T",
-            target_qty=1000,
-            target_price=0.75,
-            created_at=datetime.now(UTC),
-        )
-    )
-    db.commit()
-    db.refresh(req)
-    return req
-
-
-def _requirement_of(db: Session, req: Requisition) -> Requirement:
-    return db.query(Requirement).filter(Requirement.requisition_id == req.id).first()
-
-
-def _plan(db: Session, req: Requisition, *, status=BuyPlanStatus.DRAFT.value, **ov) -> BuyPlan:
-    defaults = dict(
-        requisition_id=req.id,
-        status=status,
-        so_status="pending",
-        total_cost=100.00,
-        total_revenue=200.00,
-        total_margin_pct=50.00,
-        ai_flags=[],
-        created_at=datetime.now(UTC),
-    )
-    defaults.update(ov)
-    plan = BuyPlan(**defaults)
-    db.add(plan)
-    db.commit()
-    db.refresh(plan)
-    return plan
-
-
-def _line(db: Session, plan: BuyPlan, **ov) -> BuyPlanLine:
-    defaults = dict(
-        buy_plan_id=plan.id,
-        quantity=100,
-        unit_cost=1.00,
-        unit_sell=2.00,
-        status=BuyPlanLineStatus.AWAITING_PO.value,
-    )
-    defaults.update(ov)
-    line = BuyPlanLine(**defaults)
-    db.add(line)
-    db.commit()
-    db.refresh(line)
-    return line
-
-
-def _offer(db: Session, requisition: Requisition, entered_by: User, **ov) -> Offer:
-    defaults = dict(
-        requisition_id=requisition.id,
-        vendor_name="Foreign Vendor",
-        mpn="LM317T",
-        qty_available=1000,
-        unit_price=0.40,
-        entered_by_id=entered_by.id,
-        status="active",
-        created_at=datetime.now(UTC),
-    )
-    defaults.update(ov)
-    offer = Offer(**defaults)
-    db.add(offer)
-    db.commit()
-    db.refresh(offer)
-    return offer
 
 
 # ══ Service-level ══════════════════════════════════════════════════════
@@ -157,7 +80,10 @@ def test_bulk_edit_vendor_change_recomputes_cost(db_session, test_user, test_req
     from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
 
     plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
-    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+    requirement = _requirement_of(db_session, test_requisition)
+    test_offer.requirement_id = requirement.id
+    db_session.commit()
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00, requirement_id=requirement.id)
 
     bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "offer_id": test_offer.id}], test_user, db_session)
     db_session.commit()
@@ -173,6 +99,8 @@ def test_bulk_edit_adds_new_line_with_buyer_assignment(db_session, test_user, te
 
     plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
     requirement = _requirement_of(db_session, test_requisition)
+    test_offer.requirement_id = requirement.id
+    db_session.commit()
 
     payload = [
         {"requirement_id": requirement.id, "offer_id": test_offer.id, "quantity": 1000, "unit_sell": 0.60},

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -29,6 +29,7 @@ from app.dependencies import require_user
 from app.main import app
 from app.models import User
 from app.models.buy_plan import BuyPlan, BuyPlanLine
+from app.services.buyplan_notifications import notify_completed
 from tests.conftest import _buyplan_line as _line
 from tests.conftest import _buyplan_offer as _offer
 from tests.conftest import _buyplan_plan as _plan
@@ -736,6 +737,10 @@ def test_route_bulk_edit_completing_save_notifies_exactly_once(
             )
     assert resp.status_code == 200
     mock_notify.assert_called_once()
+    assert mock_notify.await_args.args[0] is notify_completed
+    assert mock_notify.await_args.args[1] == plan.id
+    db_session.expire_all()
+    assert db_session.get(BuyPlan, plan.id).status == BuyPlanStatus.COMPLETED.value
 
 
 def test_route_bulk_edit_non_completing_save_never_notifies(
@@ -753,6 +758,10 @@ def test_route_bulk_edit_non_completing_save_never_notifies(
             )
     assert resp.status_code == 200
     mock_notify.assert_not_called()
+    db_session.expire_all()
+    refreshed = db_session.get(BuyPlan, plan.id)
+    assert refreshed.status == BuyPlanStatus.ACTIVE.value
+    assert float(db_session.get(BuyPlanLine, line.id).unit_sell) == 9.0
 
 
 def test_route_remove_completing_removal_notifies_exactly_once(
@@ -767,6 +776,11 @@ def test_route_remove_completing_removal_notifies_exactly_once(
             resp = client.post(f"/v2/partials/buy-plans/{plan.id}/lines/{open_line.id}/remove")
     assert resp.status_code == 200
     mock_notify.assert_called_once()
+    assert mock_notify.await_args.args[0] is notify_completed
+    assert mock_notify.await_args.args[1] == plan.id
+    db_session.expire_all()
+    assert db_session.get(BuyPlan, plan.id).status == BuyPlanStatus.COMPLETED.value
+    assert db_session.get(BuyPlanLine, open_line.id) is None
 
 
 def test_route_remove_non_completing_removal_never_notifies(

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -292,6 +292,186 @@ def test_bulk_edit_unknown_line_id_rejected(db_session, test_user, test_requisit
         bulk_edit_buy_plan_lines(plan.id, [{"line_id": 999999, "unit_sell": 1.0}], test_user, db_session)
 
 
+# ══ Fix 1 — removal scoped to known_line_ids ══════════════════════════
+
+
+def test_bulk_edit_concurrent_line_absent_from_known_ids_survives(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    seen = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+    # Added by someone else AFTER the client's form loaded — never in known_line_ids.
+    concurrent = _line(db_session, plan, quantity=50, unit_cost=4.00, unit_sell=6.00)
+
+    payload = [{"line_id": seen.id, "unit_sell": 3.00}]
+    plan = bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session, known_line_ids=[seen.id])
+    db_session.commit()
+    db_session.refresh(plan)
+
+    line_ids = {ln.id for ln in plan.lines}
+    assert seen.id in line_ids
+    assert concurrent.id in line_ids  # NOT removed — client never saw it
+
+
+def test_bulk_edit_known_line_ids_absent_uses_legacy_removal(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    seen = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+    other = _line(db_session, plan, quantity=50, unit_cost=4.00, unit_sell=6.00)
+
+    payload = [{"line_id": seen.id, "unit_sell": 3.00}]
+    # No known_line_ids kwarg at all -> legacy unscoped removal-by-omission.
+    plan = bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+    db_session.commit()
+    db_session.refresh(plan)
+
+    assert [ln.id for ln in plan.lines] == [seen.id]
+    assert other.id not in [ln.id for ln in plan.lines]
+
+
+def test_bulk_edit_known_line_ids_scopes_editable_omission_removal(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    seen = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+    known_but_dropped = _line(db_session, plan, quantity=50, unit_cost=4.00, unit_sell=6.00)
+
+    payload = [{"line_id": seen.id, "unit_sell": 3.00}]
+    plan = bulk_edit_buy_plan_lines(
+        plan.id, payload, test_user, db_session, known_line_ids=[seen.id, known_but_dropped.id]
+    )
+    db_session.commit()
+    db_session.refresh(plan)
+
+    # known_but_dropped WAS in known_line_ids and is omitted from the payload -> removed.
+    assert [ln.id for ln in plan.lines] == [seen.id]
+
+
+# ══ Fix 2a — unit_sell key-presence semantics ═════════════════════════
+
+
+def test_bulk_edit_unit_sell_null_clears(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+
+    bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "unit_sell": None}], test_user, db_session)
+    db_session.commit()
+    db_session.refresh(line)
+
+    assert line.unit_sell is None
+    assert line.margin_pct is None
+
+
+def test_bulk_edit_unit_sell_absent_leaves_unchanged(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+
+    # unit_sell key entirely absent -> unchanged (only qty changes).
+    bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "quantity": 150}], test_user, db_session)
+    db_session.commit()
+    db_session.refresh(line)
+
+    assert line.quantity == 150
+    assert float(line.unit_sell) == 2.00
+
+
+# ══ Fix 2b — unchanged qty/offer on a PO-cut line is a no-op ══════════
+
+
+def test_bulk_edit_unchanged_qty_offer_on_po_cut_line_is_noop(db_session, manager_user, test_requisition, test_offer):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(
+        db_session,
+        plan,
+        quantity=100,
+        unit_cost=0.50,
+        unit_sell=2.00,
+        offer_id=test_offer.id,
+        status=BuyPlanLineStatus.PENDING_VERIFY.value,
+    )
+
+    # Resending the SAME quantity and SAME offer_id must not trip the cut-PO guard —
+    # only the sell price (which is always editable) actually changes.
+    payload = [{"line_id": line.id, "quantity": 100, "offer_id": test_offer.id, "unit_sell": 3.00}]
+    bulk_edit_buy_plan_lines(plan.id, payload, manager_user, db_session)
+    db_session.commit()
+    db_session.refresh(line)
+
+    assert line.quantity == 100
+    assert line.offer_id == test_offer.id
+    assert float(line.unit_sell) == 3.00
+
+
+def test_bulk_edit_actual_qty_change_on_po_cut_line_still_rejected(db_session, manager_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db_session, plan, quantity=100, status=BuyPlanLineStatus.PENDING_VERIFY.value)
+
+    with pytest.raises(ValueError, match="quantity"):
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "quantity": 101}], manager_user, db_session)
+
+
+# ══ Fix 2c — fractional quantity rejected ══════════════════════════════
+
+
+def test_bulk_edit_fractional_quantity_rejected_on_edit(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan, quantity=100)
+
+    with pytest.raises(ValueError, match="whole number"):
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "quantity": 3.5}], test_user, db_session)
+
+
+def test_bulk_edit_fractional_quantity_rejected_on_add(db_session, test_user, test_requisition, test_offer):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+
+    payload = [{"requirement_id": requirement.id, "offer_id": test_offer.id, "quantity": 12.5}]
+    with pytest.raises(ValueError, match="whole number"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+# ══ Fix 4 — offer must belong to the plan's requisition ════════════════
+
+
+def test_bulk_edit_foreign_offer_rejected_on_add(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    other_req = _req(db_session, test_user)
+    foreign_offer = _offer(db_session, other_req, test_user)
+
+    payload = [{"requirement_id": requirement.id, "offer_id": foreign_offer.id, "quantity": 10}]
+    with pytest.raises(ValueError, match="requisition"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+def test_bulk_edit_foreign_offer_rejected_on_vendor_change(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00)
+    other_req = _req(db_session, test_user)
+    foreign_offer = _offer(db_session, other_req, test_user)
+
+    payload = [{"line_id": line.id, "offer_id": foreign_offer.id}]
+    with pytest.raises(ValueError, match="requisition"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
 # ══ Route-level ══════════════════════════════════════════════════════
 
 
@@ -360,3 +540,54 @@ def test_route_bulk_edit_sales_on_active_plan_403(client: TestClient, db_session
             data={"payload": json.dumps(payload)},
         )
     assert resp.status_code == 403
+
+
+def test_route_bulk_edit_known_line_ids_wrong_type_400(client: TestClient, db_session, test_requisition):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan)
+
+    payload = {"lines": [{"line_id": line.id, "unit_sell": 9.0}], "known_line_ids": ["not-an-int"]}
+    resp = client.post(
+        f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+        data={"payload": json.dumps(payload)},
+    )
+    assert resp.status_code == 400
+
+
+# ══ Fix 3 — auto-completion after removing the last open line ═════════
+
+
+def test_route_bulk_edit_removing_last_open_line_completes_active_plan(
+    client: TestClient, db_session, manager_user, test_requisition
+):
+    # ACTIVE-plan line edits are manager-only, so act as manager_user.
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value, so_status="approved")
+    verified = _line(db_session, plan, quantity=100, status=BuyPlanLineStatus.VERIFIED.value)
+    open_line = _line(db_session, plan, quantity=50, status=BuyPlanLineStatus.AWAITING_PO.value)
+
+    # Omit open_line from both the payload and known_line_ids -> removed by omission,
+    # leaving only the already-VERIFIED line -> plan should auto-complete.
+    payload = {"lines": [], "known_line_ids": [verified.id, open_line.id]}
+    with _acting_as(manager_user):
+        resp = client.post(
+            f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+            data={"payload": json.dumps(payload)},
+        )
+    assert resp.status_code == 200
+    db_session.expire_all()
+    assert db_session.get(BuyPlan, plan.id).status == BuyPlanStatus.COMPLETED.value
+
+
+def test_route_remove_line_completes_active_plan_when_last_open_line_removed(
+    client: TestClient, db_session, manager_user, test_requisition
+):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value, so_status="approved")
+    verified = _line(db_session, plan, quantity=100, status=BuyPlanLineStatus.VERIFIED.value)
+    open_line = _line(db_session, plan, quantity=50, status=BuyPlanLineStatus.AWAITING_PO.value)
+
+    with _acting_as(manager_user):
+        resp = client.post(f"/v2/partials/buy-plans/{plan.id}/lines/{open_line.id}/remove")
+    assert resp.status_code == 200
+    db_session.expire_all()
+    assert db_session.get(BuyPlan, plan.id).status == BuyPlanStatus.COMPLETED.value
+    assert db_session.get(BuyPlanLine, verified.id) is not None

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -16,6 +16,7 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from contextlib import contextmanager
 from datetime import UTC, datetime
 
 import pytest
@@ -27,8 +28,6 @@ from app.dependencies import require_user
 from app.main import app
 from app.models import Requirement, Requisition, User
 from app.models.buy_plan import BuyPlan, BuyPlanLine
-
-from contextlib import contextmanager
 
 
 @contextmanager
@@ -229,9 +228,7 @@ def test_bulk_edit_vendor_change_on_po_cut_line_rejected(db_session, manager_use
     line = _line(db_session, plan, status=BuyPlanLineStatus.PENDING_VERIFY.value)
 
     with pytest.raises(ValueError, match="vendor"):
-        bulk_edit_buy_plan_lines(
-            plan.id, [{"line_id": line.id, "offer_id": test_offer.id}], manager_user, db_session
-        )
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "offer_id": test_offer.id}], manager_user, db_session)
 
 
 def test_bulk_edit_qty_zero_rejected(db_session, test_user, test_requisition):

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 from app.constants import BuyPlanLineStatus, BuyPlanStatus
 from app.dependencies import require_user
 from app.main import app
-from app.models import Requirement, Requisition, User
+from app.models import Offer, Requirement, Requisition, User
 from app.models.buy_plan import BuyPlan, BuyPlanLine
 
 
@@ -105,6 +105,25 @@ def _line(db: Session, plan: BuyPlan, **ov) -> BuyPlanLine:
     db.commit()
     db.refresh(line)
     return line
+
+
+def _offer(db: Session, requisition: Requisition, entered_by: User, **ov) -> Offer:
+    defaults = dict(
+        requisition_id=requisition.id,
+        vendor_name="Foreign Vendor",
+        mpn="LM317T",
+        qty_available=1000,
+        unit_price=0.40,
+        entered_by_id=entered_by.id,
+        status="active",
+        created_at=datetime.now(UTC),
+    )
+    defaults.update(ov)
+    offer = Offer(**defaults)
+    db.add(offer)
+    db.commit()
+    db.refresh(offer)
+    return offer
 
 
 # ══ Service-level ══════════════════════════════════════════════════════

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -19,6 +19,7 @@ import os
 os.environ["TESTING"] = "1"
 
 from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -398,6 +399,200 @@ def test_bulk_edit_foreign_offer_rejected_on_vendor_change(db_session, test_user
     payload = [{"line_id": line.id, "offer_id": foreign_offer.id}]
     with pytest.raises(ValueError, match="requisition"):
         bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+# ══ Fix 1/9 — offer must also match the requirement/part and be ACTIVE ═
+
+
+def test_bulk_edit_wrong_part_offer_rejected_on_add(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    other_req = _req(db_session, test_user)
+    other_requirement = _requirement_of(db_session, other_req)
+    # Right requisition, but tagged for a DIFFERENT part.
+    wrong_part_offer = _offer(db_session, test_requisition, test_user, requirement_id=other_requirement.id)
+
+    payload = [{"requirement_id": requirement.id, "offer_id": wrong_part_offer.id, "quantity": 10}]
+    with pytest.raises(ValueError, match="part"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+def test_bulk_edit_wrong_part_offer_rejected_on_vendor_change(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00, requirement_id=requirement.id)
+    other_req = _req(db_session, test_user)
+    other_requirement = _requirement_of(db_session, other_req)
+    wrong_part_offer = _offer(db_session, test_requisition, test_user, requirement_id=other_requirement.id)
+
+    payload = [{"line_id": line.id, "offer_id": wrong_part_offer.id}]
+    with pytest.raises(ValueError, match="part"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+def test_bulk_edit_non_active_offer_rejected_on_add(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    sold_offer = _offer(
+        db_session, test_requisition, test_user, requirement_id=requirement.id, status=OfferStatus.SOLD.value
+    )
+
+    payload = [{"requirement_id": requirement.id, "offer_id": sold_offer.id, "quantity": 10}]
+    with pytest.raises(ValueError, match="not active"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+def test_bulk_edit_non_active_offer_rejected_on_vendor_change(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00, requirement_id=requirement.id)
+    sold_offer = _offer(
+        db_session, test_requisition, test_user, requirement_id=requirement.id, status=OfferStatus.SOLD.value
+    )
+
+    payload = [{"line_id": line.id, "offer_id": sold_offer.id}]
+    with pytest.raises(ValueError, match="not active"):
+        bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+
+
+def test_bulk_edit_unchanged_resend_of_now_sold_offer_still_succeeds(db_session, test_user, test_requisition):
+    """The offer-attachability revalidation NEVER runs on a no-op resend — a line's
+    already-attached offer may have legitimately gone SOLD since it was cut, and
+    resending the SAME unchanged offer_id must stay a no-op success regardless."""
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    offer = _offer(db_session, test_requisition, test_user, requirement_id=requirement.id)
+    line = _line(
+        db_session, plan, quantity=100, unit_cost=0.40, unit_sell=2.00, offer_id=offer.id, requirement_id=requirement.id
+    )
+
+    offer.status = OfferStatus.SOLD.value
+    db_session.commit()
+
+    payload = [{"line_id": line.id, "offer_id": offer.id, "unit_sell": 3.00}]
+    bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+    db_session.commit()
+    db_session.refresh(line)
+
+    assert line.offer_id == offer.id
+    assert float(line.unit_sell) == 3.00
+
+
+# ══ Fix 2 — falsy-zero unit_cost/unit_sell and stale ai_score ══════════
+
+
+def test_bulk_edit_zero_price_offer_keeps_unit_cost_zero_on_add(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    free_offer = _offer(db_session, test_requisition, test_user, requirement_id=requirement.id, unit_price=0.0)
+
+    payload = [{"requirement_id": requirement.id, "offer_id": free_offer.id, "quantity": 100, "unit_sell": 5.00}]
+    plan = bulk_edit_buy_plan_lines(plan.id, payload, test_user, db_session)
+    db_session.commit()
+    db_session.refresh(plan)
+
+    new_line = plan.lines[0]
+    assert float(new_line.unit_cost) == 0.0  # a real $0 cost, NOT None
+    assert float(plan.total_cost) == 0.0
+    assert float(plan.total_revenue) == 500.0  # 5.00 * 100
+
+
+def test_bulk_edit_vendor_change_to_zero_price_offer_keeps_unit_cost_zero(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    line = _line(db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00, requirement_id=requirement.id)
+    free_offer = _offer(db_session, test_requisition, test_user, requirement_id=requirement.id, unit_price=0.0)
+
+    bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "offer_id": free_offer.id}], test_user, db_session)
+    db_session.commit()
+    db_session.refresh(line)
+
+    assert line.offer_id == free_offer.id
+    assert float(line.unit_cost) == 0.0
+
+
+def test_bulk_edit_vendor_change_recomputes_ai_score(db_session, test_user, test_requisition):
+    from app.services.buyplan_scoring import score_offer
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    requirement = _requirement_of(db_session, test_requisition)
+    line = _line(
+        db_session, plan, quantity=100, unit_cost=1.00, unit_sell=2.00, requirement_id=requirement.id, ai_score=0.0
+    )
+    new_offer = _offer(db_session, test_requisition, test_user, requirement_id=requirement.id, unit_price=0.30)
+
+    bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "offer_id": new_offer.id}], test_user, db_session)
+    db_session.commit()
+    db_session.refresh(line)
+    db_session.refresh(new_offer)
+
+    expected_score = score_offer(new_offer, requirement, new_offer.vendor_card)
+    assert line.ai_score == pytest.approx(expected_score)
+
+
+# ══ Fix 4 — offer_id/quantity key-presence (explicit null is an error) ═
+
+
+def test_bulk_edit_explicit_null_offer_id_rejected(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan)
+
+    with pytest.raises(ValueError, match="must not be null"):
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "offer_id": None}], test_user, db_session)
+
+
+def test_bulk_edit_explicit_null_quantity_rejected(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan)
+
+    with pytest.raises(ValueError, match="must not be null"):
+        bulk_edit_buy_plan_lines(plan.id, [{"line_id": line.id, "quantity": None}], test_user, db_session)
+
+
+# ══ Fix 5 — known_line_ids coerced to set[int] at service depth ════════
+
+
+def test_bulk_edit_known_line_ids_rejects_bool(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan)
+
+    with pytest.raises(ValueError, match="known_line_ids"):
+        bulk_edit_buy_plan_lines(
+            plan.id, [{"line_id": line.id, "unit_sell": 1.0}], test_user, db_session, known_line_ids=[True]
+        )
+
+
+def test_bulk_edit_known_line_ids_rejects_non_int(db_session, test_user, test_requisition):
+    from app.services.buyplan_workflow import bulk_edit_buy_plan_lines
+
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.DRAFT.value)
+    line = _line(db_session, plan)
+
+    with pytest.raises(ValueError, match="known_line_ids"):
+        bulk_edit_buy_plan_lines(
+            plan.id, [{"line_id": line.id, "unit_sell": 1.0}], test_user, db_session, known_line_ids=["abc"]
+        )
 
 
 # ══ Route-level ══════════════════════════════════════════════════════

--- a/tests/test_buyplan_bulk_edit.py
+++ b/tests/test_buyplan_bulk_edit.py
@@ -714,3 +714,72 @@ def test_route_remove_line_completes_active_plan_when_last_open_line_removed(
     db_session.expire_all()
     assert db_session.get(BuyPlan, plan.id).status == BuyPlanStatus.COMPLETED.value
     assert db_session.get(BuyPlanLine, verified.id) is not None
+
+
+# ══ Fix 6 — notify_completed fires EXACTLY ONCE, driven by the service's
+#    own check_completion call (never re-derived by a second scan) ═════
+
+
+def test_route_bulk_edit_completing_save_notifies_exactly_once(
+    client: TestClient, db_session, manager_user, test_requisition
+):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value, so_status="approved")
+    verified = _line(db_session, plan, quantity=100, status=BuyPlanLineStatus.VERIFIED.value)
+    open_line = _line(db_session, plan, quantity=50, status=BuyPlanLineStatus.AWAITING_PO.value)
+
+    payload = {"lines": [], "known_line_ids": [verified.id, open_line.id]}
+    with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()) as mock_notify:
+        with _acting_as(manager_user):
+            resp = client.post(
+                f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+                data={"payload": json.dumps(payload)},
+            )
+    assert resp.status_code == 200
+    mock_notify.assert_called_once()
+
+
+def test_route_bulk_edit_non_completing_save_never_notifies(
+    client: TestClient, db_session, manager_user, test_requisition
+):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value, so_status="approved")
+    line = _line(db_session, plan, quantity=100, status=BuyPlanLineStatus.AWAITING_PO.value)
+
+    payload = {"lines": [{"line_id": line.id, "unit_sell": 9.0}], "known_line_ids": [line.id]}
+    with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()) as mock_notify:
+        with _acting_as(manager_user):
+            resp = client.post(
+                f"/v2/partials/buy-plans/{plan.id}/lines/bulk",
+                data={"payload": json.dumps(payload)},
+            )
+    assert resp.status_code == 200
+    mock_notify.assert_not_called()
+
+
+def test_route_remove_completing_removal_notifies_exactly_once(
+    client: TestClient, db_session, manager_user, test_requisition
+):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value, so_status="approved")
+    _line(db_session, plan, quantity=100, status=BuyPlanLineStatus.VERIFIED.value)
+    open_line = _line(db_session, plan, quantity=50, status=BuyPlanLineStatus.AWAITING_PO.value)
+
+    with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()) as mock_notify:
+        with _acting_as(manager_user):
+            resp = client.post(f"/v2/partials/buy-plans/{plan.id}/lines/{open_line.id}/remove")
+    assert resp.status_code == 200
+    mock_notify.assert_called_once()
+
+
+def test_route_remove_non_completing_removal_never_notifies(
+    client: TestClient, db_session, manager_user, test_requisition
+):
+    plan = _plan(db_session, test_requisition, status=BuyPlanStatus.ACTIVE.value, so_status="approved")
+    keep = _line(db_session, plan, quantity=100, status=BuyPlanLineStatus.AWAITING_PO.value)
+    drop = _line(db_session, plan, quantity=50, status=BuyPlanLineStatus.AWAITING_PO.value)
+
+    with patch("app.services.buyplan_notifications.run_notify_bg", new=AsyncMock()) as mock_notify:
+        with _acting_as(manager_user):
+            resp = client.post(f"/v2/partials/buy-plans/{plan.id}/lines/{drop.id}/remove")
+    assert resp.status_code == 200
+    mock_notify.assert_not_called()
+    db_session.expire_all()
+    assert db_session.get(BuyPlanLine, keep.id) is not None


### PR DESCRIPTION
## Summary

Consolidates buy-plan line editing into **one editable form**. Instead of clicking Edit on each row and using a separate add-line panel, an **Edit plan** mode makes the entire line-items grid editable at once:

- Every line's **quantity, sell price, and vendor** editable together
- **+ Add vendor** under each part — source one part from multiple vendors (split lines; no schema change, the PO pipeline is untouched)
- **+ Add line** for additional parts; **remove** with undo
- One **Save all** posts everything as a single request; **Cancel** restores the untouched state
- Lines with a cut PO stay locked (except sell price), preserving all purchasing safety rules

## Implementation

- `app/services/buyplan_workflow/buyplan_lines.py` — `bulk_edit_buy_plan_lines()`: shared `_apply_line_edit`/`_build_new_line` helpers (single definition of per-field rules), removal-by-omission scoped to client-rendered `known_line_ids` (concurrent-edit safe), key-presence semantics (null clears, absent unchanged), no-op guards so unchanged fields never trip the PO-cut check, offer attach validation (requisition + requirement + ACTIVE), batched offer loading, completion checked at service depth
- `app/routers/htmx/buy_plans.py` — `POST /v2/partials/buy-plans/{plan_id}/lines/bulk`; shared `_notify_if_completed` tail (exactly-once completion notification, no redundant recheck); existing per-line routes kept as API
- `app/models/buy_plan.py` — `BuyPlanLine.has_cut_po` property (single PO-cut predicate for service + template)
- `app/templates/htmx/partials/buy_plans/_detail_lines.html` + `app/static/htmx_app.js` — `buyPlanLinesEditor` Alpine component; truthful rendering of stale/inactive offers, unit-cost fallback for locked rows, integer-qty client validation, double-submit guard
- Bug fixes surfaced by review: zero-priced offers no longer drop out of cost rollups; all-zero plan totals no longer collapse to `None`; `ai_score` recomputes on vendor change
- Merged current `main` (post #715–#720): clean, zero conflicts; the 246 salvaged nightly-coverage tests pass against the reworked code

## Quality process

Architecture review → parallel build → 4-angle simplify pass → 8-angle code review with adversarial verification → all confirmed findings fixed.

## Tests

- `tests/test_buyplan_bulk_edit.py` — ~50 route/service tests (permissions, PO-cut guards, removal scoping, offer validation, zero-price, exactly-once notify)
- `tests/frontend/buy-plan-lines-editor.test.ts` — 39 Vitest specs (payload contract, snapshot/cancel, double-submit)
- Shared buy-plan test factories promoted to `conftest.py`
- Full suite post-merge with `main`: **23,220 passed**; pre-commit (ruff, mypy, docformatter, custom hooks) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM37SRf7PmotfDnM6QU3wX