### PR TITLE
fix: db-backup Spaces upload — bootstrap aws CLI, guard initial upload

### DIFF
--- a/scripts/backup-cron.sh
+++ b/scripts/backup-cron.sh
@@ -18,10 +18,15 @@ log "Retention: ${BACKUP_RETENTION_DAYS:-30} days local, ${SPACES_RETENTION_DAYS
 log "Running initial backup..."
 /scripts/backup.sh
 
-# Upload to Spaces if configured
+# Upload to Spaces if configured. Guarded like the in-loop call below: under
+# `set -e` an unguarded failure here would kill the entrypoint and (with
+# restart: always) crash-loop the whole backup service over a transient
+# Spaces/network error at container start.
 if [ -n "${DO_SPACES_KEY:-}" ]; then
     log "Uploading to DigitalOcean Spaces..."
-    /scripts/backup-to-spaces.sh
+    if ! /scripts/backup-to-spaces.sh; then
+        log "WARNING: initial off-site upload failed — local backup exists; will retry next cycle"
+    fi
 else
     log "DO_SPACES_KEY not set — skipping off-site upload"
 fi

--- a/scripts/backup-to-spaces.sh
+++ b/scripts/backup-to-spaces.sh
@@ -36,6 +36,14 @@ if [ -z "${DO_SPACES_KEY:-}" ] || [ -z "${DO_SPACES_SECRET:-}" ] || [ -z "${DO_S
     exit 0
 fi
 
+# The db-backup container is stock postgres:16-alpine, which does not ship the
+# aws CLI this script depends on — bootstrap it on first use. apk state does not
+# survive a container recreate, hence install-if-missing rather than assume.
+if ! command -v aws >/dev/null 2>&1; then
+    log "aws CLI not found — installing via apk..."
+    apk add --no-cache aws-cli >/dev/null 2>&1 || die "apk add aws-cli failed (offline?); cannot upload off-site"
+fi
+
 # Find latest backup
 if [ -f "${BACKUP_DIR}/LATEST" ]; then
     BACKUP_FILE=$(cat "${BACKUP_DIR}/LATEST")

--- a/scripts/backup-to-spaces.sh
+++ b/scripts/backup-to-spaces.sh
@@ -94,8 +94,11 @@ fi
 log "Upload complete"
 
 # ─── Verify upload ───────────────────────────────────────────────────────────
+# `aws s3 ls <key>` PREFIX-matches, so listing the dump also returns its
+# .sha256 sibling (uploaded above) — filter to the exact key or REMOTE_SIZE
+# becomes two concatenated sizes and the comparison always "mismatches".
 REMOTE_SIZE=$(aws s3 ls "s3://${DO_SPACES_BUCKET}/db-backups/${FILENAME}" \
-    --endpoint-url "$ENDPOINT" 2>/dev/null | awk '{print $3}')
+    --endpoint-url "$ENDPOINT" 2>/dev/null | awk -v f="$FILENAME" '$4 == f {print $3}')
 LOCAL_SIZE=$(stat -c%s "$BACKUP_FILE" 2>/dev/null || stat -f%z "$BACKUP_FILE")
 
 if [ "$REMOTE_SIZE" != "$LOCAL_SIZE" ]; then


### PR DESCRIPTION
Preparation for enabling off-site DB backups to DO Spaces (launch-checklist item). Two latent bugs would have fired the moment `DO_SPACES_KEY` was set in `.env`:

1. **`aws` CLI missing**: `backup-to-spaces.sh` depends on the aws CLI, but the `db-backup` service runs stock `postgres:16-alpine`, which doesn't ship it. The script now installs it via `apk` if missing (container-recreate-safe), and dies with a clear message if the install fails.
2. **Crash-loop on transient failure**: `backup-cron.sh`'s initial upload call was unguarded under `set -euo pipefail` — unlike its in-loop counterpart — so a transient Spaces/network error at container start would kill the entrypoint and, with `restart: always`, crash-loop the backup service. Now guarded with a warning + next-cycle retry.

Verified: `bash -n` clean on both scripts. Runtime verification (real upload to a real bucket) happens when the Spaces credentials land in `.env` — will be exercised as part of enabling the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)