### PR TITLE
chore(connectors): Sourcengine Phase-4 validation verdict — API host dead, connector stays disabled

### DIFF
--- a/app/connectors/sourcengine.py
+++ b/app/connectors/sourcengine.py
@@ -65,9 +65,19 @@ class SourcengineConnector(BaseConnector):
         #      would also crash the ``data.get`` calls below, so bail out cleanly.
         #   2. The body IS an object but carries NONE of the recognized offer keys
         #      (offers/results/data) — the envelope has changed.
-        # FLAG (Phase-4 audit): the connector's SEARCH_URL (/v1/search) no longer matches
-        # the currently-documented endpoint (/app/api/search/parts/searchpart); a LIVE
-        # Sourcengine call is required to confirm the real endpoint + response shape.
+        # VALIDATED 2026-07-15 (closes the Phase-4 audit FLAG): live probes with the
+        # configured key found the ENTIRE official API host dead — every path on
+        # https://api.sourcengine.com (including this connector's /v1/search and the
+        # documented GET /app/api/search/parts/searchpart) returns Cloudflare 530 /
+        # error 1016 (origin DNS failure), and the webapp-side path on sourcengine.com
+        # sits behind a Cloudflare browser challenge (not server-usable). Docs
+        # (dev.sourcengine.com) confirm base URL api.sourcengine.com + Bearer auth —
+        # matching this connector's auth — but tokens come from a Sourcengine account
+        # manager. The api_sources row is 'disabled'/is_active=false on the live DB
+        # (zero successes ever), so this connector is inert. Reviving it requires
+        # working access from the account manager, then re-pointing SEARCH_URL at the
+        # documented searchpart path and validating the (currently unknowable)
+        # response shape against _OFFER_KEYS.
         if not isinstance(data, dict):
             logger.warning(
                 "Sourcengine: 200 response for {} was not a JSON object ({}) — response shape may have drifted",


### PR DESCRIPTION
Closes the last loose end of the API-search core sprint (Phase-4 "validate/disable Sourcengine parser").

**Live validation performed 2026-07-15** with the configured `SOURCENGINE_API_KEY`:
- `GET https://api.sourcengine.com/v1/search` (the connector's coded endpoint) → **HTTP 530, Cloudflare error 1016** (origin DNS failure).
- `GET https://api.sourcengine.com/app/api/search/parts/searchpart` (the documented endpoint) → same 530/1016. The bare host too — the official API host is dead end-to-end.
- `https://sourcengine.com/app/api/search/parts/searchpart` → Cloudflare browser challenge (webapp-internal, not server-usable).
- Docs (dev.sourcengine.com) confirm base URL `api.sourcengine.com` + `Authorization: Bearer` — matching the connector — with tokens issued by a Sourcengine account manager.
- Live `api_sources` row: `status=disabled`, `is_active=false`, zero successes ever recorded.

**Verdict:** the connector is inert and correctly disabled; nothing to fix in code today. This PR is comment-only — it replaces the open FLAG in `_parse()` with the dated verdict and the concrete revive path (account-manager access → re-point SEARCH_URL → validate response shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)