### PR TITLE
Fix Resell bid-assembly 500 on dangling best_offer_id + seeder type-confusion

### DIFF
--- a/app/management/seed_sample_data.py
+++ b/app/management/seed_sample_data.py
@@ -1328,13 +1328,16 @@ def _seed_wf_e(db: Session, counts: _Counts, co: dict, mc: dict, vc: dict, u: di
     _offer(u["u_buyer1"], vc["vc_highrel"], ExcessOfferScope.TAKE_ALL, Decimal(18000))
 
     # Best-price rollup (seeder writes it so the column renders without a service call).
+    # best_offer_id holds the parent ExcessOffer id (recompute_line_rollup writes
+    # ExcessOfferLine.offer_id, NOT the offer-LINE id) — the bid-back seeds provenance from
+    # it, so an offer-line id here would dangle and 500 the assembly.
     if eli1.best_offer_id is None:
         eli1.best_offer_unit_price = Decimal(26)
-        eli1.best_offer_id = eol2a.id
+        eli1.best_offer_id = eol2a.offer_id
         eli1.offer_count = 2
     if eli2.best_offer_id is None:
         eli2.best_offer_unit_price = Decimal(10)
-        eli2.best_offer_id = eol3a.id
+        eli2.best_offer_id = eol3a.offer_id
         eli2.offer_count = 2
     _ = eol1a  # Pinnacle's matched line retained for the spread/comparison view.
 

--- a/app/services/bid_back_service.py
+++ b/app/services/bid_back_service.py
@@ -23,11 +23,36 @@ from decimal import Decimal
 
 from fastapi import HTTPException
 from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..constants import CustomerBidStatus
 from ..models import User
-from ..models.excess import CustomerBid, CustomerBidLine, ExcessLineItem, ExcessList
+from ..models.excess import (
+    CustomerBid,
+    CustomerBidLine,
+    ExcessLineItem,
+    ExcessList,
+    ExcessOffer,
+    ExcessOfferLine,
+)
+
+
+def _safe_commit(db: Session, *, entity: str = "record") -> None:
+    """Commit the session, mapping IntegrityError to HTTP 409 instead of an unhandled
+    500.
+
+    A dangling provenance pointer (e.g. a corrupt ``best_offer_id``) is sanitized before it
+    reaches a real FK column, so this is a backstop: any OTHER conflicting write surfaces as
+    a clean 409 rather than a 500 out of the global handler.
+    """
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        logger.warning("IntegrityError on {}: {}", entity, exc)
+        raise HTTPException(409, f"Duplicate or conflicting {entity}") from exc
 
 
 def build_bid_back(
@@ -44,7 +69,9 @@ def build_bid_back(
     ``quantity``), create a CustomerBidLine whose ``customer_unit_price`` defaults to the
     line's ``best_offer_unit_price`` rollup and is overridden by an explicit selection
     price. The selected-offer ids are recorded for internal audit only — they are never
-    exported. The line quantity defaults to the posted line's quantity.
+    exported, and any that no longer resolve to a live offer/offer-line on this list are
+    dropped to NULL (a stale ``best_offer_id`` can never 500 the assembly). The line
+    quantity defaults to the posted line's quantity.
 
     Re-assemble semantics (M4): the list keeps ONE CustomerBid row across revisions.
     When a bid already exists, re-assembling BUMPS ``revision`` on the SAME row and
@@ -68,6 +95,21 @@ def build_bid_back(
     posted: dict[int, ExcessLineItem] = {
         it.id: it for it in db.query(ExcessLineItem).filter_by(excess_list_id=list_id).all()
     }
+
+    # The set of REAL provenance ids for this list. ``selected_offer_id`` /
+    # ``selected_offer_line_id`` are hard FKs, but ``ExcessLineItem.best_offer_id`` is a
+    # plain int (no FK) that can go stale — a corrupt rollup once held an offer-LINE id
+    # instead of an ExcessOffer id, and writing that dangling value into the FK column
+    # raised IntegrityError → an unhandled 500. Resolve every provenance pointer against
+    # these sets and drop anything that no longer points at a live row on THIS list.
+    valid_offer_ids = set(db.scalars(select(ExcessOffer.id).where(ExcessOffer.excess_list_id == list_id)).all())
+    valid_offer_line_ids = set(
+        db.scalars(
+            select(ExcessOfferLine.id)
+            .join(ExcessOffer, ExcessOfferLine.offer_id == ExcessOffer.id)
+            .where(ExcessOffer.excess_list_id == list_id)
+        ).all()
+    )
 
     # One bid per list: re-assemble bumps ``revision`` on the same row (audit chain
     # preserved) instead of leaving a pile of orphan drafts.
@@ -101,18 +143,25 @@ def build_bid_back(
         unit_price = _to_decimal(override) if override is not None else item.best_offer_unit_price
         quantity = sel.get("quantity") or item.quantity
 
+        # Resolve provenance against the live rows — a dangling id is dropped (NULL),
+        # never written into the FK column where it would 500 on commit.
+        candidate_offer_id = sel.get("selected_offer_id") or item.best_offer_id
+        selected_offer_id = candidate_offer_id if candidate_offer_id in valid_offer_ids else None
+        candidate_offer_line_id = sel.get("selected_offer_line_id")
+        selected_offer_line_id = candidate_offer_line_id if candidate_offer_line_id in valid_offer_line_ids else None
+
         db.add(
             CustomerBidLine(
                 customer_bid_id=bid.id,
                 excess_line_item_id=item.id,
-                selected_offer_id=sel.get("selected_offer_id") or item.best_offer_id,
-                selected_offer_line_id=sel.get("selected_offer_line_id"),
+                selected_offer_id=selected_offer_id,
+                selected_offer_line_id=selected_offer_line_id,
                 customer_unit_price=unit_price,
                 quantity=quantity,
             )
         )
 
-    db.commit()
+    _safe_commit(db, entity="customer bid")
     db.refresh(bid)
     logger.info(
         "Assembled CustomerBid id={} rev={} on list={} by owner={} ({} lines)",

--- a/tests/test_resell_bid_back.py
+++ b/tests/test_resell_bid_back.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Session
 
 from app.constants import CustomerBidStatus, ExcessListStatus
 from app.models import Company, User
-from app.models.excess import CustomerBid, ExcessLineItem, ExcessList
+from app.models.excess import CustomerBid, ExcessLineItem, ExcessList, ExcessOffer
 from app.services import bid_back_service, excess_service
 from app.utils.normalization import normalize_mpn_key
 
@@ -176,6 +176,62 @@ def test_build_bid_back_rejects_foreign_line(db_session, owner, priced_list, sel
             selections=[{"excess_line_item_id": foreign.id}],
         )
     assert exc.value.status_code == 404
+
+
+# ── Corrupt best_offer_id must never 500 (P1 #1 hotfix) ──────────────
+
+
+def test_build_bid_back_nulls_unresolvable_best_offer(db_session, owner, priced_list):
+    """A line whose ``best_offer_id`` points to a non-existent ExcessOffer must NOT 500.
+
+    Mirrors the corrupt staging state (``best_offer_id`` held an offer-LINE id, not an
+    ExcessOffer id, so it resolved to no ``excess_offers`` row). ``selected_offer_id`` is a
+    real FK, so seeding it with that dangling value used to raise IntegrityError on commit
+    → an unhandled 500. Assembly must instead NULL the unresolvable pointer and still build
+    the bid — and a manual price override on another line must keep working.
+    """
+    items = _lines(db_session, priced_list)
+    # Point the first line at an ExcessOffer id that does not exist (the corruption).
+    dangling_offer_id = 987654
+    assert db_session.get(ExcessOffer, dangling_offer_id) is None
+    items[0].best_offer_id = dangling_offer_id
+    db_session.commit()
+
+    override = Decimal("99.0000")
+    selections = [
+        {"excess_line_item_id": items[0].id},  # corrupt pointer → must null, not 500
+        {"excess_line_item_id": items[1].id, "customer_unit_price": override},  # manual override
+    ]
+
+    # Must not raise IntegrityError / 500.
+    bid = bid_back_service.build_bid_back(db_session, list_id=priced_list.id, owner=owner, selections=selections)
+
+    by_line = {ln.excess_line_item_id: ln for ln in bid.lines}
+    # The dangling pointer was dropped — but the line is still priced + assembled.
+    assert by_line[items[0].id].selected_offer_id is None
+    assert by_line[items[0].id].customer_unit_price == items[0].best_offer_unit_price
+    # The manual override still applies on the other line.
+    assert by_line[items[1].id].customer_unit_price == override
+
+
+def test_build_bid_back_records_valid_best_offer(db_session, owner, priced_list):
+    """When ``best_offer_id`` resolves to a real ExcessOffer, it is recorded as
+    provenance."""
+    items = _lines(db_session, priced_list)
+    offer = ExcessOffer(excess_list_id=priced_list.id, submitted_by=owner.id, scope="per_line", status="open")
+    db_session.add(offer)
+    db_session.flush()
+    items[0].best_offer_id = offer.id
+    db_session.commit()
+
+    bid = bid_back_service.build_bid_back(
+        db_session,
+        list_id=priced_list.id,
+        owner=owner,
+        selections=[{"excess_line_item_id": items[0].id}],
+    )
+    line = next(ln for ln in bid.lines if ln.excess_line_item_id == items[0].id)
+    assert line.selected_offer_id == offer.id
 
 
 # ── Export context cleanliness (the load-bearing assertion) ──────────

--- a/tests/test_seed_sample_data.py
+++ b/tests/test_seed_sample_data.py
@@ -176,6 +176,26 @@ def test_offer_qualification_and_buy_plan_links(db_session: Session) -> None:
     assert bp_active.ai_flags[0]["line_id"] is not None
 
 
+def test_seeded_best_offer_ids_resolve_to_real_offers(db_session: Session) -> None:
+    """Every seeded ``ExcessLineItem.best_offer_id`` points at a real ExcessOffer row.
+
+    ``best_offer_id`` holds a PARENT ExcessOffer id (that is what
+    ``recompute_line_rollup`` writes), and the bid-back seeds ``CustomerBidLine.selected_offer_id``
+    — a hard FK — from it. The seeder once wrote an ExcessOfferLine id here (type
+    confusion), so the value dangled and building a bid 500'd. Guards against that
+    regression: a non-null ``best_offer_id`` must resolve, and never to an offer-LINE id.
+    """
+    sds.seed(db_session)
+
+    offer_ids = {row[0] for row in db_session.query(ExcessOffer.id).all()}
+    seeded = db_session.query(ExcessLineItem).filter(ExcessLineItem.best_offer_id.isnot(None)).all()
+
+    assert seeded, "seeder must set best_offer_id on at least one line"
+    for item in seeded:
+        assert item.best_offer_id in offer_ids, f"best_offer_id={item.best_offer_id} is not a real ExcessOffer"
+        assert db_session.get(ExcessOffer, item.best_offer_id) is not None
+
+
 def test_second_seed_is_idempotent(db_session: Session) -> None:
     """Re-running the seeder creates nothing new — counts are stable."""
     sds.seed(db_session)


### PR DESCRIPTION
## What & why
Building a customer bid-back **500s on the only active staging list**. `build_bid_back` copied `ExcessLineItem.best_offer_id` — a **plain int with no FK** (`excess.py:113`) — straight into `CustomerBidLine.selected_offer_id` (a **real FK**) and did a raw `db.commit()`, so a stale pointer raised `IntegrityError` → unhandled 500 out of the global handler. The corrupt values came from the **sample-data seeder writing an `ExcessOfferLine` id** (`eol.id`) into `best_offer_id`, which must hold a parent `ExcessOffer` id. (Resell action plan **P1 #1**.)

## Fix (root-cause)
- **`build_bid_back`** — resolve every provenance pointer against the list's **live** `ExcessOffer` / `ExcessOfferLine` ids (SQLAlchemy 2.0 `select()`), and **drop danglers to NULL before they reach the FK column** — a stale `best_offer_id` can never 500 the assembly. Added `_safe_commit` as a backstop that maps any *other* `IntegrityError` to a clean **409**.
- **Seeder** (`seed_sample_data.py:1336/1340`) — write `eol.offer_id` (parent `ExcessOffer`), not `eol.id` (offer line).
- Verified the seeder was the **only** corrupt writer: the runtime rollup (`excess_service.py:620`) already writes the correct `offer_id`.

## Tests
- Dangling `best_offer_id` → assembly does **not** 500, the pointer is NULL-dropped, and the line is still priced/assembled (this assertion **fails without the fix**, independent of SQLite FK enforcement).
- Valid `best_offer_id` → recorded as provenance.
- Seeder-produced `best_offer_id` values resolve to real `excess_offers` rows.
- Full touched slice + bid-lifecycle + resell-offers: green. ruff + hook-env mypy clean.

## Ops (at deploy)
Repair the two corrupt staging lines with `recompute_line_rollup` (not run here — staging DB is off-limits to the build).

Built via a TDD workflow; the workflow's own output step errored, so I salvaged the diff, ran the adversarial checks it skipped (other unsafe copies, PG-vs-SQLite test validity, lint/types, broader slice) manually, and converted the new queries to 2.0 style to satisfy the legacy-query ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)