### PR TITLE
Surface offer-review / follow-up / buy-plans hubs via nav entry points

### DIFF
--- a/app/routers/htmx/offers/follow_ups.py
+++ b/app/routers/htmx/offers/follow_ups.py
@@ -335,13 +335,13 @@ async def send_batch_follow_up(
     return resp
 
 
-@router.get("/v2/partials/follow-ups/badge", response_class=HTMLResponse)
-async def follow_up_badge(
-    request: Request,
-    user: User = Depends(require_user),
-    db: Session = Depends(get_db),
-):
-    """Return follow-up count badge for nav sidebar."""
+def follow_up_count(db: Session, user: User) -> int:
+    """Count stale RFQ contacts due for follow-up, scoped to what this user may act on.
+
+    The single source of truth for the follow-up count: the nav badge AND any other
+    surface that wants the number (e.g. the Sightings workspace quick-link) call this so
+    they never drift from the queue/batch predicate (see ``_build_follow_ups_ctx``).
+    """
     threshold = datetime.now(UTC) - timedelta(days=settings.follow_up_days)
     q = db.query(sqlfunc.count(RfqContact.id)).filter(
         RfqContact.contact_type == "email",
@@ -352,7 +352,17 @@ async def follow_up_badge(
     # Same per-owner scope as send_batch_follow_up so the badge matches the batch.
     if user.role in RESTRICTED_ROLES:
         q = q.join(Requisition, RfqContact.requisition_id == Requisition.id).filter(Requisition.created_by == user.id)
-    count = q.scalar() or 0
+    return q.scalar() or 0
+
+
+@router.get("/v2/partials/follow-ups/badge", response_class=HTMLResponse)
+async def follow_up_badge(
+    request: Request,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Return follow-up count badge for nav sidebar."""
+    count = follow_up_count(db, user)
     if count > 0:
         return HTMLResponse(
             f'<span class="ml-auto px-1.5 py-0.5 text-[10px] font-bold text-white bg-amber-500 rounded-full">{count}</span>'

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -151,6 +151,7 @@ _MODULE_ENTRY_URLS: tuple[tuple[AccessKey, str], ...] = (
 @router.get("/v2/materials", response_class=HTMLResponse)
 @router.get("/v2/materials/{card_id:int}", response_class=HTMLResponse)
 @router.get("/v2/follow-ups", response_class=HTMLResponse)
+@router.get("/v2/offers/review-queue", response_class=HTMLResponse)
 @router.get("/v2/crm", response_class=HTMLResponse)
 @router.get("/v2/sightings", response_class=HTMLResponse)
 @router.get("/v2/trouble-tickets", response_class=HTMLResponse)
@@ -177,6 +178,9 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         "settings",
         "materials",
         "follow-ups",
+        # "/offers" only appears in the review-queue full page — no collision with other
+        # view segments, so its position here is not load-bearing.
+        "offers",
         "trouble-tickets",
         "my-day",
         "crm",
@@ -231,6 +235,11 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         partial_url = "/v2/partials/crm/shell"
     elif current_view == "sightings":
         partial_url = "/v2/partials/sightings/workspace"
+    elif current_view == "offers":
+        # The offer review queue (medium-confidence AI-parsed offers) — surfaced from the
+        # Sightings workspace quick-links. Its own canonical page so a pushed/bookmarked
+        # /v2/offers/review-queue reloads straight into the queue instead of 404ing.
+        partial_url = "/v2/partials/offers/review-queue"
     elif current_view == "resell":
         partial_url = "/v2/partials/resell/workspace"
     elif current_view == "my-day":

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -360,9 +360,20 @@ async def sightings_workspace(
 ):
     """Return the split-panel workspace layout.
 
-    The table loads via hx-get inside.
+    The table loads via hx-get inside. Two workspace-level quick-links (offer review
+    queue + follow-ups queue) carry their pending counts so a buyer can jump straight to
+    either from their home screen; both counts are computed once here (not on the hot
+    table-refresh path).
     """
-    ctx = {"request": request, "user": user}
+    from .htmx.offers.follow_ups import follow_up_count
+
+    review_count = db.query(sqlfunc.count(Offer.id)).filter(Offer.status == OfferStatus.PENDING_REVIEW).scalar() or 0
+    ctx = {
+        "request": request,
+        "user": user,
+        "review_count": review_count,
+        "follow_up_count": follow_up_count(db, user),
+    }
     return template_response("htmx/partials/sightings/list.html", ctx)
 
 

--- a/app/templates/htmx/partials/approvals/_tab_buy_plan.html
+++ b/app/templates/htmx/partials/approvals/_tab_buy_plan.html
@@ -19,6 +19,15 @@
   <div class="flex items-center justify-between">
     <h2 class="h2">Buy Plans / Sales Orders <span class="text-sm font-normal text-gray-500">({{ rows | length }})</span></h2>
     <div class="flex items-center gap-2">
+      {# My Buy Plans — entry point to the PERSONAL hub (My Queue + Pipeline) at
+         /v2/buy-plans, distinct from this org-wide decide console. Loads the hub shell
+         (no ?new=1, so it lands on the lens body, not the origination picker) and pushes
+         its canonical URL so a reload/bookmark lands on the hub. #}
+      <a hx-get="/v2/partials/buy-plans" hx-target="#main-content" hx-push-url="/v2/buy-plans"
+         class="btn-secondary btn-sm inline-flex items-center gap-1 cursor-pointer" title="Go to my personal Buy Plans hub (My Queue &amp; Pipeline)">
+        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
+        My Buy Plans
+      </a>
       {# New Buy Plan (epic H) — surfaces the create flow on this console. Loads the Buy Plans
          hub landed straight on the Sales-Order origination picker (?new=1); the picker renders
          into #bp-hub-body inside that shell, so its requisition links resolve normally. #}

--- a/app/templates/htmx/partials/sightings/list.html
+++ b/app/templates/htmx/partials/sightings/list.html
@@ -32,13 +32,51 @@
   </div>
 </div>
 
+{# ── Workspace quick-links ────────────────────────────────────
+   Entry points to the two buyer queues that have no bottom-nav tab of their own —
+   the offer review queue and the cross-requisition follow-up queue. Each nav-swaps
+   #main-content (not the table) and pushes its own canonical URL so a refresh/bookmark
+   lands on the same page; the pending count rides along (computed once in
+   sightings_workspace, off the hot table-refresh path). #}
+<div id="sightings-quicklinks"
+     class="flex-shrink-0 flex items-center gap-2 flex-wrap px-3 py-2 border-b border-gray-100 bg-white">
+  <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mr-1">Queues</span>
+  <a href="/v2/offers/review-queue"
+     hx-get="/v2/partials/offers/review-queue"
+     hx-target="#main-content"
+     hx-push-url="/v2/offers/review-queue"
+     class="btn btn-sm btn-secondary inline-flex items-center gap-1.5"
+     title="Verify AI-parsed offers awaiting human review">
+    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    Review Queue
+    {% if review_count %}<span class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-amber-500 text-white text-[11px] font-semibold">{{ review_count }}</span>{% endif %}
+  </a>
+  <a href="/v2/follow-ups"
+     hx-get="/v2/partials/follow-ups"
+     hx-target="#main-content"
+     hx-push-url="/v2/follow-ups"
+     class="btn btn-sm btn-secondary inline-flex items-center gap-1.5"
+     title="Chase stale RFQ replies across requisitions">
+    <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+    </svg>
+    Follow-ups
+    {% if follow_up_count %}<span class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-amber-500 text-white text-[11px] font-semibold">{{ follow_up_count }}</span>{% endif %}
+  </a>
+</div>
+
 {# Row click is read-only: selectReq() does GET /detail to render the cached panel.
    The only way to fire a connector search is the per-row refresh icon (table.html)
    or the Search button in the detail panel header (_macros.html::search_button);
    both POST /v2/.../refresh, gated by the 48h per-MPN cooldown in search_requirement.
    NOTE: keep prose comments OUT of the x-data attribute below — a literal double-quote
-   inside the double-quoted x-data attribute truncates it and breaks Alpine init. #}
-<div class="h-[calc(100vh-90px)] flex flex-col lg:flex-row"
+   inside the double-quoted x-data attribute truncates it and breaks Alpine init.
+   The quick-links bar (flex-shrink-0) + this split panel (flex-1) share the
+   calc(100vh-90px) column, so the workspace keeps its original viewport footprint. #}
+<div class="flex flex-col h-[calc(100vh-90px)]">
+<div class="flex-1 min-h-0 flex flex-col lg:flex-row"
      x-data="{
        splitRatio: parseFloat(localStorage.getItem('sightings-split') || '0.50'),
        dragging: false,
@@ -200,4 +238,5 @@
     <div x-show="selectedReqId" x-cloak id="sightings-detail" class="sightings-fade"
          hx-indicator="#sightings-detail-skeleton"></div>
   </div>
+</div>
 </div>

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -362,7 +362,14 @@ After this final split, `htmx_views.py` retains only the cross-cutting surface: 
 full-page entry points (`v2_page` + `/v2/quotes` redirect), the parts-workspace shell
 (`GET /v2/partials/parts/workspace`), the vendor stock-list import
 (`/v2/partials/vendors/import-stock`), and the shared nav/access-gate constants
-(`_NAV_ID_ALIAS`, `_VIEW_ACCESS`, `_MODULE_ENTRY_URLS`). It no longer defines any
+(`_NAV_ID_ALIAS`, `_VIEW_ACCESS`, `_MODULE_ENTRY_URLS`). `v2_page` also owns the canonical
+full-page URLs for the two buyer queues that have **no bottom-nav tab** — `/v2/follow-ups`
+(→ `/v2/partials/follow-ups`) and `/v2/offers/review-queue` (→ `/v2/partials/offers/review-queue`,
+`offers` view segment) — both surfaced via the **Sightings workspace quick-links** bar
+(`sightings/list.html`; `sightings_workspace` computes the pending-review + follow-up counts
+once, off the table-refresh path). The Buy Plans hub (`/v2/buy-plans`) is likewise reachable
+from a **"My Buy Plans"** link on the Approvals Buy-Plans tab (`approvals/_tab_buy_plan.html`).
+It no longer defines any
 `/v2/partials/*` route directly for search, email, insights/knowledge/dashboard, My Day,
 or requisition bulk/inline-edit — those now live in the 5 modules above.
 
@@ -415,7 +422,7 @@ authoritative reference. Static-analysis tests in
 | Resell | 11 | partials/resell/ — resell-brokerage workspace (replaced the removed `partials/excess/`; router `routers/resell.py`) |
 | Parts | 13 | partials/parts/ |
 | Quotes | 5 | partials/quotes/ — `list.html` removed (standalone Quotes tab retired); detail/macros/line_row/preview/pricing_history remain |
-| Sightings | 7 | partials/sightings/ — incl. `_vendor_search_results.html` ("Find any vendor" server-rendered debounced dropdown, `GET /v2/partials/sightings/vendor-search`, swapped into `#vendor-search-results` inside `vendor_modal.html`'s `rfqVendorModal` Alpine scope) |
+| Sightings | 7 | partials/sightings/ — incl. `_vendor_search_results.html` ("Find any vendor" server-rendered debounced dropdown, `GET /v2/partials/sightings/vendor-search`, swapped into `#vendor-search-results` inside `vendor_modal.html`'s `rfqVendorModal` Alpine scope). `list.html` (the workspace shell) carries a top **quick-links** bar with count-badged entry points to the offer-review queue + follow-up queue (both nav-swap `#main-content`, pushing their canonical URLs). |
 | Search | 13 | partials/search/ — incl. the Part Dossier ("Bench") at `/v2/search?mpn=`: `dossier_shell/hero/specs/recent/market.html` (routes in `routers/part_dossier.py`). |
 | Prospecting | 8 | partials/prospecting/ — list/_card/_macros/detail/stats/add_result/enrich_status/_action_oob; buyer-ready ranking via `services/prospect_priority.build_priority_snapshot` (single source of truth); background enrich polls `/enrich-status` (HTTP 286 stops); grid actions OOB-remove cards + refresh `#prospect-stats` |
 | Proactive | 4 | partials/proactive/ |

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -230,6 +230,20 @@ def test_buy_plan_tab_lists_pending(hub_client: TestClient, db_session: Session,
     assert "Approve" in r.text  # inline decide affordance for an eligible recipient
 
 
+def test_buy_plan_tab_links_to_personal_hub(hub_client: TestClient):
+    """The Approvals Buy-Plans tab surfaces a 'My Buy Plans' entry point to the personal
+    hub at /v2/buy-plans — the org-wide decide console's only click-through to the per-
+    user My Queue / Pipeline hub.
+
+    Renders even with no pending rows.
+    """
+    r = hub_client.get("/v2/partials/approvals/buy-plan")
+    assert r.status_code == 200
+    assert "My Buy Plans" in r.text
+    # Personal hub, NOT the ?new=1 origination picker.
+    assert 'hx-get="/v2/partials/buy-plans" hx-target="#main-content" hx-push-url="/v2/buy-plans"' in r.text
+
+
 def test_po_approval_tab_has_three_action_row(hub_client: TestClient, db_session: Session, test_user: User):
     req, q, rq = _req_quote(db_session, test_user)
     bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)

--- a/tests/test_htmx_views.py
+++ b/tests/test_htmx_views.py
@@ -219,6 +219,7 @@ class TestV2FullPages:
             ("/v2/proactive", "/v2/partials/proactive"),
             ("/v2/materials", "/v2/partials/materials"),
             ("/v2/follow-ups", "/v2/partials/follow-ups"),
+            ("/v2/offers/review-queue", "/v2/partials/offers/review-queue"),
             ("/v2/sightings", "/v2/partials/sightings/workspace"),
         ],
     )

--- a/tests/test_htmx_views_coverage.py
+++ b/tests/test_htmx_views_coverage.py
@@ -922,3 +922,28 @@ class TestSightingsWorkspaceExtra:
     def test_sightings_workspace(self, client: TestClient, url: str):
         resp = client.get(url)
         assert resp.status_code == 200
+
+    def test_sightings_workspace_surfaces_queue_entry_points(self, client: TestClient):
+        """The Sightings workspace exposes nav entry points to the two buyer queues that
+        have no bottom-nav tab of their own — the offer-review queue and the follow-up
+        queue — each swapping #main-content and pushing its own canonical URL."""
+        resp = client.get("/v2/partials/sightings/workspace")
+        assert resp.status_code == 200
+        body = resp.text
+        assert 'hx-get="/v2/partials/offers/review-queue"' in body
+        assert 'hx-push-url="/v2/offers/review-queue"' in body
+        assert 'hx-get="/v2/partials/follow-ups"' in body
+        assert 'hx-push-url="/v2/follow-ups"' in body
+
+    def test_sightings_workspace_review_queue_shows_pending_count(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """A pending-review offer surfaces its count on the Review Queue quick-link."""
+        req = _make_requisition(db_session, test_user)
+        db_session.flush()
+        _make_offer(db_session, req, test_user, status=OfferStatus.PENDING_REVIEW)
+        db_session.commit()
+        resp = client.get("/v2/partials/sightings/workspace")
+        assert resp.status_code == 200
+        # The amber count pill renders only when the count is non-zero.
+        assert 'bg-amber-500 text-white text-[11px] font-semibold">1</span>' in resp.text


### PR DESCRIPTION
## Problem
Three fully-built pages had **no click-through** from the app — the bottom nav is full, so they were unreachable without typing a URL:
- Offer-review queue (`GET /v2/partials/offers/review-queue`)
- Cross-requisition follow-up queue (`GET /v2/partials/follow-ups`, page `/v2/follow-ups`)
- Buy Plans personal hub (`/v2/buy-plans`, `GET /v2/partials/buy-plans`)

## Change — entry points only (no new bottom-nav tabs)
1. **Sightings workspace** (`sightings/list.html`) gains a top **quick-links** bar with count-badged entry points to the **Review Queue** and **Follow-ups** queues. Both nav-swap `#main-content` and push their own canonical URL. `sightings_workspace` computes the two pending counts **once** (off the hot table-refresh path); the follow-up count reuses the nav-badge predicate via a new shared `follow_up_count()` helper so the two never drift. The bar is `flex-shrink-0` inside a `calc(100vh-90px)` flex column with the split panel as `flex-1`, so the workspace keeps its original viewport footprint (no magic-number height math).
2. **Canonical full page `/v2/offers/review-queue`** added to `v2_page` (new `offers` view segment → `/v2/partials/offers/review-queue`) so the pushed URL reloads/bookmarks into the queue instead of 404ing (root-cause, not a dead push-url). `/v2/follow-ups` already existed.
3. **Approvals Buy-Plans tab** (`_tab_buy_plan.html`) gains a **"My Buy Plans"** link to the personal hub at `/v2/buy-plans` — the org-wide decide console's only click-through to the per-user My Queue / Pipeline hub. Distinct from the existing "New Buy Plan" origination link.

## Tests
- `TestSightingsWorkspaceExtra` — workspace exposes both entry-point `hx-get` URLs + push URLs, and renders the amber pending-review count pill when a `PENDING_REVIEW` offer exists.
- `test_buy_plan_tab_links_to_personal_hub` — the Approvals buy-plan tab renders the "My Buy Plans" link at `/v2/partials/buy-plans` → `#main-content` → `/v2/buy-plans`.
- `TestV2FullPages::test_v2_page` — `/v2/offers/review-queue` wires the review-queue partial into the shell.

Full sightings router suite (430) + approvals hub + htmx-views-deep green; ruff + mypy clean.

Docs: `APP_MAP_ARCHITECTURE.md` updated with the new nav surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)