### PR TITLE
fix(deps): bump pillow 12.2.0 → 12.3.0 — clears 5 PYSEC advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -126,7 +126,7 @@ patchright==1.61.2
     # via -r requirements.in
 phonenumbers==9.0.34
     # via -r requirements.in
-pillow==12.2.0
+pillow==12.3.0
     # via weasyprint
 prometheus-client==0.25.0
     # via -r requirements.in


### PR DESCRIPTION
## Why

The **Security Scanning** workflow is red on `main` (and on every open PR): `pip-audit` flags **pillow 12.2.0** with 5 advisories, all fixed in **12.3.0**:

- PYSEC-2026-2253/2254/2255/2256 — four decompression-bomb-check bypasses (PCF/BDF/GD font & image loaders allocate from attacker-controlled dimensions without `_decompression_bomb_check()`)
- PYSEC-2026-2257 — `WindowsViewer.get_command()` shell injection via unescaped file path (Windows-only, but flagged regardless)

## Change

One-line lock bump. pillow is a **transitive** pin (via weasyprint) — `requirements.in` untouched; recompiled with `pip-tools==7.5.3` on **Python 3.13** using the drift gate's exact flags (`--no-header --no-strip-extras`). `requirements-dev.txt` recompiled too: no diff.

## Notes

- This unblocks the security check on Dependabot PRs #724–#727, which all fail on the same pillow finding (their branches need a rebase or re-run after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)