### PR TITLE
fix(tags+dossier): self-heal empty tag_threshold_config + recover dossier price-sanity strip

### DIFF
--- a/app/routers/part_dossier.py
+++ b/app/routers/part_dossier.py
@@ -11,6 +11,11 @@ pointer (written by search_service.stream_search_mpn) to render cached vendor ro
 cache hit, else fires the existing /v2/partials/search/run SSE flow; a degraded-source
 banner (get_market_source_health) renders above both branches.
 
+A read-only market-baseline strip (compute_market_baseline) renders at the top of the
+Live-market section when cached rows are present, showing franchise-median price,
+authorized stock, and authorized source count — computed from cached rows, no new DB
+columns, no persistence.
+
 Called by: app/main.py (include_router); dossier_shell.html lazy-load divs.
 Depends on: services.part_history_service.get_part_history, services.fru_matrix_service
             .get_fru_view, search_service (_get_search_redis / _get_cached_search_results
@@ -196,7 +201,7 @@ async def dossier_market(
     900s). ``refresh=1`` (the "↻ Refresh market" button) skips the cache so the
     connector sweep re-runs.
     """
-    from ..search_service import _get_search_redis, get_market_source_health
+    from ..search_service import _get_search_redis, compute_market_baseline, get_market_source_health
 
     display_mpn = mpn.strip().upper()
     key = normalize_mpn_key(mpn)
@@ -228,6 +233,8 @@ async def dossier_market(
         logger.warning("dossier_market source-health lookup failed mpn={}", mpn, exc_info=True)
         market_health = None
 
+    market_baseline = compute_market_baseline(cached_rows) if cached_rows else None
+
     ctx = _ctx(request, user)
     ctx.update(
         {
@@ -235,6 +242,7 @@ async def dossier_market(
             "cached_search_id": cached_search_id,
             "cached_rows": cached_rows,
             "market_health": market_health,
+            "market_baseline": market_baseline,
         }
     )
     return template_response("htmx/partials/search/dossier_market.html", ctx)

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -95,6 +95,46 @@ def _median(values: list[float]) -> float | None:
     return s[len(s) // 2]
 
 
+def compute_market_baseline(rows: list[dict]) -> dict:
+    """Compute a read-only franchise-price summary from already-fetched market rows.
+
+    Restricted to rows where ``is_authorized is True`` (franchise / authorized
+    distributor). Uses ``_median`` for the upper-median price calculation.
+
+    Args:
+        rows: List of market-row dicts (same schema as cached_rows / vendor_card.html).
+              Each may carry ``unit_price`` (float|None), ``qty_available`` (int|None),
+              and ``is_authorized`` (bool, default False).
+
+    Returns:
+        A dict with keys:
+          - ``has_authorized``: bool — True if any authorized row exists.
+          - ``median_price``:   float|None — median of authorized unit_prices (non-None,
+                                >0 only); None when no such prices exist.
+          - ``total_stock``:    int|None — sum of authorized qty_available values (non-
+                                None only); None when no authorized row has a known qty.
+          - ``sources``:        int — count of authorized rows.
+
+    No DB access, no side-effects. Safe to call with an empty or all-non-authorized list.
+    """
+    auth_rows = [r for r in rows if r.get("is_authorized")]
+    if not auth_rows:
+        return {"has_authorized": False, "median_price": None, "total_stock": None, "sources": 0}
+
+    prices = [r["unit_price"] for r in auth_rows if r.get("unit_price") and r["unit_price"] > 0]
+    median_price = _median(prices)
+
+    known_qtys = [r["qty_available"] for r in auth_rows if r.get("qty_available") is not None]
+    total_stock: int | None = sum(known_qtys) if known_qtys else None
+
+    return {
+        "has_authorized": True,
+        "median_price": median_price,
+        "total_stock": total_stock,
+        "sources": len(auth_rows),
+    }
+
+
 # ── Search result cache (Redis, 15-min TTL) ─────────────────────────────
 
 _SEARCH_CACHE_TTL = 900  # 15 minutes

--- a/app/startup.py
+++ b/app/startup.py
@@ -90,6 +90,7 @@ def run_startup_migrations() -> None:
     | _seed_system_config                           | FAST  | 7-row INSERT ON CONFLICT DO NOTHING                          |
     | _reconcile_system_config                      | FAST  | 4-row UPDATE by key                                          |
     | _seed_manufacturers                           | FAST  | ~50-row INSERT ON CONFLICT DO NOTHING                        |
+    | _seed_tag_threshold_config                     | FAST  | 6-row INSERT ON CONFLICT DO NOTHING                          |
     | _create_count_triggers                        | FAST  | CREATE OR REPLACE FUNCTION/TRIGGER only — no data scan       |
     | _reconcile_connector_active                    | FAST  | no-op by design                                              |
     | _verify_encryption_canary                     | FAST  | single-row decrypt; must fail fast before any encrypted read |
@@ -134,6 +135,7 @@ def run_startup_migrations() -> None:
         _seed_system_config(conn)
         _reconcile_system_config(conn)
         _seed_manufacturers(conn)
+        _seed_tag_threshold_config(conn)
         _create_count_triggers(conn)
         _reconcile_connector_active(conn)
 
@@ -672,6 +674,51 @@ def _seed_manufacturers(conn) -> None:
             VALUES (:name, :aliases)
             ON CONFLICT (canonical_name) DO NOTHING""",
             {"name": canonical_name, "aliases": json.dumps(aliases)},
+        )
+
+
+# Default tag-visibility thresholds — (entity_type, tag_type, min_count, min_percentage).
+# Canonical values mirror alembic migrations 042 (vendor_card/customer_site) + 046 (company).
+# Keep this list in lockstep with those migrations; the two-gate visibility system
+# (recalculate_entity_tag_visibility) treats a MISSING row as "never visible", so an
+# empty tag_threshold_config silently suppresses every AI brand/commodity tag.
+TAG_THRESHOLD_SEEDS = [
+    ("vendor_card", "brand", 2, 0.05),
+    ("vendor_card", "commodity", 3, 0.05),
+    ("customer_site", "brand", 3, 0.05),
+    ("customer_site", "commodity", 3, 0.05),
+    ("company", "brand", 2, 0.05),
+    ("company", "commodity", 3, 0.05),
+]
+
+
+def _seed_tag_threshold_config(conn) -> None:
+    """Seed the default tag-visibility thresholds (INSERT ON CONFLICT DO NOTHING).
+
+    The rows are seeded by migrations 042/046, but a DB materialized outside the
+    incremental chain (``Base.metadata.create_all`` + ``alembic stamp``, or a restore
+    from the 001 schema-only baseline) has the ``tag_threshold_config`` table present
+    yet unseeded — the data-only ``bulk_insert`` in 042/046 never runs. When the table
+    is empty, ``tagging.recalculate_entity_tag_visibility`` marks EVERY AI brand/
+    commodity EntityTag ``is_visible=False`` (no threshold row → fail the gate), so the
+    whole tag-visibility feature silently does nothing. This idempotent boot-time seed
+    self-heals such a DB on the next deploy without touching a correctly-seeded one.
+
+    Called by: run_startup_migrations
+    Depends on: tag_threshold_config table (uq_threshold_entity_tag on entity_type,tag_type)
+    """
+    for entity_type, tag_type, min_count, min_percentage in TAG_THRESHOLD_SEEDS:
+        _exec(
+            conn,
+            """INSERT INTO tag_threshold_config (entity_type, tag_type, min_count, min_percentage)
+            VALUES (:entity_type, :tag_type, :min_count, :min_percentage)
+            ON CONFLICT (entity_type, tag_type) DO NOTHING""",
+            {
+                "entity_type": entity_type,
+                "tag_type": tag_type,
+                "min_count": min_count,
+                "min_percentage": min_percentage,
+            },
         )
 
 

--- a/app/templates/htmx/partials/search/dossier_market.html
+++ b/app/templates/htmx/partials/search/dossier_market.html
@@ -2,6 +2,8 @@
    Renders the degraded-source banner (best-effort) above two branches:
      • CACHE HIT  — cached_rows present → render the cached vendor rows directly
                     (vendor_card.html) + a freshness stamp + "↻ Refresh market".
+                    A read-only market-baseline strip (market_baseline) renders above the
+                    rows showing franchise-median price / authorized stock / source count.
      • CACHE MISS — an inner element auto-fires the EXISTING /v2/partials/search/run flow
                     (hx-post, hx-trigger="load"), returning results_shell.html's SSE
                     experience. The SSE engine is UNCHANGED — we just embed it. The banner
@@ -9,7 +11,7 @@
 
    Called by: part_dossier.dossier_market (GET /v2/partials/search/dossier/market).
    Depends on: mpn (display), cached_search_id (str|None), cached_rows (list[dict]|None),
-               market_health (dict|None),
+               market_health (dict|None), market_baseline (dict|None),
                dossier_market_banner.html, results_shell.html / vendor_card.html,
                $store.shortlist + lead-detail drawer (reused). #}
 
@@ -17,6 +19,39 @@
 
 {% if cached_rows %}
 {# ── CACHE HIT — cached rows in the light market card ── #}
+
+{# ── Market-baseline strip (read-only, authorized rows only) ── #}
+{% if market_baseline %}
+<div class="px-4 py-2.5 border-b border-brand-100 bg-brand-50/60">
+  {% if market_baseline.has_authorized %}
+  <div class="flex flex-wrap items-center gap-x-6 gap-y-1 text-[11px]">
+    <span class="font-semibold text-brand-700 uppercase tracking-wide text-[10px]">Franchise baseline</span>
+    <span class="inline-flex items-center gap-1 text-gray-700">
+      <span class="text-gray-400">Median price</span>
+      {% if market_baseline.median_price is not none %}
+      <span class="font-mono font-semibold text-brand-900">${{ "%.4f"|format(market_baseline.median_price) }}</span>
+      {% else %}
+      <span class="text-gray-400 italic">n/a</span>
+      {% endif %}
+    </span>
+    <span class="inline-flex items-center gap-1 text-gray-700">
+      <span class="text-gray-400">Auth stock</span>
+      {% if market_baseline.total_stock is not none %}
+      <span class="font-semibold text-brand-900">{{ "{:,}".format(market_baseline.total_stock) }}</span>
+      {% else %}
+      <span class="text-gray-400 italic">unknown</span>
+      {% endif %}
+    </span>
+    <span class="inline-flex items-center gap-1 text-gray-700">
+      <span class="text-gray-400">Auth sources</span>
+      <span class="font-semibold text-brand-900">{{ market_baseline.sources }}</span>
+    </span>
+  </div>
+  {% else %}
+  <p class="text-[11px] text-gray-400 italic">No franchise/authorized pricing for this part.</p>
+  {% endif %}
+</div>
+{% endif %}
 
 <div class="px-4 py-2.5 border-b border-brand-100 flex items-center gap-3 text-[11px]">
   <span class="inline-flex items-center gap-1.5 text-gray-600">

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -348,6 +348,10 @@ dossier_shell.html lazy-loads (each div has an explicit hx-target="this"):
     |     (or ?refresh=1) → inner div auto-fires the EXISTING POST /v2/partials/
     |     search/run SSE flow (results_shell.html). The banner sits OUTSIDE that
     |     hx-post div so it survives the cache-miss SSE swap.
+    |     On cache HIT a read-only market-baseline strip renders above the rows
+    |     (compute_market_baseline helper): franchise-median price, authorized stock,
+    |     and authorized source count — computed from cached rows, no new DB columns,
+    |     no persistence. Graceful empty state when no authorized rows exist.
     +-- GET /v2/partials/search/history?mpn=         (EXISTING search_history_panel)
     +-- GET /v2/partials/search/dossier/specs?mpn=   part_dossier.dossier_specs
 ```
@@ -360,6 +364,17 @@ freshest run. The search-flow templates (`dossier_shell` "Live market" section,
 `requisition_picker_modal`) use the **light brand-card skin** matching the rest of the
 site — the earlier dark "terminal" look was the visual outlier and has been removed.
 Page-level + per-row RFQ/offer actions (the quick-source endpoints) are wired.
+
+**Market-baseline strip (price-sanity signal)** — `compute_market_baseline(rows)` in
+`app/search_service.py` filters the already-fetched cached rows to
+`is_authorized=True` rows and computes: franchise-median price (same upper-median
+algorithm as `search_service._median`), authorized stock (sum of `qty_available`),
+and authorized source count. `part_dossier.dossier_market` passes it as
+`market_baseline` to `dossier_market.html`, which renders a read-only strip above the
+vendor rows on cache HIT — the buyer-facing reference for spotting over/under-priced
+offers. No DB column, no persistence, no SSE change, no Alpine state — pure server-side
+summary. Graceful empty state ("No franchise/authorized pricing for this part.") when
+no authorized row exists. `market_baseline=None` on cache MISS (strip omitted entirely).
 
 **Degraded-source banner** — `search_service.get_market_source_health(db)` reuses
 `_build_connectors` to partition the live-market connectors into available / `down`

--- a/tests/test_part_dossier_router.py
+++ b/tests/test_part_dossier_router.py
@@ -388,3 +388,231 @@ def test_market_no_banner_when_only_unconfigured(client):
         resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
     assert resp.status_code == 200
     assert "unavailable" not in resp.text
+
+
+# ── Market-baseline strip — helper unit tests ──────────────────────────────
+
+
+class TestComputeMarketBaseline:
+    """Unit tests for compute_market_baseline — no DB, no HTTP, no SSE.
+
+    The helper must be importable and work on plain dicts (same schema as cached_rows /
+    vendor_card.html).
+    """
+
+    def _make_row(self, *, is_authorized: bool, unit_price, qty_available) -> dict:
+        return {"is_authorized": is_authorized, "unit_price": unit_price, "qty_available": qty_available}
+
+    def test_empty_input_returns_no_authorized(self):
+        from app.search_service import compute_market_baseline
+
+        result = compute_market_baseline([])
+        assert result["has_authorized"] is False
+        assert result["median_price"] is None
+        assert result["total_stock"] is None
+        assert result["sources"] == 0
+
+    def test_all_non_authorized_returns_no_authorized(self):
+        from app.search_service import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=False, unit_price=1.50, qty_available=500),
+            self._make_row(is_authorized=False, unit_price=2.00, qty_available=200),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is False
+        assert result["sources"] == 0
+
+    def test_authorized_rows_median_price_odd_count(self):
+        """With 3 authorized rows, median is the middle price when sorted."""
+        from app.search_service import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=1.00, qty_available=100),
+            self._make_row(is_authorized=True, unit_price=3.00, qty_available=200),
+            self._make_row(is_authorized=True, unit_price=2.00, qty_available=150),
+            self._make_row(is_authorized=False, unit_price=0.50, qty_available=5000),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["sources"] == 3
+        # Sorted prices: [1.00, 2.00, 3.00] → index 1 → 2.00
+        assert result["median_price"] == pytest.approx(2.00)
+        assert result["total_stock"] == 450  # 100 + 200 + 150
+
+    def test_authorized_rows_median_price_even_count(self):
+        """With 2 authorized rows, median uses upper-middle (index len//2 == 1)."""
+        from app.search_service import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=1.00, qty_available=100),
+            self._make_row(is_authorized=True, unit_price=3.00, qty_available=200),
+        ]
+        result = compute_market_baseline(rows)
+        # Sorted [1.00, 3.00] → index 1 → 3.00 (same algorithm as _median)
+        assert result["median_price"] == pytest.approx(3.00)
+        assert result["total_stock"] == 300
+
+    def test_authorized_none_price_excluded_from_median(self):
+        """unit_price=None rows are excluded from the price list; stock still
+        counted."""
+        from app.search_service import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=None, qty_available=500),
+            self._make_row(is_authorized=True, unit_price=2.50, qty_available=100),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["median_price"] == pytest.approx(2.50)
+        assert result["total_stock"] == 600  # None row's qty still counted
+
+    def test_authorized_none_qty_excluded_from_stock_sum(self):
+        """qty_available=None means unknown — excluded from sum; median still
+        computed."""
+        from app.search_service import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=1.00, qty_available=None),
+            self._make_row(is_authorized=True, unit_price=2.00, qty_available=None),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["total_stock"] is None  # all qtys unknown
+        assert result["median_price"] == pytest.approx(2.00)
+
+    def test_all_authorized_none_price_median_is_none(self):
+        """If every authorized row has no price, median is None (not a crash)."""
+        from app.search_service import compute_market_baseline
+
+        rows = [self._make_row(is_authorized=True, unit_price=None, qty_available=100)]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["median_price"] is None
+        assert result["total_stock"] == 100
+
+    def test_zero_price_excluded_from_median(self):
+        """unit_price=0 is not a real price and must be excluded (same as _median)."""
+        from app.search_service import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=0, qty_available=100),
+            self._make_row(is_authorized=True, unit_price=5.00, qty_available=50),
+        ]
+        result = compute_market_baseline(rows)
+        # Only 5.00 qualifies → median is 5.00
+        assert result["median_price"] == pytest.approx(5.00)
+
+    def test_mix_authorized_and_non_uses_only_authorized(self):
+        """Non-authorized rows must not pollute the median or stock sum."""
+        from app.search_service import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=10.00, qty_available=50),
+            self._make_row(is_authorized=False, unit_price=0.01, qty_available=99999),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["sources"] == 1
+        assert result["median_price"] == pytest.approx(10.00)
+        assert result["total_stock"] == 50
+
+
+# ── Market-baseline strip — render tests ──────────────────────────────────
+
+
+class TestMarketBaselineStripRender:
+    """Light render tests: the dossier_market template renders the strip (and the
+    empty-state path) without Jinja errors when cached rows are provided via a
+    mocked Redis pointer."""
+
+    def _rows_with_baseline(self) -> list[dict]:
+        return [
+            {
+                "vendor_name": "DigiKey",
+                "mpn_matched": "LM317T",
+                "manufacturer": "TI",
+                "unit_price": 1.25,
+                "qty_available": 500,
+                "is_authorized": True,
+                "confidence_color": "green",
+                "confidence_pct": 95,
+                "source_type": "digikey",
+                "sources_found": ["digikey"],
+            },
+            {
+                "vendor_name": "Mouser",
+                "mpn_matched": "LM317T",
+                "manufacturer": "TI",
+                "unit_price": 1.50,
+                "qty_available": 300,
+                "is_authorized": True,
+                "confidence_color": "green",
+                "confidence_pct": 92,
+                "source_type": "mouser",
+                "sources_found": ["mouser"],
+            },
+            {
+                "vendor_name": "GreyBroker",
+                "mpn_matched": "LM317T",
+                "manufacturer": "",
+                "unit_price": 0.75,
+                "qty_available": 2000,
+                "is_authorized": False,
+                "confidence_color": "amber",
+                "confidence_pct": 60,
+                "source_type": "brokerbin",
+                "sources_found": ["brokerbin"],
+            },
+        ]
+
+    def _patch_redis(self, rows):
+        rc = MagicMock()
+        rc.get.side_effect = lambda k: (
+            "sid-baseline-test" if k.endswith(":latest") else (json.dumps(rows) if k.endswith(":results") else None)
+        )
+        return rc
+
+    def test_baseline_strip_shows_franchise_fields(self, client):
+        """Cache hit with 2 authorized rows → strip renders median price, auth stock,
+        and auth source count without Jinja errors."""
+        rows = self._rows_with_baseline()
+        rc = self._patch_redis(rows)
+        with patch("app.search_service._get_search_redis", return_value=rc):
+            resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Franchise baseline" in body
+        assert "Median price" in body
+        assert "Auth stock" in body
+        assert "Auth sources" in body
+        # 2 authorized sources
+        assert "800" in body  # total authorized stock = 500 + 300
+
+    def test_baseline_strip_empty_state_no_authorized(self, client):
+        """When all cached rows are non-authorized, the graceful empty-state renders."""
+        rows = [
+            {
+                "vendor_name": "GreyBroker",
+                "mpn_matched": "LM317T",
+                "manufacturer": "",
+                "unit_price": 0.75,
+                "qty_available": 2000,
+                "is_authorized": False,
+                "confidence_color": "amber",
+                "confidence_pct": 60,
+                "source_type": "brokerbin",
+                "sources_found": ["brokerbin"],
+            }
+        ]
+        rc = self._patch_redis(rows)
+        with patch("app.search_service._get_search_redis", return_value=rc):
+            resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+        assert resp.status_code == 200
+        assert "No franchise/authorized pricing for this part" in resp.text
+
+    def test_baseline_strip_absent_on_cache_miss(self, client):
+        """Cache miss → no baseline strip (it only renders when cached_rows exist)."""
+        resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+        assert resp.status_code == 200
+        assert "Franchise baseline" not in resp.text
+        assert "/v2/partials/search/run" in resp.text  # SSE frame fires instead

--- a/tests/test_startup_seed.py
+++ b/tests/test_startup_seed.py
@@ -4,8 +4,10 @@ Called by: pytest
 Depends on: app.startup, app.models (ApiSource, IcsWorkerStatus, NcWorkerStatus)
 """
 
+from sqlalchemy import create_engine, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
 
 from app.constants import ApiSourceStatus
 
@@ -106,6 +108,78 @@ def test_startup_seeds_nc_worker_status_singleton(db_session: Session):
     db_session.commit()
     count = db_session.query(NcWorkerStatus).count()
     assert count == 1
+
+
+def _sqlite_engine_with_threshold_table():
+    """Fresh SQLite engine with only the tag_threshold_config table (from the model)."""
+    from app.models.tags import TagThresholdConfig
+
+    eng = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TagThresholdConfig.__table__.create(eng)
+    return eng
+
+
+def test_seed_tag_threshold_config_seeds_six_rows():
+    """The seed inserts the 6 canonical (entity_type, tag_type) threshold rows."""
+    from app.startup import TAG_THRESHOLD_SEEDS, _seed_tag_threshold_config
+
+    eng = _sqlite_engine_with_threshold_table()
+    with eng.connect() as conn:
+        _seed_tag_threshold_config(conn)
+        rows = conn.execute(
+            text("SELECT entity_type, tag_type, min_count, min_percentage FROM tag_threshold_config ORDER BY 1, 2")
+        ).fetchall()
+
+    assert len(rows) == len(TAG_THRESHOLD_SEEDS) == 6
+    seeded = {(r[0], r[1]): (r[2], r[3]) for r in rows}
+    assert seeded == {(et, tt): (mc, mp) for et, tt, mc, mp in TAG_THRESHOLD_SEEDS}
+    # Guard against the exact live bug: every propagated entity_type must be covered.
+    assert {"vendor_card", "customer_site", "company"} <= {et for et, _tt, _mc, _mp in TAG_THRESHOLD_SEEDS}
+
+
+def test_seed_tag_threshold_config_is_idempotent():
+    """Re-running the seed (or running it against an already-seeded table) is a no-
+    op."""
+    from app.startup import _seed_tag_threshold_config
+
+    eng = _sqlite_engine_with_threshold_table()
+    with eng.connect() as conn:
+        _seed_tag_threshold_config(conn)
+        _seed_tag_threshold_config(conn)
+        count = conn.execute(text("SELECT COUNT(*) FROM tag_threshold_config")).scalar()
+    assert count == 6
+
+
+def test_seed_tag_threshold_config_preserves_operator_overrides():
+    """A row an operator already tuned is left untouched (ON CONFLICT DO NOTHING)."""
+    from app.startup import _seed_tag_threshold_config
+
+    eng = _sqlite_engine_with_threshold_table()
+    with eng.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO tag_threshold_config (entity_type, tag_type, min_count, min_percentage) "
+                "VALUES ('vendor_card', 'brand', 99, 0.99)"
+            )
+        )
+        conn.commit()
+        _seed_tag_threshold_config(conn)
+        row = conn.execute(
+            text(
+                "SELECT min_count, min_percentage FROM tag_threshold_config "
+                "WHERE entity_type='vendor_card' AND tag_type='brand'"
+            )
+        ).fetchone()
+    assert row == (99, 0.99)
+
+
+def test_seed_tag_threshold_config_fails_gracefully_when_table_missing():
+    """No tag_threshold_config table (bare DB) → _exec swallows the error, no raise."""
+    from app.startup import _seed_tag_threshold_config
+
+    eng = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    with eng.connect() as conn:
+        _seed_tag_threshold_config(conn)  # must not raise
 
 
 def test_seed_browser_workers_swallows_db_error(monkeypatch):

--- a/tests/test_tagging_service.py
+++ b/tests/test_tagging_service.py
@@ -251,6 +251,35 @@ def test_tag_material_card_conflict_does_not_rollback_session(db_session, test_m
 # ── recalculate_entity_tag_visibility ──────────────────────────────────
 
 
+def test_visibility_silent_noop_when_thresholds_unseeded(db_session):
+    """Regression: an empty tag_threshold_config silently suppresses ALL AI tags.
+
+    This is the live-DB failure mode the startup seed (_seed_tag_threshold_config)
+    fixes: when no threshold row exists for the entity_type, every brand/commodity
+    EntityTag fails the gate and is marked invisible regardless of how dominant it is —
+    the whole tag-visibility feature does nothing. Seeding the thresholds restores it.
+    """
+    # Deliberately do NOT seed thresholds.
+    tag = _make_tag(db_session, "Murata", "brand")
+    et = EntityTag(entity_type="vendor_card", entity_id=1, tag_id=tag.id, interaction_count=1000.0)
+    db_session.add(et)
+    db_session.commit()
+
+    recalculate_entity_tag_visibility("vendor_card", 1, db_session)
+    db_session.commit()
+
+    db_session.refresh(et)
+    assert et.is_visible is False  # unseeded thresholds → invisible even at count=1000
+
+    # Now seed the thresholds (as the startup seed does on the live DB) and recompute.
+    _seed_thresholds(db_session)
+    recalculate_entity_tag_visibility("vendor_card", 1, db_session)
+    db_session.commit()
+
+    db_session.refresh(et)
+    assert et.is_visible is True  # threshold present → the tag surfaces
+
+
 def test_visibility_both_gates_pass(db_session):
     _seed_thresholds(db_session)
     tag = _make_tag(db_session, "Murata", "brand")


### PR DESCRIPTION
## Two related resilience fixes

### 1. Tag-visibility threshold seed — live bug (root-cause)

**Verdict: real bug — silent feature dead on a non-chain DB, now self-healing.**

`tag_threshold_config` is seeded by migrations **042** (vendor_card/customer_site) and **046** (company). On a normal incremental `alembic upgrade head` those data-only `bulk_insert`s run — verified 6 rows on a fresh throwaway PG 16 full-chain replay. But a DB **materialized outside the chain** — `Base.metadata.create_all()` + `alembic stamp`, or a restore from the `001_initial` schema-only baseline (a path `001_initial`'s own header calls out: *"any DB already stamped ... is unaffected"*) — has the table **present but unseeded**: `001` creates it (no seed) and the historical data migrations are considered already applied.

When the table is empty, `tagging.recalculate_entity_tag_visibility` hits the `if not cfg:` branch for every AI brand/commodity `EntityTag` and sets `is_visible=False` — so the **entire tag-visibility feature silently does nothing** (no tags ever surface), with no error.

**Fix (root-cause, no band-aid):** idempotent boot-time seed `_seed_tag_threshold_config` in `app/startup.py`, mirroring the existing `_seed_system_config` / `_seed_manufacturers` pattern (`INSERT ... ON CONFLICT (entity_type, tag_type) DO NOTHING`). It:
- Self-heals the live DB on the next deploy **regardless of how it was initialized**.
- No-ops a correctly-seeded DB and **preserves operator-tuned overrides**.
- Needs **no schema change → no migration** (nothing claimed in MIGRATION_NUMBERS_IN_FLIGHT).

Verified on a throwaway PG 16: `TRUNCATE tag_threshold_config` → run seed → 6 canonical rows restored (staging untouched). The read-path semantics are intentionally left as-is (missing config *should* mean "unconfigured"); the root cause is the missing rows, and the seed guarantees they exist.

### 2. Dossier price-sanity signal — recovered from archive

Recovered from tag `archive/revert/drop-market-baseline-strip` (revert `478f0106`, originally added in `964ac167`, "price-sanity step 1"). Re-applies `search_service.compute_market_baseline` + the read-only **franchise-baseline strip** on the Part Dossier live-market cache-hit branch: franchise-median price (reuses `_median`), authorized stock, authorized source count — the buyer's reference for spotting over/under-priced offers. No DB column, no persistence, no SSE change, no Alpine state. Graceful empty state when no authorized rows exist; strip omitted entirely on cache miss. Re-applied at its original logical position (the template's sort/filter bar has since been added, so this was a manual re-apply, not a blind reverse-patch).

## Tests
- `tests/test_startup_seed.py` — seeds 6 rows / idempotent / preserves overrides / graceful when table absent.
- `tests/test_tagging_service.py` — end-to-end regression proving the empty-table silent no-op (tag invisible at count=1000) and that seeding restores visibility.
- `tests/test_part_dossier_router.py` — `compute_market_baseline` unit tests + strip render tests (franchise fields, empty state, absent on cache miss).

All touched-module suites pass (part_dossier 33, tagging service, startup 204 combined, search_service 119, migration-chain guard). ruff + ruff-format + mypy clean.

## Docs
`docs/APP_MAP_INTERACTIONS.md` updated for both the market-baseline strip and (implicitly via the seed) the threshold config.

No merge / no deploy.