### PR TITLE
Security: password-login fail-boot guard (launch blocker #1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ SEED_ADMIN_NAME=
 # DEFAULT_USER_PASSWORD with role DEFAULT_USER_ROLE — which defaults to
 # `buyer`; only set a higher tier (e.g. admin) if genuinely needed.
 ENABLE_PASSWORD_LOGIN=false
+# Set true ONLY on a non-production env to acknowledge the ENABLE_PASSWORD_LOGIN
+# auth-bypass risk. Boot RAISES a RuntimeError if ENABLE_PASSWORD_LOGIN=true
+# without this. Staging sets this to keep booting; leave false everywhere else.
+ALLOW_PASSWORD_LOGIN_RISK=false
 DEFAULT_USER_EMAIL=
 DEFAULT_USER_PASSWORD=
 DEFAULT_USER_ROLE=buyer

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,12 @@ class Settings(BaseSettings):
     rate_limit_default: str = "120/minute"
     rate_limit_enabled: bool = True
 
+    # Explicit acknowledgement that ENABLE_PASSWORD_LOGIN (an auth bypass) is
+    # intentional on a non-prod env. Boot refuses password login without this.
+    # The boot guard reads os.getenv at runtime (auth.password_login_risk_
+    # acknowledged); this field documents the var and lets Settings load it.
+    allow_password_login_risk: bool = False
+
     # --- Cross-app alerts ---
     alert_recency_days: int = 30  # FYI alerts only count items newer than this
     alerts_epoch: str = ""  # ISO datetime; FYI items dated before this never count (default: no epoch floor)

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -244,6 +244,17 @@ def password_login_env_enabled() -> bool:
     return os.getenv("ENABLE_PASSWORD_LOGIN", "false").lower() == "true"
 
 
+def password_login_risk_acknowledged() -> bool:
+    """True iff ALLOW_PASSWORD_LOGIN_RISK is set truthy in the environment.
+
+    Explicit operator acknowledgement that the ENABLE_PASSWORD_LOGIN auth bypass
+    is intended on this (non-production) environment. Read at call time — exactly
+    like ``password_login_env_enabled`` — NOT via config.py's import-time
+    Settings, so the boot guard and its tests can toggle it per-process.
+    """
+    return os.getenv("ALLOW_PASSWORD_LOGIN_RISK", "false").lower() == "true"
+
+
 def _password_login_enabled() -> bool:
     """Return True when local/test password login should be allowed.
 

--- a/app/startup.py
+++ b/app/startup.py
@@ -116,13 +116,26 @@ def run_startup_migrations() -> None:
 
     Safe to call on every app boot.
     """
-    # Warn if password login backdoor is active outside test mode
-    from .routers.auth import password_login_env_enabled
+    # Fail-boot guard: password login is an auth bypass. On a real (non-TESTING)
+    # boot it may run ONLY when the operator has explicitly acknowledged the risk
+    # via ALLOW_PASSWORD_LOGIN_RISK=true (staging sets this). Otherwise refuse to
+    # start so the bypass can never reach an unacknowledged environment. Read via
+    # the runtime os.getenv helpers (not settings.*, which froze at import) and
+    # keep the auth import function-local (avoids import-time capture and an
+    # auth-router circular import).
+    from .routers.auth import password_login_env_enabled, password_login_risk_acknowledged
 
     if password_login_env_enabled() and not os.getenv("TESTING"):
+        if not password_login_risk_acknowledged():
+            raise RuntimeError(
+                "ENABLE_PASSWORD_LOGIN=true creates an authentication bypass and is "
+                "refused at boot. Disable it, or set ALLOW_PASSWORD_LOGIN_RISK=true to "
+                "acknowledge the risk (non-production environments only, e.g. staging)."
+            )
         logger.critical(
-            "ENABLE_PASSWORD_LOGIN is active in non-test mode. "
-            "This creates an authentication bypass. Disable before production use."
+            "ENABLE_PASSWORD_LOGIN is active in non-test mode with "
+            "ALLOW_PASSWORD_LOGIN_RISK=true — authentication bypass acknowledged. "
+            "Acceptable only on non-production environments."
         )
 
     if os.environ.get("TESTING"):

--- a/deploy.sh
+++ b/deploy.sh
@@ -72,6 +72,18 @@ if [ "$NO_COMMIT" = false ]; then
     fi
 fi
 
+# Step 1.5: Preflight — refuse to deploy a password-login backdoor without an
+# explicit risk acknowledgement in .env. The app also fail-boots on this
+# (app/startup.py), but asserting here fails fast with a clear message instead
+# of a health-check timeout. Staging sets ALLOW_PASSWORD_LOGIN_RISK=true → passes.
+if grep -qiE '^[[:space:]]*ENABLE_PASSWORD_LOGIN[[:space:]]*=[[:space:]]*true' .env 2>/dev/null \
+   && ! grep -qiE '^[[:space:]]*ALLOW_PASSWORD_LOGIN_RISK[[:space:]]*=[[:space:]]*true' .env 2>/dev/null; then
+    echo "ERROR: ENABLE_PASSWORD_LOGIN=true but ALLOW_PASSWORD_LOGIN_RISK is not true in .env." >&2
+    echo "Password login is an auth bypass. Set ALLOW_PASSWORD_LOGIN_RISK=true to acknowledge" >&2
+    echo "(non-production environments only), or disable ENABLE_PASSWORD_LOGIN." >&2
+    exit 5
+fi
+
 # Step 2: Rebuild app with a unique BUILD_COMMIT each deploy.
 # No --no-cache: the Dockerfile consumes BUILD_COMMIT right before the source COPYs (in
 # BOTH stages), so the template/static COPYs + the Vite build + the app COPY ALWAYS

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -158,6 +158,16 @@ capabilities a user is granted).
     OAuth login by an unknown email (no pre-provisioned row) is rejected at the callback
     unless the email is in `ADMIN_EMAILS`. See APP_MAP_INTERACTIONS for the allowlist +
     invite-adoption flow.
+  - **Password-login fail-boot guard** — `ENABLE_PASSWORD_LOGIN=true` (the local password
+    form, an auth bypass relative to Azure SSO) now **hard-fails boot** on any real
+    (non-`TESTING`) start unless the operator acknowledges the risk with
+    `ALLOW_PASSWORD_LOGIN_RISK=true`. The guard lives in `app/startup.py`
+    (`run_startup_migrations`, before the TESTING short-circuit) and reads `os.getenv` at
+    runtime via `auth.password_login_env_enabled` / `auth.password_login_risk_acknowledged`
+    (not the import-frozen `settings.*`). With the ack it logs a CRITICAL "bypass
+    acknowledged" line and boots; without it, it raises `RuntimeError`. `deploy.sh` mirrors
+    this as a Step 1.5 preflight (exit 5) so a missing ack fails fast instead of timing out
+    the health check. Staging sets the ack; leave it false everywhere else.
 
 ## Frontend Architecture
 

--- a/tests/test_auth_password_guard.py
+++ b/tests/test_auth_password_guard.py
@@ -1,8 +1,10 @@
 """test_auth_password_guard.py — Tests for password login production guard.
 
 Verifies:
-1. Startup logs a CRITICAL warning when ENABLE_PASSWORD_LOGIN=true without TESTING set
-2. /auth/login-form has rate limiting applied (5/minute)
+1. A real (non-TESTING) boot RAISES when ENABLE_PASSWORD_LOGIN=true unless
+   ALLOW_PASSWORD_LOGIN_RISK=true acknowledges the auth-bypass risk
+2. The acknowledged (ack) boot logs a CRITICAL warning instead of raising
+3. /auth/login-form has rate limiting applied (5/minute)
 
 Called by: pytest
 Depends on: app.startup, app.routers.auth
@@ -11,6 +13,7 @@ Depends on: app.startup, app.routers.auth
 import os
 from unittest.mock import patch
 
+import pytest
 from loguru import logger
 
 
@@ -45,11 +48,20 @@ def _critical_msgs_from_startup(env: dict[str, str], *, remove_keys: tuple[str, 
 
 
 class TestStartupPasswordWarning:
-    """Startup should log CRITICAL when ENABLE_PASSWORD_LOGIN=true in non-test mode."""
+    """Startup logs CRITICAL when ENABLE_PASSWORD_LOGIN=true is acknowledged.
 
-    def test_critical_warning_when_password_login_enabled_no_testing(self):
-        """ENABLE_PASSWORD_LOGIN=true + no TESTING → CRITICAL log."""
-        critical_msgs = _critical_msgs_from_startup({"ENABLE_PASSWORD_LOGIN": "true"}, remove_keys=("TESTING",))
+    The unacknowledged non-test path no longer logs-and-continues — it fail-boots (see
+    TestStartupPasswordFailBoot). The CRITICAL log now marks only the explicitly-
+    acknowledged (ALLOW_PASSWORD_LOGIN_RISK=true) boot.
+    """
+
+    def test_critical_warning_when_password_login_enabled_with_ack(self):
+        """ENABLE_PASSWORD_LOGIN=true + ALLOW_PASSWORD_LOGIN_RISK=true + no TESTING →
+        CRITICAL log."""
+        critical_msgs = _critical_msgs_from_startup(
+            {"ENABLE_PASSWORD_LOGIN": "true", "ALLOW_PASSWORD_LOGIN_RISK": "true"},
+            remove_keys=("TESTING",),
+        )
         assert len(critical_msgs) >= 1, f"Expected CRITICAL log about ENABLE_PASSWORD_LOGIN, got: {critical_msgs}"
 
     def test_no_warning_when_testing_is_set(self):
@@ -96,3 +108,62 @@ class TestLoginFormRateLimit:
             f"password_login (POST) should have rate limiting. "
             f"Registered endpoints: {list(limiter._route_limits.keys())}"
         )
+
+
+class TestStartupPasswordFailBoot:
+    """Real (non-TESTING) boot must RAISE when ENABLE_PASSWORD_LOGIN=true unless
+    ALLOW_PASSWORD_LOGIN_RISK=true acknowledges the auth-bypass risk.
+
+    The log-only CRITICAL warning (TestStartupPasswordWarning) was upgraded to a fail-
+    boot guard so the password-login bypass can never silently reach an environment
+    where the operator has not explicitly acknowledged the risk.
+    """
+
+    def test_boot_raises_without_ack(self):
+        """ENABLE_PASSWORD_LOGIN=true, no TESTING, no ack → RuntimeError at boot.
+
+        The guard raises BEFORE any DB access, so no DB patching is needed here.
+        """
+        from app.startup import run_startup_migrations
+
+        with patch.dict(os.environ, {"ENABLE_PASSWORD_LOGIN": "true"}, clear=False):
+            os.environ.pop("TESTING", None)
+            os.environ.pop("ALLOW_PASSWORD_LOGIN_RISK", None)
+            try:
+                with pytest.raises(RuntimeError, match="ALLOW_PASSWORD_LOGIN_RISK"):
+                    run_startup_migrations()
+            finally:
+                os.environ["TESTING"] = "1"
+
+    def test_boot_succeeds_with_ack(self):
+        """ENABLE_PASSWORD_LOGIN=true + ALLOW_PASSWORD_LOGIN_RISK=true → boots.
+
+        Every conn-taking FAST helper and the DB-touching seed helpers are stubbed
+        (engine patched to in-memory SQLite) so the guard is the only behavior under
+        test — it must NOT raise when the risk is acknowledged.
+        """
+        from app.startup import run_startup_migrations
+        from tests.test_startup import _make_sqlite_engine
+
+        env = {"ENABLE_PASSWORD_LOGIN": "true", "ALLOW_PASSWORD_LOGIN_RISK": "true"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("TESTING", None)
+            try:
+                with (
+                    patch("app.startup.engine", _make_sqlite_engine()),
+                    patch("app.startup._create_fts_triggers"),
+                    patch("app.startup._seed_system_config"),
+                    patch("app.startup._reconcile_system_config"),
+                    patch("app.startup._seed_manufacturers"),
+                    patch("app.startup._create_count_triggers"),
+                    patch("app.startup._reconcile_connector_active"),
+                    patch("app.startup._verify_encryption_canary"),
+                    patch("app.startup._create_default_user_if_env_set"),
+                    patch("app.startup._seed_admin_user_if_env_set"),
+                    patch("app.startup._seed_agent_user"),
+                    patch("app.startup._seed_verification_group_from_admin_emails"),
+                    patch("app.startup._seed_commodity_schemas"),
+                ):
+                    run_startup_migrations()  # must NOT raise
+            finally:
+                os.environ["TESTING"] = "1"


### PR DESCRIPTION
Roadmap Phase 1. Only the log severity had been raised; the prescribed boot guard was dropped. Boot now raises `RuntimeError` when `ENABLE_PASSWORD_LOGIN=true` without `ALLOW_PASSWORD_LOGIN_RISK=true` (read via os.getenv at **runtime**, before the TESTING short-circuit), plus a `deploy.sh` preflight assertion. Staging sets the ack env so it still boots. 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)