### PR TITLE
Bound GraphClient delta_query resume + stop silent truncation / delta-token loss

### DIFF
--- a/app/connectors/email_mining.py
+++ b/app/connectors/email_mining.py
@@ -257,6 +257,10 @@ class EmailMiner:
                     delta_token=delta_token,
                     params={"$select": MSG_SELECT, "$top": "50"},
                     max_items=max_messages,
+                    max_page_size=50,
+                    # Bound the initial full-sync round to the same window the
+                    # keyword-search fallback below scans.
+                    initial_lookback_days=lookback_days,
                 )
                 messages = items
                 used_delta = True
@@ -269,6 +273,8 @@ class EmailMiner:
                 messages = []
                 used_delta = False
             except Exception as e:
+                # Any other failure (typed error page, network) keeps the token —
+                # it was never advanced past unfetched data — and falls back.
                 logger.warning(f"Delta query failed for mining, falling back to search: {e}")
                 messages = []
                 used_delta = False
@@ -494,6 +500,11 @@ class EmailMiner:
                     delta_token=delta_token,
                     params={"$select": SENT_SELECT, "$top": "50"},
                     max_items=max_messages,
+                    max_page_size=50,
+                    # Bound the initial full-sync round to the same window the
+                    # search fallback below scans (delta only supports filtering
+                    # on receivedDateTime, ≈ sentDateTime for sent items).
+                    initial_lookback_days=lookback_days,
                 )
                 messages = items
                 used_delta = True
@@ -506,6 +517,8 @@ class EmailMiner:
                 messages = []
                 used_delta = False
             except Exception as e:
+                # Any other failure (typed error page, network) keeps the token —
+                # it was never advanced past unfetched data — and falls back.
                 logger.warning(f"Delta query failed for SentItems, falling back: {e}")
                 messages = []
                 used_delta = False

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -602,8 +602,9 @@ async def poll_inbox(
 
     Returns list of new responses found (already saved to DB).
     """
+    from app.config import settings
     from app.models import SyncState
-    from app.utils.graph_client import GraphClient
+    from app.utils.graph_client import GraphAPIError, GraphClient, GraphSyncStateExpired
 
     gc = GraphClient(token)
 
@@ -630,6 +631,11 @@ async def poll_inbox(
                     "$top": "50",
                 },
                 max_items=200,
+                max_page_size=50,
+                # Bound the initial full-sync round (and thus the whole resumable
+                # drain) to the standard first-time backfill window instead of the
+                # entire mailbox history.
+                initial_lookback_days=settings.inbox_backfill_days,
             )
             messages = items
             used_delta = True
@@ -648,17 +654,35 @@ async def poll_inbox(
                     )
                     db.add(sync)
                 db.flush()
-        except Exception as e:
-            err_str = str(e).lower()
-            if "401" in err_str or "403" in err_str or "unauthorized" in err_str:
-                logger.error(f"Inbox auth failure (not falling back): {e}")
-                raise
-            logger.warning(f"Delta query failed, falling back to full scan: {e}")
+        except GraphSyncStateExpired as e:
+            # 410 — Graph itself says the stored token is invalid. This is the
+            # ONLY condition under which clearing it is correct; the fallback
+            # full scan covers this poll and the next delta round starts fresh.
+            logger.warning(f"Inbox delta token expired (410) — clearing and falling back: {e}")
             if sync and sync.delta_token:
                 sync.delta_token = None
                 db.flush()
             messages = []
             used_delta = False
+        except GraphAPIError as e:
+            # Typed error page mid-round — delta_query did NOT return a token, so
+            # the stored one still points at the unfetched data and the next poll
+            # resumes incrementally. Do NOT clear it; auth failures bubble up so
+            # the caller marks the poll failed (no silent success).
+            if e.status in (401, 403):
+                logger.error(f"Inbox auth failure (not falling back): {e}")
+                raise
+            logger.warning(f"Inbox delta hit Graph error page (token kept), falling back to full scan: {e}")
+            messages = []
+            used_delta = False
+        except Exception as e:
+            # Transient/network error (e.g. httpx.ReadTimeout re-raised by the
+            # retry layer). The stored token is still valid — clearing it would
+            # force a full re-enumeration of the backfill window — so keep it and
+            # surface a failed poll (the same outage would break the fallback
+            # scan too).
+            logger.error(f"Inbox delta failed (token kept): {e}")
+            raise
 
     # ── Fallback: traditional top-50 fetch ──
     if not messages and not used_delta:
@@ -671,6 +695,11 @@ async def poll_inbox(
                     "$select": "id,subject,from,receivedDateTime,bodyPreview,body,conversationId",
                 },
             )
+            if data and "error" in data:
+                # The retry layer signals exhausted retries / non-retryable 4xx
+                # as an {"error": ...} dict — a hard Graph outage must surface
+                # as a failed poll, not a successful empty one.
+                raise GraphAPIError(data["error"], str(data.get("detail", "")))
             messages = data.get("value", []) if data else []
         except Exception as e:
             logger.error(f"Inbox poll failed: {e}")

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -618,6 +618,9 @@ async def _sync_user_contacts(user, db):
     delta_token = sync_state.delta_token if sync_state else None
 
     try:
+        # No initial_lookback_days: contacts deltas don't support the
+        # receivedDateTime filter, and an address book is a finite collection —
+        # draining it fully on the initial round IS the desired full sync.
         contacts, new_token = await gc.delta_query(
             "/me/contacts/delta",
             delta_token=delta_token,
@@ -626,6 +629,7 @@ async def _sync_user_contacts(user, db):
                 "$top": "100",
             },
             max_items=2500,
+            max_page_size=100,
         )
         # Persist new delta token
         if new_token:
@@ -661,7 +665,9 @@ async def _sync_user_contacts(user, db):
             logger.warning(f"Contacts sync failed for {user.email}: {e}")
             return
     except Exception as e:
-        logger.warning(f"Contacts sync failed for {user.email}: {e}")
+        # Typed error page or network failure — no token was returned, so the
+        # stored one still covers the unfetched data; next run resumes from it.
+        logger.warning(f"Contacts sync failed for {user.email} (token kept): {e}")
         return
 
     enriched = 0
@@ -778,6 +784,7 @@ async def scan_sent_folder(user, db):
 
     from app.utils.graph_client import GraphClient, GraphSyncStateExpired
 
+    from ..config import settings
     from ..models import SyncState
     from ..models.intelligence import ActivityLog
     from ..utils.token_manager import get_valid_token
@@ -804,6 +811,11 @@ async def scan_sent_folder(user, db):
             delta_token=delta_token,
             params=delta_params,
             max_items=500,
+            max_page_size=100,
+            # Bound the initial full-sync round (and thus the whole resumable
+            # drain) to the standard first-time backfill window instead of the
+            # entire Sent Items history.
+            initial_lookback_days=settings.inbox_backfill_days,
         )
     except GraphSyncStateExpired:
         logger.warning(f"Sent folder delta expired for {user.email} — full resync")
@@ -815,7 +827,12 @@ async def scan_sent_folder(user, db):
             delta_token=None,
             params=delta_params,
             max_items=500,
+            max_page_size=100,
+            initial_lookback_days=settings.inbox_backfill_days,
         )
+    # GraphAPIError (typed error page — token NOT advanced) intentionally
+    # propagates: _job_scan_sent_folders logs it per-user and rolls back, so the
+    # run is marked failed and the next scan resumes from the kept token.
 
     # Persist new delta token
     if new_token:

--- a/app/services/faceted_search_service.py
+++ b/app/services/faceted_search_service.py
@@ -240,7 +240,8 @@ def get_facet_counts(
         )
         if only_spec_key is not None:
             q = q.filter(MaterialSpecFacet.spec_key == only_spec_key)
-        return q.group_by(MaterialSpecFacet.spec_key, MaterialSpecFacet.value_numeric).all()
+        rows: list = q.group_by(MaterialSpecFacet.spec_key, MaterialSpecFacet.value_numeric).all()
+        return rows
 
     # Pass 1: every facet narrowed by ALL active filters — correct for facets the user has NOT
     # filtered on (they should reflect the full current narrowing).

--- a/app/utils/graph_client.py
+++ b/app/utils/graph_client.py
@@ -11,6 +11,7 @@ Usage:
 
 import asyncio
 import os
+from datetime import UTC, datetime, timedelta
 from typing import cast
 
 from loguru import logger
@@ -23,6 +24,22 @@ GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 class GraphSyncStateExpired(Exception):
     """Raised when Graph API returns 410 — the delta token is stale and must be
     discarded."""
+
+
+class GraphAPIError(Exception):
+    """Raised when a paged request (delta_query / get_all_pages) hits an error page.
+
+    _request_with_retry returns ``{"error": <status>, "detail": ...}`` dicts for
+    non-retryable failures (401/4xx/max_retries) — a contract webhook_service
+    branches on, so it stays. Pagination helpers must NOT treat those dicts as
+    empty pages (that silently ends the round and lets callers persist a token
+    past unfetched data), so they raise this instead.
+    """
+
+    def __init__(self, status: int | str, detail: str = ""):
+        self.status = status
+        self.detail = detail
+        super().__init__(f"Graph API error {status}: {detail}")
 
 
 # H1: Immutable IDs — prevents ID changes when messages are moved between folders
@@ -72,7 +89,9 @@ class GraphClient:
     ) -> list[dict]:
         """GET with auto-pagination.
 
-        Returns flat list of items.
+        Returns a flat list of items, truncated to max_items. An error page
+        ({"error": ...} from the retry layer) raises GraphAPIError instead of
+        silently returning the short list fetched so far.
         """
         url = path if path.startswith("http") else f"{GRAPH_BASE}{path}"
         items: list[dict] = []
@@ -80,6 +99,8 @@ class GraphClient:
             data = await self._request_with_retry(
                 "GET", url, params=params if GRAPH_BASE in url else None, timeout=timeout
             )
+            if "error" in data:
+                raise GraphAPIError(data["error"], str(data.get("detail", "")))
             items.extend(data.get("value", []))
             url = data.get("@odata.nextLink")
             params = None  # nextLink has params baked in
@@ -128,37 +149,81 @@ class GraphClient:
         params: dict | None = None,
         max_items: int = 1000,
         timeout: int = 30,
+        max_page_size: int | None = None,
+        initial_lookback_days: int | None = None,
     ) -> tuple[list[dict], str | None]:
-        """Run a Delta Query. Returns (items, new_delta_token).
+        """Run a Delta Query. Returns (items, new_state_token).
 
-        If delta_token is None, performs a full sync and returns the initial token. On
-        subsequent calls, only returns changes since the last token.
+        If delta_token is None, performs a full sync from ``path``; otherwise it
+        resumes from the stored token URL (a deltaLink OR a mid-round nextLink —
+        both are opaque, durable Graph URLs and are interchangeable here).
+
+        Contract — fetched items are NEVER dropped:
+        - Round completes → (all items, deltaLink).
+        - max_items reached mid-round → stop paging and return (all items fetched
+          so far, current nextLink). The nextLink is the resumable state: persist
+          it exactly like a deltaLink and the next call finishes the round.
+          Because whole pages are returned, len(items) may exceed max_items by up
+          to one page — max_items is a paging budget, not a slice.
+        - Error page ({"error": ...} from the retry layer) → raise GraphAPIError;
+          no token is returned, so sync state cannot advance past unfetched data.
+
+        Initial full-sync rounds (delta_token=None) enumerate the ENTIRE
+        collection — because the nextLink is resumable state, successive calls
+        WILL drain it all. For message folders that means the whole mailbox
+        history, so callers MUST bound it with initial_lookback_days: it adds
+        ``$filter=receivedDateTime ge {ts}`` to the initial request — the only
+        $filter Graph supports on message deltas — and Graph bakes the filter
+        into every nextLink/deltaLink it returns, so the bound sticks for the
+        life of the sync state (a filtered round also returns at most 5,000
+        messages, per Graph docs). Ignored when resuming from a token. Leave it
+        None for non-message deltas (e.g. /me/contacts/delta) — they don't
+        support this filter and are finite collections anyway.
+
+        max_page_size sets "Prefer: odata.maxpagesize" (the documented page-size
+        control for delta queries), preserving the ImmutableId preference (H1).
         """
         url = path if path.startswith("http") else f"{GRAPH_BASE}{path}"
         if delta_token:
-            # Use the stored delta link directly
+            # Use the stored state URL (deltaLink or nextLink) directly
             url = delta_token
             params = None
+        elif initial_lookback_days:
+            since = (datetime.now(UTC) - timedelta(days=initial_lookback_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            params = {**(params or {}), "$filter": f"receivedDateTime ge {since}"}
+
+        headers: dict[str, str] | None = None
+        if max_page_size:
+            # Prefer values combine — keep IdType="ImmutableId" (H1) alongside.
+            headers = {"Prefer": f"{IMMUTABLE_ID_HEADER['Prefer']}, odata.maxpagesize={max_page_size}"}
 
         items: list[dict] = []
-        new_token: str | None = None
-
-        while url and len(items) < max_items:
-            data = await self._request_with_retry(
-                "GET", url, params=params if not delta_token else None, timeout=timeout
-            )
+        while True:
+            data = await self._request_with_retry("GET", url, params=params, timeout=timeout, headers=headers)
+            if "error" in data:
+                raise GraphAPIError(data["error"], str(data.get("detail", "")))
             items.extend(data.get("value", []))
 
-            # Check for delta link (means we've consumed all changes)
-            new_token = data.get("@odata.deltaLink")
-            if new_token:
-                break
+            # Delta link → round complete, all changes consumed
+            delta_link: str | None = data.get("@odata.deltaLink")
+            if delta_link:
+                return items, delta_link
 
-            # More pages of changes
-            url = data.get("@odata.nextLink")
-            params = None
+            next_link: str | None = data.get("@odata.nextLink")
+            if not next_link:
+                # Defensive: Graph ends every delta round with a deltaLink, so a
+                # link-less page is an anomaly — return None so the caller keeps
+                # its previous token rather than persisting bogus state.
+                logger.warning(f"Delta page had neither deltaLink nor nextLink: {url[:120]}")
+                return items, None
 
-        return items[:max_items], new_token
+            if len(items) >= max_items:
+                # Per-run budget reached — the nextLink is durable, resumable
+                # state; the next run picks up the round exactly here.
+                return items, next_link
+
+            url = next_link
+            params = None  # nextLink has params baked in
 
     # ── Internal retry logic ────────────────────────────────────────
 
@@ -169,8 +234,13 @@ class GraphClient:
         params: dict | None = None,
         json_data: dict | None = None,
         timeout: int = 30,
+        headers: dict[str, str] | None = None,
     ) -> dict:
         """Execute HTTP request with retry logic.
+
+        headers, when given, are merged OVER the constructor-level base headers
+        for this request only (a per-request "Prefer" replaces the base one, so
+        callers overriding it must re-include IdType="ImmutableId").
 
         Retry strategy:
         - 429 (rate limit): always retry, honor Retry-After header (use max of
@@ -182,15 +252,16 @@ class GraphClient:
         - 410 (delta token expired): raise GraphSyncStateExpired immediately.
         """
         last_error: Exception | None = None
+        request_headers = self._base_headers if headers is None else {**self._base_headers, **headers}
 
         for attempt in range(MAX_RETRIES + 1):
             try:
                 if method == "GET":
-                    resp = await http.get(url, params=params, headers=self._base_headers, timeout=timeout)
+                    resp = await http.get(url, params=params, headers=request_headers, timeout=timeout)
                 elif method == "PATCH":
-                    resp = await http.patch(url, json=json_data, headers=self._base_headers, timeout=timeout)
+                    resp = await http.patch(url, json=json_data, headers=request_headers, timeout=timeout)
                 else:
-                    resp = await http.post(url, json=json_data, headers=self._base_headers, timeout=timeout)
+                    resp = await http.post(url, json=json_data, headers=request_headers, timeout=timeout)
 
                 # Success
                 if resp.status_code in (200, 201):

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1307,6 +1307,32 @@ email_service.poll_inbox()
     +---> graph_client.py --> Graph API: GET inbox messages
     |       (delta query incremental sync when available; top-50 fallback —
     |        ALL messages fetched, matching happens locally below)
+    |       delta_query contract: fetched items are NEVER dropped — when the
+    |       per-run max_items budget is hit mid-round it stops paging and
+    |       returns the current @odata.nextLink as the resumable state token
+    |       (persisted into SyncState.delta_token exactly like a deltaLink;
+    |       both are opaque Graph URLs, so backlogs > cap drain across runs
+    |       instead of stalling). Because the nextLink is resumable, an
+    |       UNBOUNDED initial round would drain the whole mailbox history —
+    |       so message-delta call sites pass initial_lookback_days, which adds
+    |       "$filter=receivedDateTime ge {ts}" (the only $filter Graph supports
+    |       on message deltas; baked by Graph into every subsequent link, max
+    |       5,000 msgs per filtered round) to the first request: poll_inbox and
+    |       scan_sent_folder use settings.inbox_backfill_days; EmailMiner
+    |       scan_inbox/scan_sent_items use their own lookback_days (same window
+    |       as their search fallbacks). /me/contacts/delta stays unbounded —
+    |       the filter is unsupported there and an address book is finite.
+    |       Page size via "Prefer: odata.maxpagesize" (max_page_size param,
+    |       keeps IdType="ImmutableId"). An {"error": ...} page raises typed
+    |       GraphAPIError (also from get_all_pages) instead of reading as an
+    |       empty page — callers log + fail the run and the token is NOT
+    |       advanced. poll_inbox failure ladder: 410/GraphSyncStateExpired is
+    |       the ONLY case that clears the token (then full-scan fallback);
+    |       GraphAPIError keeps the token and falls back (401/403 re-raise);
+    |       any other exception (transient/network) keeps the token and
+    |       re-raises so the poll is recorded as FAILED — and the top-50
+    |       fallback itself raises GraphAPIError on an {"error": ...} body
+    |       instead of reporting a successful empty poll.
     |
     +---> reply matching (first tier that hits wins; exact before fuzzy):
     |       Tier 1: graph_conversation_id (global, exact) — matches ALL
@@ -3600,7 +3626,8 @@ selection the calendar/inbox jobs use — resolves a token via
 `token_manager.get_valid_token(user, db)`, builds `GraphClient(token)`, and calls
 `prospect_discovery_email.run_email_mining_batch(...)`. `mine_unknown_domains` lists the
 inbox via `GraphClient.get_all_pages("/me/mailFolders/inbox/messages", params={$filter,
-$select, $orderby, $top})`, which auto-paginates and returns a flat list of message dicts.
+$select, $orderby, $top})`, which auto-paginates and returns a flat list of message dicts
+(an `{"error": ...}` page raises typed `GraphAPIError` instead of reading as empty).
 No mailbox or no token ⇒ the branch logs a warning and skips (email_count stays 0); the
 surrounding `except` keeps the scheduler resilient. (There is no `get_graph_client()`
 factory and `GraphClient` has no `list_messages` — both were dead references, now fixed.)

--- a/tests/test_email_jobs.py
+++ b/tests/test_email_jobs.py
@@ -966,6 +966,35 @@ class TestScanSentFolder:
             assert sync_state.delta_token is None or sync_state.delta_token == "new-token"
 
     @pytest.mark.asyncio
+    async def test_scan_initial_sync_bounded_by_backfill_lookback(self):
+        """The initial SentItems delta round (and the post-410 resync) must be bounded
+        to the backfill window — the resumable-nextLink contract would otherwise drain
+        the entire folder history across runs."""
+        from app.config import settings
+        from app.jobs.email_jobs import scan_sent_folder
+        from app.utils.graph_client import GraphSyncStateExpired
+
+        user = MagicMock()
+        user.id = 1
+        user.email = "buyer@trioscs.com"
+        sync_state = MagicMock()
+        sync_state.delta_token = "old"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = sync_state
+
+        gc_mock = MagicMock()
+        gc_mock.delta_query = AsyncMock(side_effect=[GraphSyncStateExpired("expired"), ([], "new-token")])
+
+        with (
+            patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
+        ):
+            await scan_sent_folder(user, mock_db)
+
+        for call in gc_mock.delta_query.call_args_list:
+            assert call.kwargs["initial_lookback_days"] == settings.inbox_backfill_days
+
+    @pytest.mark.asyncio
     async def test_scan_with_attachments(self):
         from app.jobs.email_jobs import scan_sent_folder
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -58,6 +58,7 @@ from app.models import (
     User,
     VendorResponse,
 )
+from app.utils.graph_client import GraphSyncStateExpired
 
 # ── _build_html_body ─────────────────────────────────────────────────
 
@@ -2223,10 +2224,10 @@ class TestPollInbox:
         assert sync.delta_token == "existing-token"
 
     @pytest.mark.asyncio
-    async def test_delta_failure_fallback(self, db_session, test_user, test_requisition):
-        """When delta query fails, fall back to full fetch."""
+    async def test_delta_expired_fallback(self, db_session, test_user, test_requisition):
+        """When the delta token expires (410), fall back to full fetch."""
         mock_gc = AsyncMock()
-        mock_gc.delta_query.side_effect = Exception("Delta gone")
+        mock_gc.delta_query.side_effect = GraphSyncStateExpired("SyncStateNotFound")
         mock_gc.get_json.return_value = {"value": [self._make_inbox_message()]}
 
         with (
@@ -2243,9 +2244,9 @@ class TestPollInbox:
         assert len(results) == 1
 
     @pytest.mark.asyncio
-    async def test_delta_failure_clears_stale_token(self, db_session, test_user, test_requisition):
-        """When delta query fails (e.g. 410), the stale delta_token is cleared from
-        SyncState."""
+    async def test_delta_expired_clears_stale_token(self, db_session, test_user, test_requisition):
+        """A 410 (GraphSyncStateExpired) is the ONLY delta failure that clears the
+        stored delta_token from SyncState."""
         sync = SyncState(
             user_id=test_user.id,
             folder="inbox",
@@ -2256,7 +2257,7 @@ class TestPollInbox:
         db_session.commit()
 
         mock_gc = AsyncMock()
-        mock_gc.delta_query.side_effect = Exception("410 SyncStateNotFound")
+        mock_gc.delta_query.side_effect = GraphSyncStateExpired("410 SyncStateNotFound")
         mock_gc.get_json.return_value = {"value": [self._make_inbox_message()]}
 
         with (
@@ -2274,6 +2275,140 @@ class TestPollInbox:
         # Stale delta token must be cleared so next poll starts fresh
         sync = db_session.query(SyncState).first()
         assert sync.delta_token is None
+
+    @pytest.mark.asyncio
+    async def test_graph_error_page_keeps_delta_token_and_falls_back(self, db_session, test_user, test_requisition):
+        """A typed Graph error page mid-delta must NOT clear the stored token —
+        delta_query never advanced it, so the next poll resumes incrementally.
+
+        This poll falls back to a full scan.
+        """
+        from app.utils.graph_client import GraphAPIError
+
+        sync = SyncState(
+            user_id=test_user.id,
+            folder="inbox",
+            delta_token="mid-round-token",
+            last_sync_at=datetime.now(UTC),
+        )
+        db_session.add(sync)
+        db_session.commit()
+
+        mock_gc = AsyncMock()
+        mock_gc.delta_query.side_effect = GraphAPIError(503, "max_retries")
+        mock_gc.get_json.return_value = {"value": [self._make_inbox_message()]}
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(
+                token="fake-token",
+                db=db_session,
+                requisition_id=test_requisition.id,
+                scanned_by_user_id=test_user.id,
+            )
+
+        assert len(results) == 1  # fallback full scan still processed the inbox
+        sync = db_session.query(SyncState).first()
+        assert sync.delta_token == "mid-round-token"  # token kept, NOT cleared
+
+    @pytest.mark.asyncio
+    async def test_graph_error_page_auth_status_raises(self, db_session, test_user, test_requisition):
+        """A 401 Graph error page raises (poll marked failed) instead of the old silent
+        success with zero messages."""
+        from app.utils.graph_client import GraphAPIError
+
+        mock_gc = AsyncMock()
+        mock_gc.delta_query.side_effect = GraphAPIError(401, "token expired")
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            with pytest.raises(GraphAPIError):
+                await poll_inbox(
+                    token="fake-token",
+                    db=db_session,
+                    requisition_id=test_requisition.id,
+                    scanned_by_user_id=test_user.id,
+                )
+        mock_gc.get_json.assert_not_called()  # no fallback on auth failure
+
+    @pytest.mark.asyncio
+    async def test_transient_error_keeps_delta_token_and_fails_poll(self, db_session, test_user, test_requisition):
+        """A transient/network exception (httpx.ReadTimeout re-raised by the retry
+        layer) must NOT clear the stored token — it is still valid — and must surface as
+        a failed poll, not fall back to a full scan."""
+        import httpx
+
+        sync = SyncState(
+            user_id=test_user.id,
+            folder="inbox",
+            delta_token="still-valid-token",
+            last_sync_at=datetime.now(UTC),
+        )
+        db_session.add(sync)
+        db_session.commit()
+
+        mock_gc = AsyncMock()
+        mock_gc.delta_query.side_effect = httpx.ReadTimeout("timed out")
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            with pytest.raises(httpx.ReadTimeout):
+                await poll_inbox(
+                    token="fake-token",
+                    db=db_session,
+                    requisition_id=test_requisition.id,
+                    scanned_by_user_id=test_user.id,
+                )
+
+        mock_gc.get_json.assert_not_called()  # failed poll, not a fallback scan
+        sync = db_session.query(SyncState).first()
+        assert sync.delta_token == "still-valid-token"  # token survives
+
+    @pytest.mark.asyncio
+    async def test_fallback_error_dict_raises(self, db_session, test_user, test_requisition):
+        """An {"error": ...} dict from the fallback fetch (exhausted retries) must raise
+        — a hard Graph outage is a failed poll, not a successful empty one."""
+        from app.utils.graph_client import GraphAPIError
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {"error": "max_retries", "detail": "All retries exhausted"}
+
+        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+            with pytest.raises(GraphAPIError):
+                await poll_inbox(
+                    token="fake-token",
+                    db=db_session,
+                    requisition_id=test_requisition.id,
+                )
+
+    @pytest.mark.asyncio
+    async def test_initial_sync_bounded_by_backfill_lookback(self, db_session, test_user, test_requisition):
+        """The initial delta round (no stored token) must be bounded to the standard
+        backfill window — otherwise the resumable-nextLink contract would drain the
+        entire mailbox history across polls."""
+        from app.config import settings
+
+        mock_gc = AsyncMock()
+        mock_gc.delta_query.return_value = ([], "initial-delta-token")
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            await poll_inbox(
+                token="fake-token",
+                db=db_session,
+                requisition_id=test_requisition.id,
+                scanned_by_user_id=test_user.id,
+            )
+
+        assert mock_gc.delta_query.call_args.kwargs["initial_lookback_days"] == settings.inbox_backfill_days
 
     @pytest.mark.asyncio
     async def test_fallback_fetch_failure_raises(self, db_session, test_user, test_requisition):
@@ -2497,6 +2632,8 @@ class TestPollInbox:
         db_session.commit()
 
         mock_gc = AsyncMock()
+        # Expired delta token → explicit fall back to the get_json full scan
+        mock_gc.delta_query.side_effect = GraphSyncStateExpired("expired")
         mock_gc.get_json.return_value = {
             "value": [
                 self._make_inbox_message(
@@ -2536,6 +2673,8 @@ class TestPollInbox:
         db_session.commit()
 
         mock_gc = AsyncMock()
+        # Expired delta token → explicit fall back to the get_json full scan
+        mock_gc.delta_query.side_effect = GraphSyncStateExpired("expired")
         mock_gc.get_json.return_value = {
             "value": [
                 self._make_inbox_message(
@@ -2575,6 +2714,8 @@ class TestPollInbox:
         db_session.commit()
 
         mock_gc = AsyncMock()
+        # Expired delta token → explicit fall back to the get_json full scan
+        mock_gc.delta_query.side_effect = GraphSyncStateExpired("expired")
         # This email is from microsoft.com but with a non-noise prefix
         # However, _is_noise_email checks domain first, so it gets filtered
         mock_gc.get_json.return_value = {
@@ -2923,6 +3064,8 @@ class TestPollInbox:
         db_session.commit()
 
         mock_gc = AsyncMock()
+        # Expired delta token → explicit fall back to the get_json full scan
+        mock_gc.delta_query.side_effect = GraphSyncStateExpired("expired")
         mock_gc.get_json.return_value = {
             "value": [
                 self._make_inbox_message(

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -7,12 +7,13 @@ Called by: pytest
 Depends on: app/utils/graph_client.py
 """
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import app.utils.graph_client as _gc_mod
-from app.utils.graph_client import GraphClient, GraphSyncStateExpired
+from app.utils.graph_client import GraphAPIError, GraphClient, GraphSyncStateExpired
 
 
 @pytest.fixture(autouse=True)
@@ -307,6 +308,264 @@ class TestGraphClientDelta:
         assert len(items) == 2
         assert token == "https://graph.microsoft.com/v1.0/delta?token=final"
         assert mock_http.get.call_count == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Delta Query — truncation contract (never drop items, resumable nextLink)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDeltaQueryTruncationContract:
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_budget_hit_returns_nextlink_and_stops_paging(self, mock_http):
+        """When max_items is reached mid-round, delta_query stops paging and returns the
+        current nextLink as resumable state — it must NOT keep fetching and must NOT
+        return new_token=None."""
+        page1 = _mock_response(
+            200,
+            {
+                "value": [{"id": "m1"}, {"id": "m2"}, {"id": "m3"}],
+                "@odata.nextLink": "https://graph.microsoft.com/v1.0/delta?$skiptoken=page2",
+            },
+        )
+        mock_http.get = AsyncMock(return_value=page1)
+
+        gc = GraphClient("test-token")
+        items, token = await gc.delta_query("/me/mailFolders/Inbox/messages/delta", max_items=3)
+
+        assert [i["id"] for i in items] == ["m1", "m2", "m3"]
+        assert token == "https://graph.microsoft.com/v1.0/delta?$skiptoken=page2"
+        assert mock_http.get.call_count == 1  # budget hit → no second fetch
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_budget_overshoot_keeps_every_fetched_item(self, mock_http):
+        """A fetched page is NEVER sliced: if the page overshoots max_items,
+        all its items are returned alongside the resumable nextLink."""
+        mock_http.get = AsyncMock(
+            return_value=_mock_response(
+                200,
+                {
+                    "value": [{"id": f"m{i}"} for i in range(5)],
+                    "@odata.nextLink": "https://graph.microsoft.com/v1.0/delta?$skiptoken=p2",
+                },
+            )
+        )
+
+        gc = GraphClient("test-token")
+        items, token = await gc.delta_query("/me/mailFolders/Inbox/messages/delta", max_items=3)
+
+        assert len(items) == 5  # old code sliced to 3 and lost m3/m4 forever
+        assert token == "https://graph.microsoft.com/v1.0/delta?$skiptoken=p2"
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_resume_from_persisted_nextlink_completes_round(self, mock_http):
+        """A nextLink persisted as the delta token resumes the round exactly where it
+        stopped and finishes with the final deltaLink."""
+        next_link = "https://graph.microsoft.com/v1.0/delta?$skiptoken=page2"
+        mock_http.get = AsyncMock(
+            return_value=_mock_response(
+                200,
+                {
+                    "value": [{"id": "m4"}, {"id": "m5"}],
+                    "@odata.deltaLink": "https://graph.microsoft.com/v1.0/delta?token=final",
+                },
+            )
+        )
+
+        gc = GraphClient("test-token")
+        items, token = await gc.delta_query(
+            "/me/mailFolders/Inbox/messages/delta", delta_token=next_link, max_items=500
+        )
+
+        assert [i["id"] for i in items] == ["m4", "m5"]
+        assert token == "https://graph.microsoft.com/v1.0/delta?token=final"
+        # Resumed from the persisted nextLink URL, not from the base path
+        first_call = mock_http.get.call_args_list[0]
+        assert next_link in str(first_call)
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_backlog_larger_than_cap_advances_across_runs(self, mock_http):
+        """Backlog > cap twice in a row: each run advances (distinct tokens, distinct
+        items) and the round eventually terminates — no permanent stall refetching the
+        same first-N items."""
+        pages = {
+            "https://graph.microsoft.com/v1.0/me/x/delta": {
+                "value": [{"id": "m1"}, {"id": "m2"}],
+                "@odata.nextLink": "https://g/next1",
+            },
+            "https://g/next1": {
+                "value": [{"id": "m3"}, {"id": "m4"}],
+                "@odata.nextLink": "https://g/next2",
+            },
+            "https://g/next2": {
+                "value": [{"id": "m5"}],
+                "@odata.deltaLink": "https://g/delta-final",
+            },
+        }
+
+        async def _get(url, **kwargs):
+            return _mock_response(200, pages[url])
+
+        mock_http.get = AsyncMock(side_effect=_get)
+        gc = GraphClient("test-token")
+
+        items1, token1 = await gc.delta_query("/me/x/delta", max_items=2)
+        assert [i["id"] for i in items1] == ["m1", "m2"]
+        assert token1 == "https://g/next1"
+
+        items2, token2 = await gc.delta_query("/me/x/delta", delta_token=token1, max_items=2)
+        assert [i["id"] for i in items2] == ["m3", "m4"]
+        assert token2 == "https://g/next2"
+        assert token2 != token1  # progress, not a stall
+
+        items3, token3 = await gc.delta_query("/me/x/delta", delta_token=token2, max_items=2)
+        assert [i["id"] for i in items3] == ["m5"]
+        assert token3 == "https://g/delta-final"
+
+        all_ids = [i["id"] for i in items1 + items2 + items3]
+        assert all_ids == ["m1", "m2", "m3", "m4", "m5"]  # complete, no dupes
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_max_page_size_sets_prefer_header_keeping_immutable_id(self, mock_http):
+        """max_page_size adds odata.maxpagesize to Prefer WITHOUT dropping the
+        ImmutableId preference (H1)."""
+        mock_http.get = AsyncMock(return_value=_mock_response(200, {"value": [], "@odata.deltaLink": "https://g/d"}))
+
+        gc = GraphClient("test-token")
+        await gc.delta_query("/me/x/delta", max_page_size=50)
+
+        prefer = mock_http.get.call_args.kwargs["headers"]["Prefer"]
+        assert "odata.maxpagesize=50" in prefer
+        assert "ImmutableId" in prefer
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Delta Query — initial full-sync bound (initial_lookback_days)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDeltaQueryInitialLookback:
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_initial_round_applies_receiveddatetime_filter(self, mock_http):
+        """With no stored token, initial_lookback_days adds the only $filter Graph
+        supports on message deltas — bounding the round (and, since Graph bakes the
+        filter into its links, every resumed continuation) to recent history instead of
+        the entire mailbox."""
+        mock_http.get = AsyncMock(return_value=_mock_response(200, {"value": [], "@odata.deltaLink": "https://g/d"}))
+
+        gc = GraphClient("test-token")
+        await gc.delta_query("/me/mailFolders/Inbox/messages/delta", params={"$top": "50"}, initial_lookback_days=180)
+
+        params = mock_http.get.call_args.kwargs["params"]
+        assert params["$top"] == "50"  # caller params preserved
+        flt = params["$filter"]
+        assert flt.startswith("receivedDateTime ge ")
+        since = datetime.strptime(flt.removeprefix("receivedDateTime ge "), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+        assert abs(since - (datetime.now(UTC) - timedelta(days=180))) < timedelta(minutes=5)
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_resumed_round_ignores_lookback(self, mock_http):
+        """Resuming from a stored token URL sends no params — the filter is already
+        baked into the deltaLink/nextLink by Graph."""
+        mock_http.get = AsyncMock(return_value=_mock_response(200, {"value": [], "@odata.deltaLink": "https://g/d2"}))
+
+        gc = GraphClient("test-token")
+        await gc.delta_query("/me/x/delta", delta_token="https://g/next1", initial_lookback_days=180)
+
+        assert mock_http.get.call_args.kwargs["params"] is None
+        assert "https://g/next1" in str(mock_http.get.call_args)
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_initial_round_without_lookback_is_unfiltered(self, mock_http):
+        """Omitting initial_lookback_days (non-message deltas like /me/contacts that
+        don't support the receivedDateTime filter) sends the caller's params
+        untouched."""
+        mock_http.get = AsyncMock(return_value=_mock_response(200, {"value": [], "@odata.deltaLink": "https://g/d"}))
+
+        gc = GraphClient("test-token")
+        await gc.delta_query("/me/contacts/delta", params={"$top": "100"})
+
+        params = mock_http.get.call_args.kwargs["params"]
+        assert params == {"$top": "100"}
+        assert "$filter" not in params
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Error-dict pages — typed GraphAPIError instead of silent empty pages
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestGraphErrorPages:
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_delta_error_page_mid_pagination_raises_typed(self, mock_http):
+        """An error page mid-round raises GraphAPIError; no token is returned so the
+        caller cannot advance its sync state past the failure."""
+        mock_http.get = AsyncMock(
+            side_effect=[
+                _mock_response(
+                    200,
+                    {"value": [{"id": "m1"}], "@odata.nextLink": "https://g/next"},
+                ),
+                _mock_response(400, text="Bad Request"),
+            ]
+        )
+
+        gc = GraphClient("test-token")
+        with pytest.raises(GraphAPIError) as exc_info:
+            await gc.delta_query("/me/x/delta", max_items=500)
+        assert exc_info.value.status == 400
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_delta_error_page_on_first_page_raises_typed(self, mock_http):
+        """A 401 on the very first delta page raises instead of returning (items=[],
+        token=None) — the old silent-success path."""
+        mock_http.get = AsyncMock(return_value=_mock_response(401, text="Unauthorized"))
+
+        gc = GraphClient("test-token")
+        with pytest.raises(GraphAPIError) as exc_info:
+            await gc.delta_query("/me/x/delta")
+        assert exc_info.value.status == 401
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.asyncio.sleep", new_callable=AsyncMock)
+    @patch("app.utils.graph_client.http")
+    async def test_delta_410_mid_pagination_still_raises_sync_state_expired(self, mock_http, mock_sleep):
+        """410 mid-round keeps the existing GraphSyncStateExpired contract."""
+        mock_http.get = AsyncMock(
+            side_effect=[
+                _mock_response(
+                    200,
+                    {"value": [{"id": "m1"}], "@odata.nextLink": "https://g/next"},
+                ),
+                _mock_response(410, text="SyncStateNotFound"),
+            ]
+        )
+
+        gc = GraphClient("test-token")
+        with pytest.raises(GraphSyncStateExpired):
+            await gc.delta_query("/me/x/delta")
+
+    @pytest.mark.asyncio
+    @patch("app.utils.graph_client.http")
+    async def test_get_all_pages_error_page_raises_typed(self, mock_http):
+        """get_all_pages raises GraphAPIError on an error page instead of returning a
+        silently-empty list."""
+        mock_http.get = AsyncMock(return_value=_mock_response(403, text="Forbidden"))
+
+        gc = GraphClient("test-token")
+        with pytest.raises(GraphAPIError) as exc_info:
+            await gc.get_all_pages("/me/messages")
+        assert exc_info.value.status == 403
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_p1b_send_clock.py
+++ b/tests/test_p1b_send_clock.py
@@ -391,6 +391,10 @@ class TestReplyMatchingAfterReconcile:
         }
 
         mock_gc = AsyncMock()
+        # Expired delta token → explicit fall back to the get_json full scan
+        from app.utils.graph_client import GraphSyncStateExpired
+
+        mock_gc.delta_query.side_effect = GraphSyncStateExpired("expired")
         mock_gc.get_json.return_value = {"value": [inbound_msg]}
 
         with (


### PR DESCRIPTION
## What & why
`GraphClient.delta_query`'s `max_items` truncation could **silently drop items and stall delta tokens** for the contacts / sent / inbox syncs — a latent shared bug surfaced during the calendar-delta analysis. Fixing the truncation naively (drain-and-resume) would have made the *initial* full-sync unbounded, so this PR also gives initial sync a deliberate bound.

## Changes
- **Resumable, honest pagination** — `delta_query` persists the mid-round `nextLink` and resumes across polls; an `{"error": ...}` page now **raises `GraphAPIError`** instead of returning a short/empty list. Contract documented on both `delta_query` and `get_all_pages` docstrings.
- **Bounded initial sync** — when `delta_token is None`, inject `$filter=receivedDateTime ge <now − inbox_backfill_days>`. Verified via Microsoft Learn that `/messages/delta` supports exactly this filter form, and Graph bakes it into every subsequent `nextLink`/`deltaLink` (filtered rounds also cap at 5,000). Inbox + SentItems (incl. post-410 resync) use `settings.inbox_backfill_days` (180); the miner paths use their own `lookback_days`. `/me/contacts/delta` stays deliberately unbounded (filter unsupported there; address book is finite).
- **Token-loss fix** — `poll_inbox` now clears the delta token **only** on `GraphSyncStateExpired` (410). A transient error (e.g. `httpx.ReadTimeout` re-raised by the retry layer) keeps the token and records a **failed** poll. The fallback path treats an error dict as a failure so `_scan_user_inbox` records a failed scan, not a successful empty poll.
- **Dead-code removal** — three `except GraphAPIError` branches that were behaviorally identical to the generic handlers below them (token untouched, same fallback) are gone.
- **Tests** — initial-lookback filter applied / omitted-on-resume, transient-keeps-token-and-fails-poll, fallback-error-dict-raises, sent-folder lookback on initial + resync. Update `APP_MAP_INTERACTIONS`.

## Behavior changes to flag
Initial inbox/SentItems enumeration now covers **180 days**, not all history (existing persisted tokens unaffected — the filter only applies to token-less initial rounds). `poll_inbox` no longer nukes the delta token on arbitrary exceptions.

## Verification
275 targeted tests pass (`test_graph_client`, `test_email_service`, `test_email_jobs`); ruff clean; hook-env mypy green.

Carries the shared `faceted_search_service` hook-env `warn_return_any` straggler fix (same as #737) so the local mypy hook stays green. Recovered from an interrupted session; reviewed by an assess→fix→re-review agent workflow (both re-review lenses: ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)