### PR TITLE
Resell rework Phase 3: anonymization hardening (D2)

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -181,9 +181,14 @@ def _list_cards(db: Session, lists: list[ExcessList], *, can_see_customer: bool)
                 "list": el,
                 "display_title": _display_title(el, can_see_customer=can_see_customer),
                 "customer_name": (el.company.name if (can_see_customer and el.company) else None),
-                "coverage_filled": covered,
-                "coverage_total": total,
-                "offer_count": offer_counts.get(el.id, 0),
+                # Offer coverage + count are OWNER-PRIVATE (D2): a non-owner (the "Open to
+                # Me" lens) must not learn how many lines already have offers or how many
+                # bids are in — same competitive leak the per-line offer badge hides. Null
+                # them here so the data never reaches the template (defense-in-depth with
+                # the ``can_see_customer`` gate around the meter/badge in _lists.html).
+                "coverage_filled": covered if can_see_customer else None,
+                "coverage_total": total if can_see_customer else None,
+                "offer_count": offer_counts.get(el.id, 0) if can_see_customer else None,
                 "hours_until": _hours_until(getattr(el, "close_at", None)),
             }
         )
@@ -400,6 +405,7 @@ async def resell_lists(
             "needs": needs,
             "q": q,
             "cards": cards,
+            "can_see_customer": can_see_customer,
             "can_post": excess_service.can_post(user),
         },
     )

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -28,7 +28,7 @@ from decimal import Decimal, InvalidOperation
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import HTMLResponse, Response
-from sqlalchemy import case, func
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.orm import Session, joinedload
 
 from ..constants import (
@@ -55,6 +55,7 @@ from ..services import (
 )
 from ..template_env import template_response
 from ..utils.csv_export import stream_csv
+from ..utils.normalization import normalize_mpn_key
 from ..utils.sql_helpers import escape_like
 
 router = APIRouter(tags=["resell"])
@@ -390,7 +391,21 @@ async def resell_lists(
             offer_lists = offer_lists.filter(ExcessOffer.scope == ExcessOfferScope.TAKE_ALL)
         query = query.filter(ExcessList.id.in_(offer_lists))
     if q:
-        query = query.filter(ExcessList.title.ilike(f"%{escape_like(q)}%", escape="\\"))
+        if lens == "open":
+            # #10: a non-owner must NOT be able to search the free-text title — traders name
+            # lists after the customer ("Acme Corp — surplus"), so title search is a
+            # de-anonymization oracle (a hit/miss confirms the hidden customer name). Match
+            # on PART IDENTITY instead: normalized MPN (query normalized the same way the
+            # column is) or manufacturer — both indexed (models/excess.py) — via a subquery
+            # on excess_list_id. The title ILIKE stays for the owner's mine lens only.
+            conds = [ExcessLineItem.manufacturer.ilike(f"%{escape_like(q)}%", escape="\\")]
+            norm_q = normalize_mpn_key(q)
+            if norm_q:
+                conds.append(ExcessLineItem.normalized_part_number.ilike(f"%{escape_like(norm_q)}%", escape="\\"))
+            part_match = select(ExcessLineItem.excess_list_id).where(or_(*conds))
+            query = query.filter(ExcessList.id.in_(part_match))
+        else:
+            query = query.filter(ExcessList.title.ilike(f"%{escape_like(q)}%", escape="\\"))
 
     lists = query.order_by(ExcessList.updated_at.desc().nullslast(), ExcessList.id.desc()).all()
     cards = _list_cards(db, lists, can_see_customer=can_see_customer)

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -1338,6 +1338,13 @@ def _buyer_panel_context(
     suggestions = _suggestion_rows(db, el, owner, line_ids)
     suggested_ids = {row["buyer"].vendor_card_id for row in suggestions}
     scope_lines = db.query(ExcessLineItem).filter(ExcessLineItem.id.in_(line_ids)).all() if line_ids else None
+    # Line count for the neutral outreach subject prefill (#11) — the campaign's scope:
+    # the selected lines, or the whole list. NEVER the title (which names the customer).
+    line_count = (
+        len(scope_lines)
+        if scope_lines
+        else (db.scalar(select(func.count(ExcessLineItem.id)).where(ExcessLineItem.excess_list_id == el.id)) or 0)
+    )
     return {
         "request": request,
         "user": owner,
@@ -1347,6 +1354,7 @@ def _buyer_panel_context(
         "channels": [c.value for c in ExcessOutreachChannel],
         "line_ids": line_ids or [],
         "scope_lines": scope_lines,
+        "line_count": line_count,
         "preselect_ids": preselect_ids or [],
     }
 

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -379,6 +379,17 @@ async def resell_lists(
         query = query.filter(ExcessList.owner_id == user.id)
         can_see_customer = True
 
+    # D2 (offer-EXISTENCE oracle): the offer-based ``needs`` triage — "lists carrying a
+    # live bid" — is the OWNER's board only. Applied in the open (offerer) lens it becomes
+    # an existence oracle: a non-owner could diff ``lens=open&needs=offers`` against plain
+    # ``lens=open`` to learn which anonymized "Excess listing #N" postings have already drawn
+    # a competing bid (``needs=take_all`` narrows it to whole-list bids) — the SAME
+    # competitive signal the coverage meter / amber badge / offer-count chip are hidden from
+    # non-owners to protect. Gate it on the one predicate (``can_see_customer``) everywhere:
+    # for a non-owner the filter never runs and the passed-through state never reflects it.
+    if not can_see_customer:
+        needs = ""
+
     if stage:
         query = query.filter(ExcessList.status == stage)
     if needs:
@@ -1562,7 +1573,6 @@ async def resell_not_yet_strip(
             vendor_card_id=b.vendor_card_id,
             owner_id=el.owner_id,
             buyer_name=b.display_name,
-            list_title=el.title,
             due_at=due,
         )
     return template_response(
@@ -1657,11 +1667,25 @@ async def resell_submit_outreach(
     return template_response("htmx/partials/resell/_outreach.html", _outreach_tracker_context(request, db, el, user))
 
 
-# Retry re-uses the standard offer template (the compose modal's seeded subject/body in
-# offer_buyers_modal.html) — the original campaign's subject/body are not persisted, so a
-# one-click retry re-sends with the default text. Kept in sync with that template.
-_RETRY_SUBJECT = "Excess available: {title}"
+# Retry prefers the EXACT subject/body the campaign was sent with (persisted on the row
+# since Phase 2: ``send_subject`` / ``send_body``) so the Sent-folder reconcile matches and
+# a customized send re-sends verbatim. These are only the FALLBACK for a row missing that
+# persisted text (legacy / cleared-subject rows). The subject ships EXTERNALLY to the buyer,
+# so the fallback must stay anonymized — a part-count subject, NEVER ``el.title`` (which
+# traders write as the customer name, the #11/#12 leak class the modal prefill + internal
+# ActivityLog subject already neutralized). Kept in sync with offer_buyers_modal.html.
 _RETRY_BODY = "We have the following excess available — let us know if you'd like to bid."
+
+
+def _neutral_outreach_subject(line_count: int) -> str:
+    """Neutral, part-count outreach subject — mirrors the compose-modal prefill.
+
+    Used as the retry resend's fallback subject when a row has no persisted ``send_subject``.
+    NEVER embeds ``el.title`` (the customer name), so the anonymized listing stays anonymized
+    on the external send. Matches ``offer_buyers_modal.html``'s ``Excess available: N line(s)``.
+    """
+    return f"Excess available: {line_count} line" + ("s" if line_count != 1 else "")
+
 
 # Outreach statuses a failed send can be retried FROM (a genuine send failure or an
 # interrupted/orphaned send — never a live sending/sent/engaged row).
@@ -1698,7 +1722,8 @@ async def resell_retry_outreach(
     if row.status not in _RETRYABLE_OUTREACH:
         raise HTTPException(409, "Only a failed or interrupted outreach can be retried")
 
-    subject = _RETRY_SUBJECT.format(title=el.title)
+    line_count = db.scalar(select(func.count(ExcessLineItem.id)).where(ExcessLineItem.excess_list_id == el.id)) or 0
+    subject = _neutral_outreach_subject(line_count)
     body = _RETRY_BODY
     # Optimistic flip so the tracker shows ``sending`` + self-polls to the final state.
     # Refresh ``created_at`` to now so the row is not "born stale": the nightly stale-sending

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -434,7 +434,13 @@ def notify_owner_of_offer(
     list gets its own row. Does NOT commit — the caller owns the transaction boundary.
     """
     token = f"resell-offer:{excess_list.id}:{buyer_ref}"
-    subject = f"New offer from {buyer_label} on {excess_list.title}"[:500]
+    # #12: reference the list neutrally by id, NEVER the free-text title — this row carries
+    # the buyer's ``vendor_card_id`` and renders on the SHARED cross-trader buyer timeline
+    # (the vendor-card Activity tab + GET /api/vendors/{id}/activities are keyed on
+    # vendor_card_id only), so a customer-named title would leak the customer to any other
+    # trader viewing that buyer. Same anonymization gate as the T3 ``_log_outreach_activity``
+    # "list #N" fix and the non-owner "Excess listing #N" label.
+    subject = f"New offer from {buyer_label} on list #{excess_list.id}"[:500]
     existing = (
         db.query(ActivityLog)
         .filter(

--- a/app/services/resell_outreach_service.py
+++ b/app/services/resell_outreach_service.py
@@ -288,7 +288,11 @@ def _log_outreach_activity(
         excess_list_id=excess_list.id,
         vendor_card_id=card.id,
         contact_name=card.display_name,
-        subject=f"{verb} {card.display_name}: excess offer ({excess_list.title})",
+        # #11: reference the list neutrally by id, NEVER the free-text title — this log lands
+        # on the SHARED buyer vendor-card timeline, so the customer-named title would leak the
+        # customer to any other trader viewing that buyer (same anonymization gate as the
+        # non-owner "Excess listing #N" label).
+        subject=f"{verb} {card.display_name}: excess offer (list #{excess_list.id})",
         notes=notes,
         is_meaningful=True,
         auto_logged=True,

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -741,7 +741,6 @@ def auto_create_resell_followup_task(
     vendor_card_id: int,
     owner_id: int,
     buyer_name: str,
-    list_title: str | None = None,
     due_at: datetime | None = None,
 ) -> RequisitionTask:
     """Idempotently create the list owner's My-Day follow-up for a buyer the resell
@@ -765,8 +764,13 @@ def auto_create_resell_followup_task(
     )
     if existing:
         return existing
-    suffix = f" on {list_title}" if list_title else ""
-    title = f"Follow up: offer {buyer_name}{suffix} this round"[:255]
+    # #12: reference the list by the neutral, id-derived label — NEVER the free-text title
+    # (which traders write as the customer name). This task is scoped to the buyer's
+    # ``vendor_card_id`` and renders on the SHARED cross-trader buyer Tasks tab
+    # (get_open_tasks_for_vendor_card returns every open task on the card, no assignee
+    # filter), so a customer-named title would leak the customer to any other trader viewing
+    # that buyer. Same anonymization gate as the non-owner "Excess listing #N" label.
+    title = f"Follow up: offer {buyer_name} on Excess listing #{excess_list_id} this round"[:255]
     task = RequisitionTask(
         vendor_card_id=vendor_card_id,
         title=title,

--- a/app/templates/htmx/partials/resell/_header_chips.html
+++ b/app/templates/htmx/partials/resell/_header_chips.html
@@ -28,10 +28,15 @@
   'expired': 'bg-gray-50 text-gray-400 border-gray-200'
 }) }}
 <span>{{ line_count }} line{{ 's' if line_count != 1 }}</span>
+{# Offer count is OWNER-PRIVATE (D2): a non-owner offerer must not learn how much
+   competitive interest the list has drawn (same leak class as the per-line offer badge). #}
+{% if can_see_customer %}
 <span>{{ offer_count }} offer{{ 's' if offer_count != 1 }}</span>
-{# Awarded coverage — emerald once every line is decided, amber while partial. Visible to
-   non-owners too (like the line/offer counts): "this deal is done" is not private. #}
-{% if awarded_line_count %}
+{% endif %}
+{# Awarded coverage — emerald once every line is decided, amber while partial. OWNER-PRIVATE
+   (D2, one policy everywhere): a non-owner watching deal progress is the same leak class as
+   the offer count, so it is gated with the rest of the count/coverage surfaces. #}
+{% if can_see_customer and awarded_line_count %}
 <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full font-medium border
     {{ 'bg-emerald-50 text-emerald-700 border-emerald-200' if awarded_line_count == line_count
        else 'bg-amber-50 text-amber-700 border-amber-200' }}">

--- a/app/templates/htmx/partials/resell/_lists.html
+++ b/app/templates/htmx/partials/resell/_lists.html
@@ -5,7 +5,7 @@
   awarded→won, draft→muted) — no new colors (spec §"Design consistency").
   Receives: cards [{list, display_title, customer_name, coverage_filled,
             coverage_total, offer_count, hours_until}], lens, stage, needs, q,
-            can_post, user.
+            can_see_customer (owner-only coverage/offer gate — D2), can_post, user.
   Called by: resell.resell_lists.
 #}
 {% from "htmx/partials/shared/_macros.html" import status_badge, coverage_meter, time_text, filter_pill %}
@@ -71,6 +71,11 @@
         }) }}
       </div>
       <div class="mt-1.5 flex items-center gap-3 text-secondary">
+        {# Offer coverage + count are OWNER-PRIVATE (D2): the "Open to Me" (offerer) lens
+           must not learn how many lines already have offers or how many bids are in —
+           same competitive leak the per-line offer badge hides. The closing time below
+           stays public (offerers need the window). #}
+        {% if can_see_customer %}
         <span class="inline-flex items-center gap-1.5" title="Offer coverage: {{ c.coverage_filled }} of {{ c.coverage_total }} lines have an offer">
           {{ coverage_meter(c.coverage_filled, c.coverage_total) }}
           <span class="tabular-nums">{{ c.coverage_filled }}/{{ c.coverage_total }}</span>
@@ -80,6 +85,7 @@
           <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
           {{ c.offer_count }}
         </span>
+        {% endif %}
         {% endif %}
         {% if c.hours_until is not none %}
         <span class="ml-auto">{{ time_text(c.hours_until) }}</span>

--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -98,7 +98,9 @@
             :class="tab === '{{ key }}' ? 'border-accent-500 text-accent-700' : 'border-transparent text-gray-500 hover:text-gray-700'"
             class="py-2.5 text-sm font-medium border-b-2 transition-colors">
       {{ label }}
-      {% if key == 'offers' and offer_count %}<span class="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-amber-100 text-amber-700" aria-label="{{ offer_count }} offers">{{ offer_count }}</span>{% endif %}
+      {# Offer-count badge is OWNER-PRIVATE (D2) — the tab body is already owner-only; gate
+         the label badge too so the count never leaks to a non-owner. #}
+      {% if key == 'offers' and offer_count and can_see_customer %}<span class="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-amber-100 text-amber-700" aria-label="{{ offer_count }} offers">{{ offer_count }}</span>{% endif %}
     </button>
     {% endfor %}
   </div>

--- a/app/templates/htmx/partials/resell/offer_buyers_modal.html
+++ b/app/templates/htmx/partials/resell/offer_buyers_modal.html
@@ -8,6 +8,7 @@
 
   Receives: list, suggestions [{buyer: RankedBuyer, overlap}], no_contact_buyers
             [{card}], channels (list), line_ids (list), scope_lines (or None),
+            line_count (int — neutral subject prefill, #11),
             preselect_ids (buyer vendor_card_ids to pre-check — RS-8), user.
   Called by: resell.resell_offer_buyers_form (via the detail "Offer to buyers" action
              and the "not yet offered" nudge chips, which pass a preselect buyer).
@@ -189,7 +190,10 @@
     <div x-show="channel === 'email'" x-cloak class="space-y-3">
       <div>
         <label class="form-label">Subject</label>
-        <input type="text" name="subject" class="input" value="Excess available: {{ el.title }}">
+        {# #11: NEVER prefill the customer-named list title — the subject ships externally
+           to the buyer and would de-anonymize the customer. Neutral, part-count default;
+           the owner can still edit it before sending. #}
+        <input type="text" name="subject" class="input" value="Excess available: {{ line_count }} line{{ 's' if line_count != 1 }}">
       </div>
       <div>
         <label class="form-label">Message</label>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2202,7 +2202,7 @@ never the seller company, and never any of these owner-private aggregates:
   the amber offer-count badge, and the **"N/M awarded"** progress chip — all competitive signal,
   gated identically to the already-private per-line offer badge / best-offer price (RS-1);
   `_list_cards` also NULLs coverage/offer_count for non-owners as defense-in-depth.
-Two de-anonymization ORACLES are closed the same way: (1) the left-list `q` search filters on
+Three de-anonymization ORACLES are closed the same way: (1) the left-list `q` search filters on
 **part identity** (normalized MPN / manufacturer, both indexed) in the open lens — never the
 title, which would let a non-owner confirm a hidden customer name by hit/miss; the title ILIKE
 stays for the owner's mine lens only. (2) The outreach email **subject** prefill is neutral
@@ -2210,6 +2210,18 @@ stays for the owner's mine lens only. (2) The outreach email **subject** prefill
 buyer; and the internal per-touch **ActivityLog subject** references the list by id
 (`excess offer (list #N)`), since that log lands on the SHARED buyer vendor-card timeline.
 Reply-matching is unaffected — it keys on the PERSISTED `send_subject`, not the prefill default.
+(3) The left-list **`needs`** offer-triage filter (`needs=offers` / `needs=take_all` → lists
+carrying a live/whole-list bid) is the OWNER's board only — gated on `can_see_customer`
+(`resell.py resell_lists`), so a non-owner cannot craft `lens=open&needs=offers` and diff it
+against the plain open lens to learn which anonymized `Excess listing #N` postings have already
+drawn a bid (the offer-EXISTENCE sibling of the offer-count chip it hides).
+
+Same gate on every OTHER cross-trader writer that names the list, since each lands on a surface
+keyed only on `vendor_card_id` (the shared buyer timeline / Tasks tab): the retry resend's
+**fallback** subject is the neutral part-count default, never `el.title` (used only when a legacy
+/ cleared row has no persisted `send_subject`); the inbound-offer **owner notification**
+(`notify_owner_of_offer` → `New offer from <buyer> on list #N`); and the "not yet offered"
+**follow-up task** title (`auto_create_resell_followup_task` → `… on Excess listing #N …`).
 
 **Notification tiers (`buyplan_notifications.py`).** Two tiers gate which channels fire:
 - **Urgent → email + Teams DM + in-app**: SO kickback (`notify_so_rejected`), PO kickback

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2190,6 +2190,27 @@ Demo seed: `python -m app.management.seed_resell_demo` (idempotent; `--reset` to
 three deal shapes (40-line collecting w/ per-line + unmatched + take-all offers, a single-line
 one-off w/ 2 offers, an awarded list).
 
+**Anonymization policy (Phase 3, decision D2 — one predicate everywhere).** Customer-identity
+hiding is enforced through the SINGLE ownership predicate `can_see_customer` (== `is_owner` ==
+`el.owner_id == user.id`), threaded from `resell.py` into every template. To a NON-owner (the
+"Open to Me" offerer lens + the non-owner detail) the app projects only MPN / qty / condition —
+never the seller company, and never any of these owner-private aggregates:
+- the seller **company name** and the **owner name** chip (`_header_chips.html`);
+- the free-text **title** — traders name lists after the customer, so a non-owner gets the
+  neutral `Excess listing #N` label (`_display_title`);
+- **offer count** (header "N offers" chip + Offers-tab count badge), **offer coverage** meter,
+  the amber offer-count badge, and the **"N/M awarded"** progress chip — all competitive signal,
+  gated identically to the already-private per-line offer badge / best-offer price (RS-1);
+  `_list_cards` also NULLs coverage/offer_count for non-owners as defense-in-depth.
+Two de-anonymization ORACLES are closed the same way: (1) the left-list `q` search filters on
+**part identity** (normalized MPN / manufacturer, both indexed) in the open lens — never the
+title, which would let a non-owner confirm a hidden customer name by hit/miss; the title ILIKE
+stays for the owner's mine lens only. (2) The outreach email **subject** prefill is neutral
+(`Excess available: N lines`) — never the customer-named title, which ships externally to the
+buyer; and the internal per-touch **ActivityLog subject** references the list by id
+(`excess offer (list #N)`), since that log lands on the SHARED buyer vendor-card timeline.
+Reply-matching is unaffected — it keys on the PERSISTED `send_subject`, not the prefill default.
+
 **Notification tiers (`buyplan_notifications.py`).** Two tiers gate which channels fire:
 - **Urgent → email + Teams DM + in-app**: SO kickback (`notify_so_rejected`), PO kickback
   (`notify_po_rejected`, fired from the verify-po reject path), new assignment / approval

--- a/docs/superpowers/plans/2026-07-17-resell-phase3-anonymization.md
+++ b/docs/superpowers/plans/2026-07-17-resell-phase3-anonymization.md
@@ -1,0 +1,77 @@
+# Resell Rework — Phase 3: Anonymization Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Close every known Resell anonymization leak before multi-user go-live — apply D2 (offer counts/coverage PRIVATE) to all surfaces via ONE predicate, stop the open-lens search + outreach-subject de-anonymization oracles, and replace assert-200 theater with real inclusion/exclusion + owner-scoping tests.
+
+**Architecture:** No schema change. Route every count/coverage/existence surface through the single existing ownership flag `can_see_customer` (== `el.owner_id == user.id`); reconcile the one code comment that declares the opposite. Search filters on part identity (indexed) in the open lens, never title. Subject prefill goes neutral.
+
+**Tech Stack:** FastAPI, Jinja2/HTMX templates, pytest. **No migration** (code + template + test only).
+
+## Global Constraints
+- ONE policy: reuse `can_see_customer` everywhere — do NOT invent a second flag. It already means "viewer owns this list" (`resell.py:267`, aliased `is_owner` at `_lines.html:16`).
+- The private-side precedent to mirror: `_lines.html:_line_offer_badge:20-34` (dash to non-owners) + the 403 guards (`resell.py:654-656`, `:557-561`). D2 generalizes this to the aggregate surfaces.
+- Do not change UI layout/elements beyond gating visibility (UI guardrail) — gating an existing chip on ownership is a visibility change, allowed; adding/removing chips is not.
+- Touching any resell test file forces its assertion-theater baseline entry to be burned down (CI lints changed files) — strengthen the test AND delete its `scripts/assertion_theater_baseline.txt` line in the same commit.
+
+## OPEN CONFIRM (surface to user when Phase 3 starts)
+- The adjacent **"N/M awarded" chip** (`_header_chips.html:34-40`) is declared *public* by the comment at `:32-33`. D2's "one policy everywhere" implies gating it too (a non-owner sees competitive progress), but D2 was scoped to offer counts/coverage. **Ask the user: gate the awarded chip on ownership too, or keep "deal done" public?** Recommend gate (consistency). Low-stakes, one quick confirm.
+
+---
+
+### Task 1: Apply D2 — gate the three count/coverage surfaces + reconcile the comment
+
+**Files:** Modify `app/routers/resell.py:_list_cards:135-186` (null the counts when `not can_see_customer`; pass the flag into `_lists.html` context at `:393-405`); `app/templates/htmx/partials/resell/_header_chips.html:30-33` (gate offer chip; rewrite the public-position comment); `detail.html:101` (add `and can_see_customer`); `_lists.html:73-83` (wrap coverage meter + amber badge). Test `tests/test_resell_draft_offer_privacy.py`.
+
+**Interfaces:** Consumes `can_see_customer`. Produces: header "N offers" chip, Offers-tab count badge, and open-lens coverage meter/badge all render ONLY for the owner; non-owner sees none of them (matching the already-private per-line badge).
+
+- [ ] **Step 1:** Failing tests (extend RS-1 pattern `tests/test_resell_draft_offer_privacy.py:127-144`) — a non-owner viewing a posted list's **detail** sees no "N offers" header chip and no Offers-tab count badge; a non-owner in `lens=open` sees no coverage meter / amber offer badge on the list rows. Owner still sees all three.
+- [ ] **Step 2:** Run — FAIL (surfaces currently leak).
+- [ ] **Step 3:** In `_list_cards`, set `coverage_filled/coverage_total/offer_count = None` when `not can_see_customer`; pass `can_see_customer` into the `_lists.html` render context. Gate `_header_chips.html:31` offer chip + `detail.html:101` badge on `can_see_customer`. Wrap `_lists.html:73-83` on the passed flag. Rewrite the `_header_chips.html:32-33` comment to state the PRIVATE policy.
+- [ ] **Step 4:** Run — PASS. **Step 5:** Commit.
+
+---
+
+### Task 2: #10 — open-lens search filters on part identity, not title
+
+**Files:** Modify `app/routers/resell.py:resell_lists` q-filter `:387-388`; Test `tests/test_resell_routes.py`.
+
+**Interfaces:** Produces: in `lens=open`, `q` matches `ExcessLineItem.normalized_part_number` / `.manufacturer` (both indexed, `models/excess.py:99-104`) via a subquery on `excess_list_id` — NEVER `ExcessList.title`. The title ILIKE stays only for `lens=mine`.
+
+- [ ] **Step 1:** Failing tests — `GET /...lists?lens=open&q=<customer name>` returns NO rows (title no longer searchable by non-owners); `?lens=open&q=<real MPN>` returns the matching anonymized row; `lens=mine&q=<title fragment>` still matches (owner).
+- [ ] **Step 2:** Run — FAIL (title currently searchable in both lenses).
+- [ ] **Step 3:** Branch the `q` filter on lens: open → part-identity subquery; mine → existing title ILIKE.
+- [ ] **Step 4:** Run — PASS. **Step 5:** Commit.
+
+---
+
+### Task 3: #11 — neutral outreach subject prefill (+ optional warn)
+
+**Files:** Modify `app/templates/htmx/partials/resell/offer_buyers_modal.html:192` (subject prefill); review/neutralize internal ActivityLog subject `resell_outreach_service.py:251`; Test `tests/test_resell_outreach_routes.py` or a template-render test.
+
+**Interfaces:** Produces: the outreach subject `value` no longer embeds `el.title` (the un-anonymized, customer-named field). Neutral part-based default (e.g. `Excess available: {{ line_count }} lines`). Reply-matching is unaffected (the send + `_find_sent_message` both use the same sent subject, `resell_outreach_service.py:485`). Optional: Alpine advisory warn (non-blocking, mirror the overlap-warning pattern `offer_buyers_modal.html:107-113`) if the typed subject contains the customer name.
+
+- [ ] **Step 1:** Failing test — the rendered outreach modal's subject input default does NOT contain `el.title`; a neutral default is present.
+- [ ] **Step 2:** Run — FAIL. **Step 3:** Replace the prefill with the neutral default; review `:251` internal subject. **Step 4:** Run — PASS. **Step 5:** Commit.
+
+---
+
+### Task 4: #21 — real filter/owner-scoping tests + ratchet the baseline
+
+**Files:** Modify `tests/test_nightly_resell_coverage.py:308-322` (strengthen stage/q); add `test_lists_mine_lens_excludes_other_owners`; strengthen `tests/test_resell_offers.py::test_confirm_import_resolves_material_card_id` (assert MAX232); drop redundant `tests/test_resell_outreach_routes.py::test_submit_outreach_posted_list_200:509`; Modify `scripts/assertion_theater_baseline.txt` (remove the strengthened/dropped entries: `:642`, `:643`, `:698`, `:699`, and any others touched from `:641-643,697-700`).
+
+**Interfaces:** Model to copy: `tests/test_resell_routes.py:1091-1158` (override `require_user` → owner; `assert title in body` / `assert other_title not in body`).
+
+- [ ] **Step 1:** Rewrite `test_lists_stage_filter` to seed collecting+awarded lists and assert `?stage=collecting` includes the collecting title, excludes the awarded one. Rewrite `test_lists_q_filter` with a title that actually contains the query term (inclusion) + a non-matching title (exclusion). Add `test_lists_mine_lens_excludes_other_owners` (another trader's list absent from `lens=mine`). Strengthen the confirm-import test to assert the MAX232 card. Drop the redundant outreach-200 test.
+- [ ] **Step 2:** Run the new/changed tests — green.
+- [ ] **Step 3:** Delete the corresponding lines from `scripts/assertion_theater_baseline.txt`; run `python3 scripts/lint_assertion_theater.py` (changed files) — passes with the entries burned down.
+- [ ] **Step 4:** `pre-commit run --all-files`; update `docs/APP_MAP_INTERACTIONS.md` (Resell privacy policy). Commit. Open PR; pr-review-fleet; live-verify (non-owner sees no counts; open-lens name-search returns nothing).
+
+---
+
+## Self-Review
+- **Coverage:** #9 (T1), #10 (T2), #11 (T3), #21 (T4). ✓
+- **One policy:** all surfaces reuse `can_see_customer`; the contradicting comment rewritten (T1). ✓
+- **Awarded-chip judgment** surfaced as an OPEN CONFIRM, not silently decided. ✓
+- **No migration** (code/template/test only). ✓
+- **Baseline ratchet** paired with each strengthened test (T4). ✓

--- a/scripts/assertion_theater_baseline.txt
+++ b/scripts/assertion_theater_baseline.txt
@@ -639,8 +639,6 @@ tests/test_nightly_coverage_boost.py::test_reassignment_exception_aborts_merge_f
 tests/test_nightly_coverage_boost.py::test_cache_invalidation_exception_logged
 tests/test_nightly_ics_worker.py::test_enqueue_for_ics_search_delegates
 tests/test_nightly_resell_coverage.py::test_draft_list_returns_200
-tests/test_nightly_resell_coverage.py::test_lists_stage_filter
-tests/test_nightly_resell_coverage.py::test_lists_q_filter
 tests/test_offer_qualification_routes.py::test_offer_mutation_happy_path
 tests/test_offers_nightly.py::test_list_offers_valid_req_returns_200
 tests/test_opportunity_value_inline.py::test_opportunity_value_owner_returns_200
@@ -695,8 +693,6 @@ tests/test_requisitions_core_coverage.py::test_sourcing_score_returns_data
 tests/test_requisitions_core_coverage.py::test_update_field_succeeds
 tests/test_requisitions_core_coverage.py::test_update_customer_site_id
 tests/test_resell_draft_offer_privacy.py::test_non_owner_offer_form_on_posted_200
-tests/test_resell_offers.py::test_confirm_import_resolves_material_card_id
-tests/test_resell_outreach_routes.py::test_submit_outreach_posted_list_200
 tests/test_resell_routes.py::test_offers_tab_renders
 tests/test_routers_crm.py::test_update_offer
 tests/test_routers_crm.py::test_delete_offer

--- a/tests/test_nightly_resell_coverage.py
+++ b/tests/test_nightly_resell_coverage.py
@@ -305,22 +305,58 @@ class TestResellOfferFormErrors:
         assert r.status_code == 403
 
 
+def _titled_list(db, owner, company, title, status=ExcessListStatus.COLLECTING):
+    """A list with an EXPLICIT title/status — for inclusion/exclusion filter asserts."""
+    el = ExcessList(
+        title=title,
+        company_id=company.id,
+        owner_id=owner.id,
+        status=status,
+        total_line_items=0,
+        created_at=datetime.now(UTC),
+    )
+    db.add(el)
+    db.flush()
+    return el
+
+
 class TestResellListFiltering:
     def test_lists_stage_filter(self, _trader_client, db_session: Session, test_company: Company):
-        """Lists filtered by stage returns 200."""
+        """Stage=collecting returns ONLY collecting lists — an awarded list is
+        excluded."""
         client, trader = _trader_client
-        _make_list(db_session, trader, test_company)
+        _titled_list(db_session, trader, test_company, "Collecting-Widget-List", ExcessListStatus.COLLECTING)
+        _titled_list(db_session, trader, test_company, "Awarded-Gizmo-List", ExcessListStatus.AWARDED)
         db_session.commit()
-        r = client.get("/v2/partials/resell/lists?stage=collecting&lens=mine")
-        assert r.status_code == 200
+
+        body = client.get("/v2/partials/resell/lists?stage=collecting&lens=mine").text
+        assert "Collecting-Widget-List" in body  # matching stage included
+        assert "Awarded-Gizmo-List" not in body  # non-matching stage excluded
 
     def test_lists_q_filter(self, _trader_client, db_session: Session, test_company: Company):
-        """Lists filtered by search query returns 200."""
+        """Q matches the title in the mine lens — matching title included, non-matching
+        excluded (proves the search actually filters, not just returns 200)."""
         client, trader = _trader_client
-        _make_list(db_session, trader, test_company)
+        _titled_list(db_session, trader, test_company, "Titanium capacitors surplus")
+        _titled_list(db_session, trader, test_company, "Ceramic resistors clearance")
         db_session.commit()
-        r = client.get("/v2/partials/resell/lists?q=surplus&lens=mine")
-        assert r.status_code == 200
+
+        body = client.get("/v2/partials/resell/lists?q=Titanium&lens=mine").text
+        assert "Titanium capacitors surplus" in body  # title contains the query term
+        assert "Ceramic resistors clearance" not in body  # non-matching title excluded
+
+    def test_lists_mine_lens_excludes_other_owners(self, _trader_client, db_session: Session, test_company: Company):
+        """Owner-scoping guard (multi-user): the mine lens returns ONLY the caller's
+        lists — another trader's list must never appear."""
+        client, trader = _trader_client
+        other = _make_trader(db_session)
+        _titled_list(db_session, trader, test_company, "My-Own-Surplus")
+        _titled_list(db_session, other, test_company, "Someone-Elses-Surplus")
+        db_session.commit()
+
+        body = client.get("/v2/partials/resell/lists?lens=mine").text
+        assert "My-Own-Surplus" in body  # caller's own list present
+        assert "Someone-Elses-Surplus" not in body  # another owner's list absent
 
 
 class TestResellCreateListErrors:

--- a/tests/test_resell_audit_fixes.py
+++ b/tests/test_resell_audit_fixes.py
@@ -278,6 +278,36 @@ class TestM6OwnerNotification:
         assert len(notifs) == 1
         assert notifs[0].contact_name == buyer.name
 
+    def test_offer_notification_subject_omits_customer_title(self, db_session, posted_list, owner, buyer):
+        """#12: the inbound-offer owner notification is an ActivityLog carrying the
+        buyer's ``vendor_card_id``, which renders on the SHARED cross-trader buyer
+        timeline (the vendor-card Activity tab + GET /api/vendors/{id}/activities key on
+        vendor_card_id only) — so the customer-named list title must NEVER appear in its
+        subject.
+
+        It references the list by the neutral id-derived label instead (mirrors the T3
+        outreach-log fix).
+        """
+        posted_list.title = "Acme Corp — surplus FPGAs"
+        db_session.commit()
+        excess_service.submit_offer(
+            db_session,
+            list_id=posted_list.id,
+            user=buyer,
+            scope="per_line",
+            lines=[{"mpn_raw": "LM358N", "quantity": 40, "unit_price": Decimal("1.25")}],
+        )
+        notifs = _system_notifs(
+            db_session, owner_id=owner.id, list_id=posted_list.id, activity_type=ActivityType.NEW_OFFER
+        )
+        assert len(notifs) == 1
+        subject = notifs[0].subject or ""
+        assert "Acme Corp — surplus FPGAs" not in subject, (
+            "customer title leaked into the cross-trader offer notification"
+        )
+        assert f"#{posted_list.id}" in subject, "the notification should reference the list neutrally by id"
+        assert buyer.name in subject  # the buyer label is still shown
+
     def test_second_offer_same_buyer_does_not_duplicate(self, db_session, posted_list, owner, buyer):
         for _ in range(2):
             excess_service.submit_offer(

--- a/tests/test_resell_draft_offer_privacy.py
+++ b/tests/test_resell_draft_offer_privacy.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime
 import pytest
 from sqlalchemy.orm import Session
 
-from app.constants import ExcessListStatus
+from app.constants import ExcessLineItemStatus, ExcessListStatus, ExcessOfferScope, ExcessOfferStatus
 from app.models import Company, User
 from app.models.excess import ExcessLineItem, ExcessList, ExcessOffer
 from app.utils.normalization import normalize_mpn_key
@@ -160,3 +160,118 @@ def test_owner_lines_tab_shows_best_offer_price_and_count(monkeypatch, client, d
     assert resp.status_code == 200
     assert "12.3456" in resp.text, "owner must still see the best offer price"
     assert "3 offer" in resp.text, "owner must still see the offer count"
+
+
+# ── D2: offer-count / coverage / awarded aggregates are OWNER-PRIVATE ──────
+# One policy (predicate `can_see_customer`) across every count/coverage/existence
+# surface: the header "N offers" chip, the Offers-tab count badge, the open-lens
+# coverage meter + amber offer badge, and the "N/M awarded" progress chip. A
+# non-owner (offerer) sees none of them — the same class of competitive leak the
+# per-line offer badge (RS-1) already hides.
+
+
+def _posted_list_with_offers(db_session, owner, company, *, n_offers: int) -> ExcessList:
+    """A posted (collecting) list carrying ``n_offers`` live OPEN offers."""
+    el = _list_with_line(db_session, owner, company, ExcessListStatus.COLLECTING)
+    for _ in range(n_offers):
+        db_session.add(
+            ExcessOffer(
+                excess_list_id=el.id,
+                submitted_by=owner.id,
+                scope=ExcessOfferScope.PER_LINE,
+                status=ExcessOfferStatus.OPEN,
+            )
+        )
+    db_session.commit()
+    return el
+
+
+def test_non_owner_detail_hides_offer_count_chip_and_badge(client, db_session, owner_user, test_company, test_user):
+    """D2: a non-owner viewing a posted list's DETAIL must not see the "N offers" header
+    chip or the Offers-tab count badge — both leak how much competitive interest the
+    list has drawn."""
+    assert test_user.id != owner_user.id
+    el = _posted_list_with_offers(db_session, owner_user, test_company, n_offers=2)
+
+    body = client.get(f"/v2/partials/resell/{el.id}").text
+    # Header chip renders "2 offers"; the tab badge's aria-label is "2 offers" — both gone.
+    assert "2 offer" not in body, "offer count leaked to a non-owner (header chip or tab badge)"
+    # The public line-count chip is unaffected (offerers need the listing size).
+    assert "1 line" in body
+
+
+def test_owner_detail_shows_offer_count_chip_and_badge(client, db_session, owner_user, test_company):
+    """Control: the OWNER still sees the offer count (header chip + tab badge)."""
+    el = _posted_list_with_offers(db_session, owner_user, test_company, n_offers=2)
+
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: owner_user
+    try:
+        body = client.get(f"/v2/partials/resell/{el.id}").text
+    finally:
+        client.app.dependency_overrides.pop(require_user, None)
+    assert "2 offer" in body, "owner must still see the offer count"
+
+
+def test_non_owner_detail_hides_awarded_chip(client, db_session, owner_user, test_company, test_user):
+    """D2 (one policy everywhere): the "N/M awarded" progress chip is owner-private — a
+    non-owner watching deal progress is the same leak class as the offer count."""
+    assert test_user.id != owner_user.id
+    el = _list_with_line(db_session, owner_user, test_company, ExcessListStatus.COLLECTING)
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=el.id).first()
+    line.status = ExcessLineItemStatus.AWARDED
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/resell/{el.id}").text
+    assert "1/1 awarded" not in body, "awarded-progress chip leaked to a non-owner"
+
+
+def test_owner_detail_shows_awarded_chip(client, db_session, owner_user, test_company):
+    """Control: the OWNER still sees the "N/M awarded" progress chip."""
+    el = _list_with_line(db_session, owner_user, test_company, ExcessListStatus.COLLECTING)
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=el.id).first()
+    line.status = ExcessLineItemStatus.AWARDED
+    db_session.commit()
+
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: owner_user
+    try:
+        body = client.get(f"/v2/partials/resell/{el.id}").text
+    finally:
+        client.app.dependency_overrides.pop(require_user, None)
+    assert "1/1 awarded" in body, "owner must still see the awarded-progress chip"
+
+
+def test_open_lens_hides_coverage_meter_and_offer_badge(client, db_session, owner_user, test_company, test_user):
+    """D2: the open (offerer) lens must not show the per-list coverage meter or the amber
+    offer-count badge — they reveal how many lines already have offers and how many bids
+    are in. Owner (mine lens) still sees them."""
+    assert test_user.id != owner_user.id
+    el = _list_with_line(db_session, owner_user, test_company, ExcessListStatus.COLLECTING)
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=el.id).first()
+    line.offer_count = 3  # line reads as "covered" → coverage meter would show 1/1
+    db_session.add(
+        ExcessOffer(
+            excess_list_id=el.id,
+            submitted_by=owner_user.id,
+            scope=ExcessOfferScope.PER_LINE,
+            status=ExcessOfferStatus.OPEN,
+        )
+    )
+    db_session.commit()
+
+    # Non-owner, open lens: the coverage meter (+ its amber-badge sibling, same gate) is gone.
+    open_body = client.get("/v2/partials/resell/lists?lens=open").text
+    assert "Offer coverage:" not in open_body, "coverage meter leaked to a non-owner (open lens)"
+
+    # Owner, mine lens: the meter is present.
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: owner_user
+    try:
+        mine_body = client.get("/v2/partials/resell/lists?lens=mine").text
+    finally:
+        client.app.dependency_overrides.pop(require_user, None)
+    assert "Offer coverage:" in mine_body, "owner must still see the coverage meter"

--- a/tests/test_resell_draft_offer_privacy.py
+++ b/tests/test_resell_draft_offer_privacy.py
@@ -275,3 +275,49 @@ def test_open_lens_hides_coverage_meter_and_offer_badge(client, db_session, owne
     finally:
         client.app.dependency_overrides.pop(require_user, None)
     assert "Offer coverage:" in mine_body, "owner must still see the coverage meter"
+
+
+def test_open_lens_needs_filter_is_not_an_offer_existence_oracle(
+    client, db_session, owner_user, test_company, test_user
+):
+    """D2 (offer-EXISTENCE oracle): the offer-based ``needs`` triage is the OWNER's
+    board only.
+
+    A non-owner on the open lens must NOT be able to narrow the anonymized listing set
+    to only postings that already carry a live bid — diffing ``lens=open&needs=offers``
+    against plain ``lens=open`` would reveal which competitors' listings have drawn interest
+    (the same signal the coverage meter / amber badge / offer-count chip hide). The ``needs``
+    filter must be a no-op for a non-owner, so the no-offer listing is STILL returned.
+    """
+    assert test_user.id != owner_user.id
+    with_offer = _posted_list_with_offers(db_session, owner_user, test_company, n_offers=1)
+    without_offer = _list_with_line(db_session, owner_user, test_company, ExcessListStatus.COLLECTING)
+
+    body = client.get("/v2/partials/resell/lists?lens=open&needs=offers").text
+    # The no-offer listing is still present — ``needs`` did not filter it out for the non-owner.
+    assert f"Excess listing #{without_offer.id}" in body, "needs=offers acted as an offer-existence oracle (open lens)"
+    assert f"Excess listing #{with_offer.id}" in body
+    # take_all is the same oracle dimension — also a no-op for the non-owner.
+    ta_body = client.get("/v2/partials/resell/lists?lens=open&needs=take_all").text
+    assert f"Excess listing #{without_offer.id}" in ta_body, "needs=take_all acted as an oracle (open lens)"
+
+
+def test_mine_lens_needs_filter_still_narrows_to_lists_with_offers(client, db_session, owner_user, test_company):
+    """Control: the ``needs=offers`` triage still narrows the OWNER's own board (mine lens)
+    to listings that carry a live offer — the gate is owner-scoped, not a blanket disable."""
+    with_offer = _posted_list_with_offers(db_session, owner_user, test_company, n_offers=1)
+    with_offer.title = "MINE-WITH-OFFER"
+    without_offer = _list_with_line(db_session, owner_user, test_company, ExcessListStatus.COLLECTING)
+    without_offer.title = "MINE-WITHOUT-OFFER"
+    db_session.commit()
+
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: owner_user
+    try:
+        body = client.get("/v2/partials/resell/lists?lens=mine&needs=offers").text
+    finally:
+        client.app.dependency_overrides.pop(require_user, None)
+    # Owner titles render on the mine lens; only the with-offer list survives the filter.
+    assert "MINE-WITH-OFFER" in body
+    assert "MINE-WITHOUT-OFFER" not in body, "needs=offers must still narrow the owner's own board"

--- a/tests/test_resell_myday_followup.py
+++ b/tests/test_resell_myday_followup.py
@@ -108,7 +108,6 @@ class TestFollowupTaskService:
             vendor_card_id=buyer_card_a.id,
             owner_id=test_user.id,
             buyer_name=buyer_card_a.display_name,
-            list_title=owned_list.title,
         )
         assert task is not None
         assert task.assigned_to_id == test_user.id
@@ -116,6 +115,11 @@ class TestFollowupTaskService:
         assert task.source == "system"
         assert task.source_ref == f"resell_notyet:{owned_list.id}:{buyer_card_a.id}"
         assert buyer_card_a.display_name in task.title
+        # #12: this task is scoped to the buyer's vendor card and renders on the SHARED
+        # cross-trader buyer Tasks tab, so the customer-named list title ("Acme surplus")
+        # must NEVER appear in it — it references the list by the neutral id-derived label.
+        assert owned_list.title not in task.title, "customer-named list title leaked into the cross-trader task title"
+        assert f"Excess listing #{owned_list.id}" in task.title
         assert len(_tasks_for(db_session, test_user.id)) == 1
 
     def test_idempotent_same_buyer_list_owner(self, db_session, test_user, owned_list, buyer_card_a):
@@ -126,7 +130,6 @@ class TestFollowupTaskService:
                 vendor_card_id=buyer_card_a.id,
                 owner_id=test_user.id,
                 buyer_name=buyer_card_a.display_name,
-                list_title=owned_list.title,
             )
         assert len(_tasks_for(db_session, test_user.id)) == 1
 

--- a/tests/test_resell_offers.py
+++ b/tests/test_resell_offers.py
@@ -30,6 +30,7 @@ from app.services.excess_service import (
     import_line_items,
     submit_offer,
 )
+from app.utils.normalization import normalize_mpn_key
 from tests.conftest import engine
 
 _ = engine  # Ensure test DB tables are created
@@ -92,6 +93,12 @@ def test_confirm_import_resolves_material_card_id(db_session: Session):
 
     item = db_session.query(ExcessLineItem).filter_by(excess_list_id=el.id).one()
     assert item.material_card_id is not None
+    # The line resolves to the ACTUAL MAX232 card (not just some non-null row): confirm the
+    # linked card's normalized MPN matches the imported part.
+    card = db_session.get(MaterialCard, item.material_card_id)
+    assert card is not None
+    assert card.normalized_mpn == normalize_mpn_key("MAX232")
+    assert item.part_number == "MAX232"
 
 
 def test_import_unresolvable_mpn_leaves_material_card_null(db_session: Session):

--- a/tests/test_resell_outreach_async.py
+++ b/tests/test_resell_outreach_async.py
@@ -1209,6 +1209,12 @@ def test_retry_route_flips_failed_to_sending_and_enqueues(
     """POST .../retry on a FAILED row flips it to ``sending`` at once and enqueues the
     reconcile-first background retry (the request never resends inline)."""
     row_id = _fail_row(db_session, posted_list, trader, buyer_card)
+    # #11/#12: the customer-named title must NEVER reach the retry resend subject. The
+    # service resends with ``row.send_subject or subject`` — so for a legacy / cleared-
+    # subject row (send_subject NULL) this fallback ships EXTERNALLY to the buyer. Give the
+    # list a customer name and prove the enqueued fallback is neutralized.
+    posted_list.title = "Acme Corp — surplus FPGAs"
+    db_session.commit()
     retry_stub = MagicMock()
     restore = _own(trader)
     try:
@@ -1222,7 +1228,9 @@ def test_retry_route_flips_failed_to_sending_and_enqueues(
         kwargs = retry_stub.call_args.kwargs
         assert kwargs["outreach_id"] == row_id
         assert kwargs["owner_id"] == trader.id
-        assert posted_list.title in kwargs["subject"]
+        # The fallback subject is the neutral part-count default, never the customer title.
+        assert posted_list.title not in kwargs["subject"], "customer-named title leaked into the retry resend subject"
+        assert "Excess available" in kwargs["subject"]  # neutral, part-count fallback
         assert kwargs["body"]
         assert kwargs["token"]
         db_session.expire_all()

--- a/tests/test_resell_outreach_routes.py
+++ b/tests/test_resell_outreach_routes.py
@@ -277,6 +277,87 @@ def test_submit_outreach_log_path(client, db_session, trader_user, posted_list):
         restore()
 
 
+def _customer_named_list(db_session, trader_user, test_company) -> ExcessList:
+    """A posted list a trader named after the customer (the natural, leaky habit)."""
+    el = ExcessList(
+        title=f"{test_company.name} — surplus FPGAs Q3",
+        company_id=test_company.id,
+        owner_id=trader_user.id,
+        status=ExcessListStatus.COLLECTING,
+        total_line_items=1,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(el)
+    db_session.flush()
+    db_session.add(
+        ExcessLineItem(
+            excess_list_id=el.id,
+            part_number="XCVU9P-2FLGA2104I",
+            normalized_part_number=normalize_mpn_key("XCVU9P-2FLGA2104I"),
+            quantity=10,
+        )
+    )
+    db_session.commit()
+    return el
+
+
+def test_outreach_subject_prefill_is_neutral(client, db_session, trader_user, test_company):
+    """#11: the outreach email subject PREFILL must not embed the customer-named list
+    title.
+
+    The subject ships externally to the buyer, so embedding ``el.title`` (which traders
+    write as the customer name) de-anonymizes the customer. The prefill is a neutral,
+    part-count default instead; the owner can still edit it before sending.
+    """
+    import re
+
+    el = _customer_named_list(db_session, trader_user, test_company)
+    restore = _own(db_session, None, trader_user)
+    try:
+        body = client.get(f"/v2/partials/resell/{el.id}/offer-buyers-form").text
+    finally:
+        restore()
+
+    m = re.search(r'name="subject"[^>]*value="([^"]*)"', body)
+    assert m, "subject input not found in the outreach modal"
+    subject_value = m.group(1)
+    assert el.title not in subject_value, "customer-named title leaked into the outreach subject prefill"
+    assert test_company.name not in subject_value
+    assert subject_value.strip(), "a neutral default subject must be present"
+    assert "Excess available" in subject_value  # neutral, part-count prefix
+
+
+def test_outreach_activity_log_subject_omits_customer_title(client, db_session, trader_user, test_company):
+    """#11: the internal outreach ActivityLog subject must not embed the customer-named
+    list title.
+
+    The log lands on the (shared) buyer vendor-card timeline, so the title would leak
+    the customer to any OTHER trader viewing that buyer. It references the list
+    neutrally by id.
+    """
+    from app.models import ActivityLog
+
+    el = _customer_named_list(db_session, trader_user, test_company)
+    buyer = _reachable_buyer(db_session, "Timeline Buyer", engagement=10.0, commodity=_CAP)
+    db_session.commit()
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.post(
+            f"/api/resell/{el.id}/outreach",
+            data={"vendor_card_ids": str(buyer.id), "scope": "whole_list", "channel": "phone"},
+        )
+        assert resp.status_code == 200
+    finally:
+        restore()
+
+    logs = db_session.query(ActivityLog).filter_by(excess_list_id=el.id).all()
+    assert logs, "an outreach ActivityLog should have been written"
+    subject = logs[0].subject or ""
+    assert el.title not in subject, "customer title leaked into the outreach ActivityLog subject"
+    assert test_company.name not in subject
+    assert f"#{el.id}" in subject, "the log should still reference the list neutrally by id"
+
+
 def test_submit_outreach_email_path(client, db_session, trader_user, posted_list):
     """The email channel enqueues 'sending' rows + a background send, returning at once.
 

--- a/tests/test_resell_outreach_routes.py
+++ b/tests/test_resell_outreach_routes.py
@@ -587,21 +587,7 @@ def test_submit_outreach_draft_list_409(client, db_session, trader_user, draft_l
         restore()
 
 
-def test_submit_outreach_posted_list_200(client, db_session, trader_user, posted_list):
-    """Submitting outreach on a POSTED (collecting) list still succeeds — no
-    regression."""
-    buyer = _reachable_buyer(db_session, "Posted Buyer", engagement=10.0, commodity=_CAP)
-    db_session.commit()
-    restore = _own(db_session, None, trader_user)
-    try:
-        resp = client.post(
-            f"/api/resell/{posted_list.id}/outreach",
-            data={
-                "vendor_card_ids": str(buyer.id),
-                "scope": "whole_list",
-                "channel": "phone",
-            },
-        )
-        assert resp.status_code == 200
-    finally:
-        restore()
+# NB: the former assert-200-only ``test_submit_outreach_posted_list_200`` was dropped as
+# redundant assertion theater — the posted-list success path is covered with real
+# outcome assertions by ``test_submit_outreach_log_path`` (rows/channel/target created)
+# and ``test_submit_outreach_email_path`` (sending rows + background job dispatched).

--- a/tests/test_resell_routes.py
+++ b/tests/test_resell_routes.py
@@ -230,6 +230,88 @@ def test_open_lens_title_never_leaks_customer_via_free_text(client, db_session, 
         app.dependency_overrides.pop(require_user, None)
 
 
+def test_open_lens_search_matches_part_identity_not_title(client, db_session, trader_user, test_company):
+    """#10: in the OPEN (offerer) lens, ``q`` must search part identity (normalized MPN
+    / manufacturer), NEVER the free-text title.
+
+    Searching the title is a de-anonymization oracle: a non-owner could confirm a hidden
+    customer name by typing it and seeing whether a (still-anonymized) row comes back. So
+    a customer-name query returns NOTHING, while a real MPN / manufacturer query returns
+    the anonymized row.
+    """
+
+    leaky_title = f"{test_company.name} — surplus FPGAs Q3"  # trader named it after the customer
+    el = ExcessList(
+        title=leaky_title,
+        company_id=test_company.id,
+        owner_id=trader_user.id,
+        status=ExcessListStatus.OPEN,
+        total_line_items=1,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(el)
+    db_session.flush()
+    db_session.add(
+        ExcessLineItem(
+            excess_list_id=el.id,
+            part_number="XCVU9P-2FLGA2104I",
+            normalized_part_number=normalize_mpn_key("XCVU9P-2FLGA2104I"),
+            manufacturer="Xilinx",
+            quantity=50,
+            condition="New",
+        )
+    )
+    db_session.commit()
+    neutral = f"Excess listing #{el.id}"
+
+    # ── Non-owner (default buyer client), open lens ──
+    # Customer-name query → NO row (title is not searchable by non-owners).
+    by_customer = client.get(f"/v2/partials/resell/lists?lens=open&q={test_company.name}").text
+    assert neutral not in by_customer, "title search leaked the row to a non-owner (de-anon oracle)"
+    assert leaky_title not in by_customer
+
+    # Real MPN query (with the trader's dashes) → the anonymized row comes back.
+    by_mpn = client.get("/v2/partials/resell/lists?lens=open&q=XCVU9P-2FLGA2104I").text
+    assert neutral in by_mpn, "MPN search must return the matching anonymized row"
+
+    # Manufacturer query → the anonymized row comes back.
+    by_mfr = client.get("/v2/partials/resell/lists?lens=open&q=Xilinx").text
+    assert neutral in by_mfr, "manufacturer search must return the matching anonymized row"
+
+
+def test_mine_lens_search_still_matches_title(client, db_session, trader_user, test_company):
+    """Control: the OWNER's mine lens still searches the free-text title (their own data)."""
+    from app.dependencies import require_user
+    from app.main import app
+
+    el = ExcessList(
+        title="Titanium widgets clearance",
+        company_id=test_company.id,
+        owner_id=trader_user.id,
+        status=ExcessListStatus.OPEN,
+        total_line_items=1,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(el)
+    db_session.flush()
+    db_session.add(
+        ExcessLineItem(
+            excess_list_id=el.id,
+            part_number="LM358N",
+            normalized_part_number=normalize_mpn_key("LM358N"),
+            quantity=10,
+        )
+    )
+    db_session.commit()
+
+    app.dependency_overrides[require_user] = lambda: trader_user
+    try:
+        body = client.get("/v2/partials/resell/lists?lens=mine&q=Titanium").text
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+    assert "Titanium widgets clearance" in body, "owner title search must still match"
+
+
 # ── Detail + tabs ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
**Phase 3 of the Resell rework** (`docs/superpowers/plans/2026-07-17-resell-phase3-anonymization.md`) — closes every known anonymization leak before multi-user go-live. No migration.

## What changed
- **D2 — counts/coverage private:** the header "N offers" chip, the "N/M awarded" chip, the Offers-tab count badge, and the open-lens coverage meter + amber offer badge are now gated on the single `can_see_customer` predicate (NULLed server-side + hidden template-side). The public-position comment was rewritten to state the private policy.
- **#10 — open-lens search** matches part identity (`normalized_part_number`/`manufacturer`), never the customer-named title (title search kept for the owner's `mine` lens).
- **#11 — outreach subject** de-titled in the modal prefill, the internal ActivityLog subject, AND (found in review) the **retry** path.
- **#21 — real tests:** stage/q filter + mine-lens owner-scoping assertions on rendered content; 4 assert-200 theater tests burned down.

## Adversarial review (ultracode) — 4 residual leaks caught & fixed
The build passed its own tests, but a 6-dimension review + 3-skeptic verify surfaced **11 findings, 4 confirmed critical/important** that the build missed — all fixed at root cause:
1. **`needs=offers` existence oracle** — the `needs` filter ran in every lens, letting a non-owner diff `lens=open&needs=offers` to learn which anonymized postings had a live bid. Now cleared for non-owners.
2. **Retry subject** re-embedded `el.title` (title fallback when `send_subject` is NULL) → neutral part-count fallback.
3. **Inbound-offer owner notification** stamped the customer title on a `vendor_card_id`-scoped ActivityLog visible on the *shared cross-trader* buyer timeline → neutral `list #N`.
4. **Follow-up task** did the same on the shared buyer Tasks tab → neutral label.

## Verification
- 163 affected tests green under xdist; pre-commit + assertion-theater + query-API ratchets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)