### PR TITLE
Security: register global SlowAPIMiddleware (rate limit was dead code)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,7 +53,14 @@ class Settings(BaseSettings):
     sentry_profiles_sample_rate: float = 0.1
 
     # --- Rate limiting ---
-    rate_limit_default: str = "120/minute"
+    # Global per-IP default applied by SlowAPIMiddleware to every route that lacks its
+    # own @limiter.limit. 600/minute (10 req/s sustained) is sized for an htmx-heavy
+    # admin session: several 2s status pollers (30 req/min each), 3s outreach/datasheet
+    # pollers (20/min), plus badges and the per-navigation partial fan-out routinely put
+    # a single active tab well past 120/min — the old default would 429 the user's OWN
+    # UI. 600/min absorbs that headroom while still capping abuse from one IP. Streaming
+    # (SSE) and infra (/health,/metrics) endpoints are @limiter.exempt (see app/main.py).
+    rate_limit_default: str = "600/minute"
     rate_limit_enabled: bool = True
 
     # --- Cross-app alerts ---

--- a/app/main.py
+++ b/app/main.py
@@ -250,8 +250,14 @@ app.state.limiter = limiter
 if settings.rate_limit_enabled:
     from slowapi import _rate_limit_exceeded_handler
     from slowapi.errors import RateLimitExceeded
+    from slowapi.middleware import SlowAPIMiddleware
 
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type, unused-ignore]  # slowapi handler is narrower than Starlette's protocol; slowapi absent from the hook env, so the ignore is unused there
+    # Register the middleware that actually enforces the Limiter's default_limits on
+    # every request. Without it the @limiter.limit decorators still work but the global
+    # per-IP default is never applied. The SSE streams and infra probes below are
+    # @limiter.exempt so the default neither counts nor kills them.
+    app.add_middleware(SlowAPIMiddleware)
 
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -556,6 +562,7 @@ app.add_middleware(PrometheusMiddleware)
 
 
 @app.get("/metrics", include_in_schema=False, dependencies=[Depends(_metrics_auth)])
+@limiter.exempt
 async def metrics_endpoint() -> Response:
     body, content_type = render_metrics()
     return Response(content=body, media_type=content_type)
@@ -687,6 +694,7 @@ async def root_sw():
 
 
 @app.get("/health")
+@limiter.exempt
 async def health(
     request: Request,
     db: Session = Depends(get_db),
@@ -761,6 +769,7 @@ async def health(
 
 
 @app.get("/health/ready")
+@limiter.exempt
 async def health_ready() -> JSONResponse:
     """Readiness probe for the P2.7 deferred startup-backfill phase.
 

--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -12,12 +12,14 @@ from loguru import logger
 from sse_starlette.sse import EventSourceResponse
 
 from app.dependencies import require_user
+from app.rate_limit import limiter
 from app.services.sse_broker import broker
 
 router = APIRouter(tags=["events"])
 
 
 @router.get("/api/events/stream")
+@limiter.exempt
 async def event_stream(request: Request, user=Depends(require_user)):
     """SSE endpoint — one connection per user session.
 

--- a/app/routers/htmx/search_views.py
+++ b/app/routers/htmx/search_views.py
@@ -25,6 +25,7 @@ from ...constants import AccessKey, ApiSourceStatus, SourcingStatus
 from ...database import get_db
 from ...dependencies import require_access, require_requisition_access, require_user
 from ...models import ApiSource, Requirement, Requisition, Sighting, SourcingLead, User
+from ...rate_limit import limiter
 from ...scoring import classify_lead, explain_lead, score_unified
 from ...services.sighting_ingest import sighting_from_row
 from ...services.vendor_unavailability import apply_to_fresh_sightings
@@ -225,6 +226,7 @@ async def search_run(
 
 
 @router.get("/v2/partials/search/stream")
+@limiter.exempt
 async def search_stream(
     request: Request,
     search_id: str = Query(...),

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -73,7 +73,19 @@ FastAPI Middleware Stack (in order):
     │       fetched fresh, not heuristically cached stale). Guard is the response
     │       content-type ONLY (starts "text/html"), so JSON, SSE (text/event-stream), and
     │       file downloads (Content-Disposition) are untouched and streaming bodies unread.
-    └── 7. API Version Middleware (/api/v1/* -> /api/*)
+    ├── 7. API Version Middleware (/api/v1/* -> /api/*)
+    └── 8. SlowAPIMiddleware (INNERMOST — added first, in the `if settings.rate_limit_enabled`
+    │       block ~main.py:250, so it wraps closest to the route handler). This is what
+    │       actually ENFORCES the per-IP global default `rate_limit_default` (600/min,
+    │       config.py) on every route lacking its own `@limiter.limit`; without it the
+    │       decorators still work but the default is never applied. key_func is
+    │       get_remote_address — correct because uvicorn runs `--proxy-headers
+    │       --forwarded-allow-ips` (docker-compose) and fixes scope["client"] to the real
+    │       client IP before any Starlette middleware runs. Exempt (`@limiter.exempt`): the
+    │       two SSE streams (/api/events/stream, /v2/partials/search/stream — a throttled
+    │       stream would be killed) and infra probes (/health, /health/ready, /metrics).
+    │       @limiter.limit-decorated routes and static Mounts are auto-exempt. Only present
+    │       when rate_limit_enabled (config default True; tests set it False).
     │
     ▼
 Router (27 router modules)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -420,6 +420,137 @@ class TestRateLimitHandler:
         assert hasattr(app.state, "limiter")
 
 
+# ── Rate limit middleware (Task 2: SlowAPIMiddleware) ─────────────────
+
+
+class TestRateLimitMiddleware:
+    """Task 2: registering SlowAPIMiddleware makes the Limiter's ``default_limits``
+    actually enforced on undecorated routes, while streaming/infra endpoints are
+    exempted via ``@limiter.exempt``.
+
+    The 429-behaviour tests build a fresh isolated app + Limiter (in-memory storage is
+    per-instance, so counts are deterministic and need no auth/DB) — mirrors the
+    self-contained ``csrf_app`` pattern in ``test_csrf_module_importable``. The
+    real-app tests then assert app/main.py actually wired the middleware and marked
+    the right routes exempt.
+    """
+
+    @staticmethod
+    def _mini_app(limit: str = "3/minute"):
+        """Build a FastAPI app wired exactly like app/main.py's rate-limit block:
+
+        fresh Limiter (own in-memory store) → exception handler → SlowAPIMiddleware,
+        plus a plain (default-limited) route and a ``@limiter.exempt`` route.
+        """
+        from fastapi import FastAPI, Request
+        from slowapi import Limiter, _rate_limit_exceeded_handler
+        from slowapi.errors import RateLimitExceeded
+        from slowapi.middleware import SlowAPIMiddleware
+        from slowapi.util import get_remote_address
+
+        app = FastAPI()
+        limiter = Limiter(key_func=get_remote_address, default_limits=[limit])
+        app.state.limiter = limiter
+        app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+        app.add_middleware(SlowAPIMiddleware)
+
+        @app.get("/limited")
+        async def limited(request: Request):
+            return {"ok": True}
+
+        @app.get("/exempt")
+        @limiter.exempt
+        async def exempt(request: Request):
+            return {"ok": True}
+
+        return app
+
+    def test_default_limit_enforced_on_plain_route(self):
+        """A low default limit yields 429 on the 4th+ hit of an undecorated route.
+
+        TestClient pins request.client.host='testclient', so all calls share one key and
+        the counter accumulates — proving the middleware enforces default_limits.
+        """
+        client = TestClient(self._mini_app("3/minute"))
+        codes = [client.get("/limited").status_code for _ in range(5)]
+        assert codes == [200, 200, 200, 429, 429]
+
+    def test_429_body_uses_repo_error_key(self):
+        """Slowapi's default handler returns {'error': 'Rate limit exceeded: ...'},
+        matching the repo convention (tests assert ['error'], never ['detail'])."""
+        client = TestClient(self._mini_app("2/minute"))
+        client.get("/limited")
+        client.get("/limited")
+        resp = client.get("/limited")
+        assert resp.status_code == 429
+        assert resp.json()["error"].startswith("Rate limit exceeded")
+
+    def test_exempt_route_never_429s(self):
+        """A ``@limiter.exempt`` route bypasses the default limit no matter how many
+        times it is hit — the SSE streams depend on this so a stream is never killed."""
+        client = TestClient(self._mini_app("3/minute"))
+        codes = [client.get("/exempt").status_code for _ in range(8)]
+        assert codes == [200] * 8
+
+    def test_real_app_registers_slowapi_middleware(self):
+        """app/main.py must add SlowAPIMiddleware to the real app when rate limiting is
+        enabled; without it the Limiter's default_limits are never enforced (the whole
+        point of Task 2).
+
+        The test suite sets RATE_LIMIT_ENABLED=false (conftest.py:33) so the singleton
+        app.main.app has NO middleware here — re-import the app in a fresh interpreter
+        with the flag ON and assert the middleware got wired.
+        """
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        env = {
+            **os.environ,
+            "TESTING": "1",
+            "RATE_LIMIT_ENABLED": "true",
+            "DATABASE_URL": "sqlite://",
+            "REDIS_URL": "",
+            "CACHE_BACKEND": "none",
+            "PYTHONPATH": str(repo_root),
+        }
+        code = (
+            "import app.main as m; "
+            "names=[getattr(x,'cls',type(x)).__name__ for x in m.app.user_middleware]; "
+            "print('SlowAPIMiddleware' in names)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=str(repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, f"import failed: {result.stderr}"
+        assert result.stdout.strip().endswith("True"), (
+            f"SlowAPIMiddleware not registered with RATE_LIMIT_ENABLED=true; stdout={result.stdout!r}"
+        )
+
+    def test_streaming_and_infra_endpoints_are_exempt(self):
+        """The two long-lived SSE streams and the infra probes are ``@limiter.exempt``,
+        so the raised global default never counts (or, for a stream, kills) them.
+
+        Asserts on the limiter's exempt set (populated by the decorator at import time),
+        which is robust to lazy router materialisation.
+        """
+        import app.main  # noqa: F401 -- ensure every router module is imported (decorators run)
+        from app.main import health, health_ready, metrics_endpoint
+        from app.rate_limit import limiter
+        from app.routers.events import event_stream
+        from app.routers.htmx.search_views import search_stream
+
+        for fn in (event_stream, search_stream, metrics_endpoint, health, health_ready):
+            name = f"{fn.__module__}.{fn.__name__}"
+            assert name in limiter._exempt_routes, f"{name} not marked @limiter.exempt"
+
+
 # ── Global exception handler (lines 160-170) ─────────────────────────
 
 


### PR DESCRIPTION
Roadmap Phase 1. The 120/min default was **inert** — `SlowAPIMiddleware` was never `add_middleware`'d, so only ~41 decorated routes throttled. Registers it in the `rate_limit_enabled` block; **exempts the SSE streams** (`/api/events/stream`, `/v2/partials/search/stream`) + `/health` (a rate-limited stream is fatal); raises the default for htmx-heavy sessions. No custom key_func needed — the stack already runs `uvicorn --proxy-headers --forwarded-allow-ips`, so the real client IP is resolved. Live-verify: 429 past the limit; SSE + normal browsing unaffected. 43 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)