### PR TITLE
chore(hooks): bump mirrors-mypy to v2.3.0 — lockstep with mypy 2.3.0 lockfile (#726 follow-up)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
   # isolated hook venv sees the same types as a full-dep run. Bump these pins
   # together with the requirements lockfiles.
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         args: [--ignore-missing-imports, --no-strict-optional, --config-file=pyproject.toml, app/]


### PR DESCRIPTION
PR #726 bumped `requirements-dev.txt` to mypy 2.3.0, leaving the pre-commit hook env on v2.1.0 — the exact hook-vs-CI divergence class that P2.9 (PR #714) eliminated, and the config comment above the hook says these pins move together.

One-line bump. Verified with a fresh hook env build: `pre-commit run mypy --all-files` → **Success: no issues found in 560 source files** (mypy 2.3.0), and full `pre-commit run --all-files` green.

Noted during the #735 debt work (its leftovers list); this closes that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)