### PR TITLE
chore: tighten legacy SQLAlchemy Query-API ratchet + add dedicated CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,22 @@ jobs:
           python scripts/lint_assertion_theater.py tests \
             --baseline scripts/assertion_theater_baseline.txt
 
+      - name: Legacy SQLAlchemy Query-API ratchet (down-only)
+        # DOWN-only ratchet: fails if the count of legacy SQLAlchemy 1.x
+        # `<session>.query(` sites under app/ rises above the committed baseline
+        # (tests/query_api_baseline.json). Grandfathers the ~1,561 existing sites
+        # while blocking every NEW one — new code must use 2.0 style (db.get(),
+        # db.scalars(select(...)), db.execute(select(...))). Mirrored by the
+        # `query-api-ratchet` pre-commit hook and tests/test_query_api_ratchet.py;
+        # this dedicated step gives the ratchet an explicit, named CI gate (like
+        # the assertion-theater lint above) independent of test-sharding.
+        # To lower the baseline after intentionally REMOVING sites:
+        #   python -m scripts.query_api_baseline --write
+        # Shard 0 only (same rationale as pre-commit).
+        if: matrix.shard == 0
+        run: |
+          python -m scripts.query_api_baseline --check
+
       - name: No raw DDL outside Alembic
         if: matrix.shard == 0
         run: |

--- a/tests/query_api_baseline.json
+++ b/tests/query_api_baseline.json
@@ -1,4 +1,4 @@
 {
-  "total": 1562,
+  "total": 1561,
   "note": "Legacy SQLAlchemy 1.x Query-API call count under app/. DOWN-only ratchet enforced by tests/test_query_api_ratchet.py. Regenerate with: python -m scripts.query_api_baseline --write (only after intentionally REMOVING sites)."
 }


### PR DESCRIPTION
## What

The down-only ratchet that grandfathers existing legacy `<session>.query(` sites under `app/` and blocks NEW ones **already existed** (`scripts/query_api_baseline.py` + the `query-api-ratchet` pre-commit hook + `tests/test_query_api_ratchet.py`). Investigation found two gaps; this PR closes both without duplicating the guard.

## Gap 1 — slack in the baseline (a new `db.query(` could slip through)

The committed baseline was `1562` while the actual current count under `app/` is `1561` (a later PR removed one site without lowering the baseline). That 1-unit slack meant a dev could introduce **exactly one** new `db.query(` (count → 1562, still `<= 1562`) without failing the ratchet.

- **Fix:** tightened `tests/query_api_baseline.json` to the true count (`1561`) via the sanctioned `python -m scripts.query_api_baseline --write`. Now **any** new legacy site fails.

## Gap 2 — no explicit CI gate

The ratchet was enforced in CI only *indirectly* (the changed-files pre-commit step + the pytest ratchet test). Unlike the sibling assertion-theater ratchet, it had no dedicated, named CI step.

- **Fix:** added a **`Legacy SQLAlchemy Query-API ratchet (down-only)`** step to `.github/workflows/ci.yml` (shard 0, mirroring the assertion-theater lint step) running `python -m scripts.query_api_baseline --check`.

## Proof it catches a new `db.query(`

With the tightened baseline, adding one scratch `db.query(` under `app/`:
- `python -m scripts.query_api_baseline --check` → **exit 1** ("count rose from 1561 to 1562")
- `tests/test_query_api_ratchet.py::test_legacy_query_api_does_not_grow` → **FAILED**

Removing the scratch restores green (both pass). Clean-tree: 2 passed.

## Scope

No `.py` files changed — only the baseline JSON (down by 1) and one CI step. The guard logic, pre-commit hook, and test are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)