### PR TITLE
Resell rework Phase 4: workflow completion (6 approved controls)

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -1982,6 +1982,26 @@ def _load_outreach_for_owner(
     return el, outreach
 
 
+def _load_manual_outreach_for_owner(
+    db: Session, list_id: int, outreach_id: int, user: User
+) -> tuple[ExcessList, ExcessOutreach]:
+    """Owner-gated load of one MANUAL-channel outreach row (finding #12).
+
+    404 (not 403) when the row is missing or belongs to another list — existence is not
+    revealed. 409 for an ``email`` row: an emailed touch has a thread, so its outcome is
+    logged via the reply viewer / inbox matcher, not the manual-log path. Shared by the
+    manual log-response / log-bid routes.
+    """
+    el = excess_service.get_excess_list(db, list_id)
+    _require_owner(el, user)
+    outreach = db.get(ExcessOutreach, outreach_id)
+    if outreach is None or outreach.excess_list_id != el.id:
+        raise HTTPException(404, "Outreach not found")
+    if outreach.channel == ExcessOutreachChannel.EMAIL:
+        raise HTTPException(409, "Use the reply viewer to log an email outreach's outcome")
+    return el, outreach
+
+
 @router.get("/v2/partials/resell/{list_id}/outreach/{outreach_id}/reply", response_class=HTMLResponse)
 async def resell_outreach_reply(
     request: Request,
@@ -2043,6 +2063,101 @@ async def resell_outreach_convert_offer(
     resell_outreach_service.record_response(
         db,
         conversation_id=outreach.graph_conversation_id,
+        has_offer=True,
+        offer_lines=[
+            {
+                "mpn_raw": mpn_raw.strip(),
+                "quantity": qty,
+                "unit_price": _to_decimal(unit_price),
+                "lead_time_days": _to_int(lead_time_days),
+                "terms_text": terms_text or None,
+            }
+        ],
+        offer_notes=notes or None,
+    )
+
+    el = excess_service.get_excess_list(db, list_id)
+    return template_response("htmx/partials/resell/_outreach.html", _outreach_tracker_context(request, db, el, user))
+
+
+@router.post("/api/resell/{list_id}/outreach/{outreach_id}/log-response", response_class=HTMLResponse)
+async def resell_outreach_log_response(
+    request: Request,
+    list_id: int,
+    outreach_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Log a manual-channel buyer RESPONSE (owner-only), then re-render the tracker.
+
+    The manual counterpart to the inbox reply matcher for a phone/teams/marketplace touch
+    that has no email thread: advances the row sent → responded (never regresses a terminal
+    bid/declined). 409 for an email row (use the reply viewer).
+    """
+    _el, outreach = _load_manual_outreach_for_owner(db, list_id, outreach_id, user)
+    resell_outreach_service.record_manual_response(db, outreach=outreach, has_offer=False)
+    el = excess_service.get_excess_list(db, list_id)
+    return template_response("htmx/partials/resell/_outreach.html", _outreach_tracker_context(request, db, el, user))
+
+
+@router.get("/v2/partials/resell/{list_id}/outreach/{outreach_id}/log-bid-form", response_class=HTMLResponse)
+async def resell_outreach_log_bid_form(
+    request: Request,
+    list_id: int,
+    outreach_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Render the Log-their-bid modal for a manual-channel row (owner-only).
+
+    Reuses the reply viewer's convert-to-offer line form, pointed at the manual log-bid
+    route (a manual touch has no reply thread, so the ``manual`` flag renders the honest
+    "logged manually" note instead of an email thread).
+    """
+    el, outreach = _load_manual_outreach_for_owner(db, list_id, outreach_id, user)
+    return template_response(
+        "htmx/partials/resell/_reply_viewer.html",
+        {
+            "request": request,
+            "user": user,
+            "list": el,
+            "outreach": outreach,
+            "replies": [],
+            "manual": True,
+            "convert_url": f"/api/resell/{el.id}/outreach/{outreach.id}/log-bid",
+        },
+    )
+
+
+@router.post("/api/resell/{list_id}/outreach/{outreach_id}/log-bid", response_class=HTMLResponse)
+async def resell_outreach_log_bid(
+    request: Request,
+    list_id: int,
+    outreach_id: int,
+    mpn_raw: str = Form(""),
+    quantity: str = Form(""),
+    unit_price: str = Form(""),
+    lead_time_days: str = Form(""),
+    terms_text: str = Form(""),
+    notes: str = Form(""),
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Log a manual-channel buyer BID (owner-only): create the inbound ExcessOffer +
+    advance the row → bid, then re-render the tracker.
+
+    Reuses ``record_manual_response(has_offer=True)`` → the SAME queued-never-dropped line
+    matcher an emailed bid uses. 409 for an email row (use the reply viewer).
+    """
+    _el, outreach = _load_manual_outreach_for_owner(db, list_id, outreach_id, user)
+
+    qty = _to_int(quantity)
+    if not mpn_raw.strip() or qty is None:
+        raise HTTPException(400, "A logged bid needs a part number and quantity")
+
+    resell_outreach_service.record_manual_response(
+        db,
+        outreach=outreach,
         has_offer=True,
         offer_lines=[
             {

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -248,7 +248,17 @@ def _get_list_for_user(db: Session, list_id: int, user: User) -> tuple[ExcessLis
     el = excess_service.get_excess_list(db, list_id)
     is_owner = el.owner_id == user.id
     if not is_owner and el.status not in {s.value for s in _POSTED_STATUSES}:
-        raise HTTPException(404, "List not found")
+        # A non-owner may still reach a now-unposted list (closed/expired) IF they hold an
+        # offer on it — so a broker can view/withdraw their own bid after the posting window
+        # closes (finding #13). Drafts never carry offers, so this never reveals one. Only
+        # runs on the rare non-posted, non-owner read (posted statuses short-circuit above).
+        has_own_offer = db.scalar(
+            select(ExcessOffer.id)
+            .where(ExcessOffer.excess_list_id == el.id, ExcessOffer.submitted_by == user.id)
+            .limit(1)
+        )
+        if has_own_offer is None:
+            raise HTTPException(404, "List not found")
     return el, is_owner
 
 
@@ -503,9 +513,28 @@ def _offers_context(request: Request, db: Session, el: ExcessList, user: User) -
     }
 
     if not is_owner:
-        # Non-owner: render an empty offers view — no offer data in the response.
+        # Non-owner: render the viewer's OWN offers ONLY (finding #13). Carries NO
+        # competitor data — no other broker's bids, no best-price rollup, no coverage/counts
+        # (Phase-3 anonymization discipline). Scoped hard to submitted_by == user.id in the
+        # active-visible set; an open/late own-offer is Withdraw-able (the withdraw route
+        # already authorizes the submitter).
+        own_offers = (
+            db.scalars(
+                select(ExcessOffer)
+                .where(
+                    ExcessOffer.excess_list_id == el.id,
+                    ExcessOffer.submitted_by == user.id,
+                    ExcessOffer.status.in_([s.value for s in _VISIBLE_OFFER_STATUSES]),
+                )
+                .options(joinedload(ExcessOffer.lines))
+                .order_by(ExcessOffer.created_at.desc())
+            )
+            .unique()
+            .all()
+        )
         return {
             **base,
+            "own_offers": own_offers,
             "by_line": {it.id: [] for it in items},
             "unmatched": [],
             "take_all_offers": [],

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -1448,6 +1448,31 @@ async def resell_withdraw_offer(
     return _toast(resp, "Offer withdrawn")
 
 
+@router.post("/api/resell/{list_id}/offer-lines/{offer_line_id}/assign", response_class=HTMLResponse)
+async def resell_assign_offer_line(
+    request: Request,
+    list_id: int,
+    offer_line_id: int,
+    target_line_item_id: int = Form(...),
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Assign an unmatched offer line to a posted line (owner-only), then re-render the
+    Offers tab + OOB lines/chips.
+
+    Manual resolution of the unmatched queue (finding #15): the salvaged line becomes a
+    matched, awardable bid. The service owns the guards (404 list/offer-line/target, 403
+    non-owner) and the rollup recompute; the response is the same OOB compose the award
+    action uses so the Alpine tab state never resets.
+    """
+    excess_service.assign_offer_line(db, list_id, offer_line_id, target_line_item_id, user)
+    el = excess_service.get_excess_list(db, list_id)
+    resp = template_response(
+        "htmx/partials/resell/_award_response.html", _award_response_context(request, db, el, user)
+    )
+    return _toast(resp, "Offer assigned to line")
+
+
 # ── Outreach: offer-to-buyers panel + tracker + don't-forget strip ───
 #
 # The trader→buyer half of Resell (the inverse of sourcing's RFQ). Offering excess OUT

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -1286,6 +1286,19 @@ async def resell_close(
     return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
 
+@router.post("/api/resell/{list_id}/close-without-bid", response_class=HTMLResponse)
+async def resell_close_without_bid(
+    request: Request,
+    list_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Close a posted list WITHOUT bidding (owner-only): flip to the terminal ``closed``
+    state + stamp close_at, then re-render detail (D5)."""
+    el = excess_service.close_list_without_bid(db, list_id, user)
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
 @router.post("/api/resell/{list_id}/offers", response_class=HTMLResponse)
 async def resell_submit_offer(
     request: Request,

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -944,7 +944,7 @@ async def resell_add_line_form(
     el, _ = _get_list_for_user(db, list_id, user)
     _require_owner(el, user)
     if el.status != ExcessListStatus.DRAFT:
-        raise HTTPException(409, "Posted lists are locked; revise as a new version")
+        raise HTTPException(409, "Posted lists are locked. Close this list and create a new one to make changes.")
     return template_response(
         "htmx/partials/resell/add_line_modal.html",
         {"request": request, "list_id": list_id},
@@ -1017,7 +1017,7 @@ async def resell_add_line(
     el = excess_service.get_excess_list(db, list_id)
     _require_owner(el, user)
     if el.status != ExcessListStatus.DRAFT:
-        raise HTTPException(409, "Posted lists are locked; revise as a new version")
+        raise HTTPException(409, "Posted lists are locked. Close this list and create a new one to make changes.")
     if not excess_service.can_post(user):
         raise HTTPException(403, "You do not have permission to post excess lists")
     # L2: a non-positive quantity would reach the ExcessLineItem @validates("quantity")
@@ -1045,6 +1045,153 @@ async def resell_add_line(
     # draft is what makes the header Post button appear (line_count > 0), so a Lines-only
     # swap would leave the header stale and the user with no way to publish (RS-5).
     return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
+# ── Draft editing (finding #14 / D4) — all DRAFT-only + owner-only, thin over the
+#    service guards (404 → 403 → 409). A draft has no offers/mirror, so these are
+#    side-effect-free except total_line_items. ──────────────────────────────────
+
+
+@router.get("/v2/partials/resell/{list_id}/lines/{line_id}/edit-form", response_class=HTMLResponse)
+async def resell_edit_line_form(
+    request: Request,
+    list_id: int,
+    line_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Render the pre-filled edit-line modal (owner-only, draft-only)."""
+    el, _ = _get_list_for_user(db, list_id, user)
+    _require_owner(el, user)
+    if el.status != ExcessListStatus.DRAFT:
+        raise HTTPException(409, "Posted lists are locked. Close this list and create a new one to make changes.")
+    line = db.get(ExcessLineItem, line_id)
+    if line is None or line.excess_list_id != el.id:
+        raise HTTPException(404, f"Line {line_id} not found on list {list_id}")
+    return template_response(
+        "htmx/partials/resell/edit_line_modal.html",
+        {"request": request, "list_id": list_id, "line": line},
+    )
+
+
+@router.get("/v2/partials/resell/{list_id}/edit-form", response_class=HTMLResponse)
+async def resell_edit_list_form(
+    request: Request,
+    list_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Render the pre-filled edit-list-header modal (owner-only, draft-only)."""
+    el, _ = _get_list_for_user(db, list_id, user)
+    _require_owner(el, user)
+    if el.status != ExcessListStatus.DRAFT:
+        raise HTTPException(409, "Posted lists are locked. Close this list and create a new one to make changes.")
+    companies = db.scalars(select(Company).order_by(Company.name)).all()
+    return template_response(
+        "htmx/partials/resell/edit_list_modal.html",
+        {"request": request, "list": el, "companies": companies},
+    )
+
+
+@router.patch("/api/resell/{list_id}/lines/{line_id}", response_class=HTMLResponse)
+async def resell_update_line(
+    request: Request,
+    list_id: int,
+    line_id: int,
+    part_number: str = Form(...),
+    quantity: int = Form(...),
+    manufacturer: str = Form(""),
+    condition: str = Form("New"),
+    date_code: str = Form(""),
+    asking_price: str = Form(""),
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Edit one draft line, then re-render the whole detail panel."""
+    el = excess_service.update_line(
+        db,
+        list_id,
+        line_id,
+        user,
+        part_number=part_number,
+        quantity=quantity,
+        manufacturer=manufacturer or None,
+        condition=condition or "New",
+        date_code=date_code or None,
+        asking_price=_to_decimal(asking_price),
+    )
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
+@router.delete("/api/resell/{list_id}/lines/{line_id}", response_class=HTMLResponse)
+async def resell_delete_line(
+    request: Request,
+    list_id: int,
+    line_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Delete one draft line, then re-render the whole detail panel."""
+    el = excess_service.delete_line(db, list_id, line_id, user)
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
+@router.patch("/api/resell/{list_id}", response_class=HTMLResponse)
+async def resell_update_list(
+    request: Request,
+    list_id: int,
+    title: str = Form(...),
+    company_id: int = Form(...),
+    notes: str = Form(""),
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Edit a draft list's header (title/customer/notes), then re-render the detail
+    panel."""
+    el = excess_service.update_excess_list(db, list_id, user, title=title, notes=notes or None, company_id=company_id)
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
+@router.delete("/api/resell/{list_id}", response_class=HTMLResponse)
+async def resell_delete_list(
+    request: Request,
+    list_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Delete a whole draft list, then refresh the My-Lists left pane + reset the detail
+    pane.
+
+    Returns the refreshed My-Lists partial (primary → #resell-list-body) with an OOB
+    reset of the now-orphaned detail pane (#split-right-resell) and a confirmation
+    toast.
+    """
+    excess_service.delete_excess_list(db, list_id, user)
+    lists = (
+        db.scalars(
+            select(ExcessList)
+            .options(joinedload(ExcessList.company))
+            .where(ExcessList.owner_id == user.id)
+            .order_by(ExcessList.updated_at.desc().nullslast(), ExcessList.id.desc())
+        )
+        .unique()
+        .all()
+    )
+    resp = template_response(
+        "htmx/partials/resell/_list_after_delete.html",
+        {
+            "request": request,
+            "user": user,
+            "lens": "mine",
+            "stage": "",
+            "needs": "",
+            "q": "",
+            "cards": _list_cards(db, list(lists), can_see_customer=True),
+            "can_see_customer": True,
+            "can_post": excess_service.can_post(user),
+        },
+    )
+    return _toast(resp, "List deleted")
 
 
 @router.post("/api/resell/{list_id}/import-preview", response_class=HTMLResponse)
@@ -1094,7 +1241,7 @@ async def resell_import_confirm(
     el = excess_service.get_excess_list(db, list_id)
     _require_owner(el, user)
     if el.status != ExcessListStatus.DRAFT:
-        raise HTTPException(409, "Posted lists are locked; revise as a new version")
+        raise HTTPException(409, "Posted lists are locked. Close this list and create a new one to make changes.")
     if not excess_service.can_post(user):
         raise HTTPException(403, "You do not have permission to post excess lists")
     try:

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -1114,6 +1114,9 @@ async def resell_update_line(
     db: Session = Depends(get_db),
 ):
     """Edit one draft line, then re-render the whole detail panel."""
+    # 404-mask a non-owner on a private draft (existence not revealed) BEFORE the service's
+    # owner-check would 403 it — consistent with the GET edit-form path (finding #3).
+    _get_list_for_user(db, list_id, user)
     el = excess_service.update_line(
         db,
         list_id,
@@ -1138,6 +1141,8 @@ async def resell_delete_line(
     db: Session = Depends(get_db),
 ):
     """Delete one draft line, then re-render the whole detail panel."""
+    # 404-mask a non-owner on a private draft (finding #3).
+    _get_list_for_user(db, list_id, user)
     el = excess_service.delete_line(db, list_id, line_id, user)
     return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
@@ -1154,6 +1159,8 @@ async def resell_update_list(
 ):
     """Edit a draft list's header (title/customer/notes), then re-render the detail
     panel."""
+    # 404-mask a non-owner on a private draft (finding #3).
+    _get_list_for_user(db, list_id, user)
     el = excess_service.update_excess_list(db, list_id, user, title=title, notes=notes or None, company_id=company_id)
     return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
@@ -1170,8 +1177,11 @@ async def resell_delete_list(
 
     Returns the refreshed My-Lists partial (primary → #resell-list-body) with an OOB
     reset of the now-orphaned detail pane (#split-right-resell) and a confirmation
-    toast.
+    toast. Also pushes the workspace URL so the address bar no longer points at the now-
+    deleted list id (finding #8).
     """
+    # 404-mask a non-owner on a private draft (finding #3).
+    _get_list_for_user(db, list_id, user)
     excess_service.delete_excess_list(db, list_id, user)
     lists = (
         db.scalars(
@@ -1197,6 +1207,9 @@ async def resell_delete_list(
             "can_post": excess_service.can_post(user),
         },
     )
+    # Rewrite the address bar to the workspace root — the pushed /v2/resell/{deleted_id}
+    # would otherwise reopen a 404/empty detail on reload/bookmark (finding #8).
+    resp.headers["HX-Push-Url"] = "/v2/resell"
     return _toast(resp, "List deleted")
 
 
@@ -2158,8 +2171,12 @@ async def resell_outreach_log_bid(
     _el, outreach = _load_manual_outreach_for_owner(db, list_id, outreach_id, user)
 
     qty = _to_int(quantity)
-    if not mpn_raw.strip() or qty is None:
-        raise HTTPException(400, "A logged bid needs a part number and quantity")
+    # L2: reject a non-positive quantity here (400) — mirrors resell_submit_offer. A
+    # negative qty is not None, so without the ``qty <= 0`` clause it flows into
+    # _link_inbound_offer and trips the ExcessOfferLine @validates('quantity') ValueError
+    # as an unhandled 500, after the parent ExcessOffer row was already flushed.
+    if not mpn_raw.strip() or qty is None or qty <= 0:
+        raise HTTPException(400, "A logged bid needs a part number and a positive quantity")
 
     resell_outreach_service.record_manual_response(
         db,

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -400,7 +400,13 @@ async def resell_lists(
     if not can_see_customer:
         needs = ""
 
-    if stage:
+    if stage == "live":
+        # ``live`` = [open, collecting] (finding #16): the "Open" triage card counts BOTH
+        # (a list flips open→collecting on its first offer but is still live), so its filter
+        # must widen to match its count. The strict ``open`` pill keeps meaning EXACTLY
+        # status=open — only this token widens.
+        query = query.filter(ExcessList.status.in_([ExcessListStatus.OPEN, ExcessListStatus.COLLECTING]))
+    elif stage:
         query = query.filter(ExcessList.status == stage)
     if needs:
         # Lists carrying a live, unactioned offer (take_all = its whole-list slice) — the

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -931,6 +931,144 @@ def unaward_offer(db: Session, offer_id: int, owner: User) -> ExcessOffer:
     return offer
 
 
+# ---------------------------------------------------------------------------
+# Phase 4: Draft editing (finding #14 / D4)
+# ---------------------------------------------------------------------------
+#
+# Before a list is posted it is a private working draft the owner may correct in place;
+# once posted the lines lock. All four editors below are DRAFT-ONLY + owner-only. A draft
+# carries no offers and no Sighting mirror, so these are side-effect-free except the
+# ``total_line_items`` counter (kept in step with the actual line rows on delete).
+
+# The honest 409 the draft-lock guards raise (replaces the old, false "revise as a new
+# version" copy — there is no versioned-revise flow; the real path is close + re-create).
+_POSTED_LOCKED_MSG = "Posted lists are locked. Close this list and create a new one to make changes."
+
+
+def _require_owned_draft(db: Session, list_id: int, owner: User) -> ExcessList:
+    """Load a list and assert *owner* may edit it as a DRAFT (404 → 403 → 409).
+
+    Shared guard for the draft-edit set: the list must exist (404), *owner* must own it
+    (403), and it must still be a draft (409, honest copy) — mirrors ``close_list``'s
+    guard order so a direct service call is protected even if the router guard is bypassed.
+    """
+    el = get_excess_list(db, list_id)
+    if el.owner_id != owner.id:
+        raise HTTPException(403, "Only the list owner can edit it")
+    if el.status != ExcessListStatus.DRAFT:
+        raise HTTPException(409, _POSTED_LOCKED_MSG)
+    return el
+
+
+def delete_line(db: Session, list_id: int, line_id: int, owner: User) -> ExcessList:
+    """Delete one line from a draft list (owner-only, draft-only); returns the list.
+
+    404 if the line does not exist or belongs to a different list (never touch another
+    list's line). Decrements ``total_line_items`` (floored at 0) so the counter stays in
+    step with the actual rows. Commits; returns the refreshed list for the detail re-render.
+    """
+    el = _require_owned_draft(db, list_id, owner)
+    line = db.get(ExcessLineItem, line_id)
+    if line is None or line.excess_list_id != el.id:
+        raise HTTPException(404, f"Line {line_id} not found on list {list_id}")
+    db.delete(line)
+    el.total_line_items = max((el.total_line_items or 0) - 1, 0)
+    _safe_commit(db, entity="excess line delete")
+    db.refresh(el)
+    logger.info("Deleted ExcessLineItem id={} from draft list={} by owner={}", line_id, list_id, owner.id)
+    return el
+
+
+def update_line(
+    db: Session,
+    list_id: int,
+    line_id: int,
+    owner: User,
+    *,
+    part_number: str,
+    quantity: int,
+    manufacturer: str | None = None,
+    condition: str | None = None,
+    date_code: str | None = None,
+    asking_price: Decimal | None = None,
+) -> ExcessList:
+    """Edit one line on a draft list (owner-only, draft-only); returns the list.
+
+    404 across lists. Re-validates ``quantity > 0`` HERE (400) — otherwise it reaches the
+    ``ExcessLineItem.@validates('quantity')`` ValueError as an unhandled 500. When the part
+    number or manufacturer changes, the stale MaterialCard link is dropped and re-resolved
+    (the resolve is find-or-create and never raises on an unresolvable MPN). Commits.
+    """
+    el = _require_owned_draft(db, list_id, owner)
+    line = db.get(ExcessLineItem, line_id)
+    if line is None or line.excess_list_id != el.id:
+        raise HTTPException(404, f"Line {line_id} not found on list {list_id}")
+    if quantity is None or quantity <= 0:
+        raise HTTPException(400, "Quantity must be a positive whole number")
+
+    identity_changed = (part_number or "").strip() != (line.part_number or "") or (manufacturer or None) != (
+        line.manufacturer or None
+    )
+    line.part_number = part_number.strip()
+    line.normalized_part_number = normalize_mpn_key(part_number) or None
+    line.quantity = quantity
+    line.manufacturer = manufacturer or None
+    line.condition = condition or "New"
+    line.date_code = date_code or None
+    line.asking_price = asking_price
+    if identity_changed:
+        # Re-resolve the material-card link off the new MPN/manufacturer (the mirror needs
+        # a correct card at post time). Drop the stale link first so the resolver runs.
+        line.material_card_id = None
+        _resolve_line_material_card(db, line)
+    _safe_commit(db, entity="excess line update")
+    db.refresh(el)
+    logger.info("Updated ExcessLineItem id={} on draft list={} by owner={}", line_id, list_id, owner.id)
+    return el
+
+
+def update_excess_list(
+    db: Session,
+    list_id: int,
+    owner: User,
+    *,
+    title: str,
+    notes: str | None = None,
+    company_id: int | None = None,
+    customer_site_id: int | None = None,
+) -> ExcessList:
+    """Edit a draft list's header (owner-only, draft-only); returns the refreshed list.
+
+    Updates ``title`` / ``notes`` / ``customer_site_id`` and, when ``company_id`` is given
+    and differs, re-points the seller company (404 if it does not exist). Commits.
+    """
+    el = _require_owned_draft(db, list_id, owner)
+    if company_id is not None and company_id != el.company_id:
+        company = db.get(Company, company_id)
+        if not company:
+            raise HTTPException(404, f"Company {company_id} not found")
+        el.company_id = company_id
+    el.title = title
+    el.notes = notes
+    el.customer_site_id = customer_site_id
+    _safe_commit(db, entity="excess list update")
+    db.refresh(el)
+    logger.info("Updated draft ExcessList id={} by owner={}", list_id, owner.id)
+    return el
+
+
+def delete_excess_list(db: Session, list_id: int, owner: User) -> None:
+    """Delete a whole draft list (owner-only, draft-only); cascades to its children.
+
+    The ORM ``cascade="all, delete-orphan"`` on line_items/offers/customer_bids cleans the
+    children (a draft has no offers/bids, but the cascade is defence-in-depth). Commits.
+    """
+    el = _require_owned_draft(db, list_id, owner)
+    db.delete(el)
+    _safe_commit(db, entity="excess list delete")
+    logger.info("Deleted draft ExcessList id={} by owner={}", list_id, owner.id)
+
+
 # List statuses a manual close may act on: an actively-posted window. A draft was never
 # published (nothing to close), and a bid_out/awarded/closed/expired list is already
 # resolved — re-closing it is a no-op the endpoint should reject (M5).

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -1075,18 +1075,16 @@ def delete_excess_list(db: Session, list_id: int, owner: User) -> None:
 _CLOSEABLE_LIST_STATUSES = (ExcessListStatus.OPEN, ExcessListStatus.COLLECTING)
 
 
-def close_list(db: Session, list_id: int, owner: User) -> ExcessList:
-    """Close a posted list — owner-only — flip status to ``bid_out`` + stamp
+def _end_posting_window(db: Session, list_id: int, owner: User, *, target_status: str) -> ExcessList:
+    """Close a posted list into a resolved *target_status* — owner-only — + stamp
     ``close_at``.
 
-    The posting-window counterpart to ``excess_mirror.publish_list`` (which stamps
-    ``open_at``): once the trader has assembled and sent the bid back, closing the list
-    flips it to ``bid_out`` and records ``close_at`` (Chunk E). Guards: the list must
-    exist (404), *owner* must own it (403), and the list must be actively posted
-    (``open``/``collecting``) — a draft or an already-resolved list is 409 (M5). Closing
-    RETIRES the Sighting mirror (``sync_list_mirror`` on a now-closed posting drops every
-    line's live-supply row) so a sold-through / withdrawn posting stops advertising.
-    Commits. Returns the refreshed list.
+    Shared engine for both posting-window exits: ``bid_out`` (bids went out) and ``closed``
+    (closed without bidding — D5). Guards: the list must exist (404), *owner* must own it
+    (403), and it must be actively posted (``open``/``collecting``) — a draft or an
+    already-resolved list is 409 (M5). RETIRES the Sighting mirror (``sync_list_mirror`` on
+    a now-closed posting drops every line's live-supply row — both ``bid_out`` and ``closed``
+    are in the mirror's posting-closed set). Commits. Returns the refreshed list.
     """
     excess_list = get_excess_list(db, list_id)
     if excess_list.owner_id != owner.id:
@@ -1094,7 +1092,7 @@ def close_list(db: Session, list_id: int, owner: User) -> ExcessList:
     if excess_list.status not in {s.value for s in _CLOSEABLE_LIST_STATUSES}:
         raise HTTPException(409, "Only an open or collecting list can be closed")
 
-    excess_list.status = ExcessListStatus.BID_OUT
+    excess_list.status = target_status
     excess_list.close_at = datetime.now(UTC)
     db.flush()
 
@@ -1106,8 +1104,34 @@ def close_list(db: Session, list_id: int, owner: User) -> ExcessList:
 
     _safe_commit(db, entity="excess list close")
     db.refresh(excess_list)
-    logger.info("Closed ExcessList id={} (status=bid_out, mirror retired) by owner={}", list_id, owner.id)
+    logger.info("Closed ExcessList id={} (status={}, mirror retired) by owner={}", list_id, target_status, owner.id)
     return excess_list
+
+
+def close_list(db: Session, list_id: int, owner: User) -> ExcessList:
+    """Close a posted list — owner-only — flip status to ``bid_out`` + stamp
+    ``close_at``.
+
+    The posting-window counterpart to ``excess_mirror.publish_list`` (which stamps
+    ``open_at``): once the trader has assembled and sent the bid back, closing the list
+    flips it to ``bid_out`` and records ``close_at`` (Chunk E). See ``_end_posting_window``
+    for the guards and mirror-retire behaviour.
+    """
+    return _end_posting_window(db, list_id, owner, target_status=ExcessListStatus.BID_OUT)
+
+
+def close_list_without_bid(db: Session, list_id: int, owner: User) -> ExcessList:
+    """Close a posted list WITHOUT bidding → the terminal ``closed`` state (D5, finding
+    #14).
+
+    The deliberate "nothing came of this — end it" exit, distinct from the ``bid_out``
+    (bids went out) path: an owner ends a posting that drew no usable bid instead of leaving
+    it advertising forever. ``closed`` is TERMINAL — it is not swept by the nightly expiry
+    (only open/collecting are) and there is no reopen; it retires the mirror like any closed
+    window. Same owner + open/collecting guards as ``close_list`` (409 on a draft/resolved
+    list). Commits. Returns the refreshed list.
+    """
+    return _end_posting_window(db, list_id, owner, target_status=ExcessListStatus.CLOSED)
 
 
 # List statuses that are still "in flight" (the posting window has not resolved) and so

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -678,6 +678,56 @@ def withdraw_offer(db: Session, offer_id: int) -> ExcessOffer:
     return offer
 
 
+def assign_offer_line(
+    db: Session, list_id: int, offer_line_id: int, target_line_item_id: int, owner: User
+) -> ExcessOfferLine:
+    """Assign an unmatched/ambiguous offer line to a posted line (owner-only; finding
+    #15).
+
+    The queued-never-dropped matcher parks an ``ExcessOfferLine`` whose ``mpn_raw`` didn't
+    cleanly resolve in the unmatched queue; this is the manual resolution: the owner points
+    it at the intended ``ExcessLineItem``, so the salvaged bid becomes a real matched offer
+    (and thus awardable). Sets ``excess_line_item_id`` + flips ``match_status`` → MATCHED,
+    then recomputes the target line's best-price rollup (and, on a RE-assign, the line it
+    moved off of, so the old line no longer counts the moved bid). Guards: the list exists
+    (404) + *owner* owns it (403); the offer line belongs to this list (404); the target
+    line is on this list (404, never another list's line). Commits.
+    """
+    excess_list = get_excess_list(db, list_id)
+    if excess_list.owner_id != owner.id:
+        raise HTTPException(403, "Only the list owner can assign an offer line")
+
+    offer_line = db.get(ExcessOfferLine, offer_line_id)
+    if offer_line is None or offer_line.offer is None or offer_line.offer.excess_list_id != list_id:
+        raise HTTPException(404, f"Offer line {offer_line_id} not found on list {list_id}")
+
+    target = db.get(ExcessLineItem, target_line_item_id)
+    if target is None or target.excess_list_id != list_id:
+        raise HTTPException(404, f"Line {target_line_item_id} not found on list {list_id}")
+
+    previous_line_item_id = offer_line.excess_line_item_id
+    offer_line.excess_line_item_id = target.id
+    offer_line.match_status = OfferLineMatchStatus.MATCHED
+    db.flush()
+
+    # Recompute the new target, and the line it moved off of (a re-assign), so both rollups
+    # reflect the move. A first assign from the unmatched queue has no previous line.
+    if previous_line_item_id is not None and previous_line_item_id != target.id:
+        recompute_line_rollup(db, previous_line_item_id)
+    recompute_line_rollup(db, target.id)
+
+    _safe_commit(db, entity="offer line assignment")
+    db.refresh(offer_line)
+    logger.info(
+        "Assigned ExcessOfferLine id={} → line_item={} on list={} by owner={}",
+        offer_line_id,
+        target.id,
+        list_id,
+        owner.id,
+    )
+    return offer_line
+
+
 # Line statuses that are decided (no longer collecting offers) for list-status derivation.
 _DECIDED_LINE_STATUSES = (ExcessLineItemStatus.AWARDED, ExcessLineItemStatus.WITHDRAWN)
 

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -643,6 +643,19 @@ def recompute_line_rollup(db: Session, excess_line_item_id: int) -> None:
 # direct service call is guarded even when the (defence-in-depth) router guard is bypassed.
 _ACTIONABLE_OFFER_STATUSES = (ExcessOfferStatus.OPEN, ExcessOfferStatus.LATE)
 
+# List statuses that are TERMINAL — a closed-without-bid (D5) or nightly-expired list is
+# dead and must never be reopened. Awarding/assigning on one would flip it back to
+# ``awarded`` (and a later unaward to ``bid_out``), the exact reopen the D5 contract
+# forbids (finding #4). ``awarded`` is a RESOLVED (not terminal) state that award/unaward
+# legitimately toggle, so it is NOT in this set; assign adds it separately below.
+_TERMINAL_LIST_STATUSES = (ExcessListStatus.CLOSED, ExcessListStatus.EXPIRED)
+
+# List statuses on which ``assign_offer_line`` (unmatched-queue resolution) is rejected:
+# the two terminal states above PLUS ``awarded`` (a resolved list whose lines are all
+# decided). Assign is only meaningful while offers are still being resolved — open,
+# collecting, or bid_out.
+_ASSIGN_BLOCKED_LIST_STATUSES = frozenset(s.value for s in (*_TERMINAL_LIST_STATUSES, ExcessListStatus.AWARDED))
+
 
 def withdraw_offer(db: Session, offer_id: int) -> ExcessOffer:
     """Withdraw an inbound offer and recompute the rollup of every line it touched.
@@ -690,16 +703,24 @@ def assign_offer_line(
     (and thus awardable). Sets ``excess_line_item_id`` + flips ``match_status`` → MATCHED,
     then recomputes the target line's best-price rollup (and, on a RE-assign, the line it
     moved off of, so the old line no longer counts the moved bid). Guards: the list exists
-    (404) + *owner* owns it (403); the offer line belongs to this list (404); the target
-    line is on this list (404, never another list's line). Commits.
+    (404) + *owner* owns it (403); the list is not resolved/terminal — ``awarded``/
+    ``closed``/``expired`` reject 409 (finding #2 + the finding #4 "second vector": a
+    salvaged line on a dead list must not become awardable); the parent offer is still in
+    play (``open``/``late``) — a won/lost/withdrawn offer's line is 409 (re-pointing a won
+    offer's line would strand its award linkage); the offer line belongs to this list
+    (404); the target line is on this list (404, never another list's line). Commits.
     """
     excess_list = get_excess_list(db, list_id)
     if excess_list.owner_id != owner.id:
         raise HTTPException(403, "Only the list owner can assign an offer line")
+    if excess_list.status in _ASSIGN_BLOCKED_LIST_STATUSES:
+        raise HTTPException(409, "This list is resolved — its offer lines can no longer be reassigned")
 
     offer_line = db.get(ExcessOfferLine, offer_line_id)
     if offer_line is None or offer_line.offer is None or offer_line.offer.excess_list_id != list_id:
         raise HTTPException(404, f"Offer line {offer_line_id} not found on list {list_id}")
+    if offer_line.offer.status not in {s.value for s in _ACTIONABLE_OFFER_STATUSES}:
+        raise HTTPException(409, "Only an open or late offer's line can be assigned")
 
     target = db.get(ExcessLineItem, target_line_item_id)
     if target is None or target.excess_list_id != list_id:
@@ -874,6 +895,13 @@ def award_offer(db: Session, offer_id: int, owner: User) -> ExcessOffer:
 
     if offer.status == ExcessOfferStatus.WON:
         return offer  # idempotent — a double-award is a no-op, not a second flip
+
+    # A terminal list (closed-without-bid per D5, or nightly-expired) is dead: awarding an
+    # offer on it would reopen it to ``awarded`` (and a later unaward would step it to
+    # ``bid_out``), violating the D5 "terminal, no reopen" contract (finding #4). A late
+    # offer on such a list stays queued/reviewable but can never resurrect the posting.
+    if excess_list.status in {s.value for s in _TERMINAL_LIST_STATUSES}:
+        raise HTTPException(409, "This list is closed — it can't be reopened by awarding an offer")
 
     if offer.status not in {s.value for s in _ACTIONABLE_OFFER_STATUSES}:
         # A lost/withdrawn offer is already closed — awarding it would resurrect a dead

--- a/app/services/resell_outreach_service.py
+++ b/app/services/resell_outreach_service.py
@@ -1014,6 +1014,46 @@ def record_response(
     return rows
 
 
+def record_manual_response(
+    db: Session,
+    *,
+    outreach: ExcessOutreach,
+    has_offer: bool = False,
+    offer_lines: list[dict] | None = None,
+    offer_notes: str | None = None,
+    commit: bool = True,
+) -> ExcessOutreach:
+    """Log a manual-channel buyer outcome directly on ONE outreach row (finding #12).
+
+    A phone/teams/marketplace touch has no email thread, so the conversation-keyed
+    ``record_response`` can never advance it — this is the manual counterpart. Advances the
+    row to ``bid`` (when the buyer bid) or ``responded``, but NEVER regresses a row already
+    in a terminal state (``bid`` / ``declined``) — same rule as ``record_response``. When
+    ``has_offer``, creates the inbound ExcessOffer via the SAME ``_link_inbound_offer`` path
+    an emailed bid uses (buyer-scoped, queued-never-dropped line matching, rollup recompute).
+    ``commit`` (default True) commits + refreshes; pass False when the caller owns the txn.
+    """
+    _terminal = {ExcessOutreachStatus.BID, ExcessOutreachStatus.DECLINED}
+    if outreach.status not in _terminal:
+        outreach.status = ExcessOutreachStatus.BID if has_offer else ExcessOutreachStatus.RESPONDED
+
+    if has_offer:
+        _link_inbound_offer(db, outreach, offer_lines or [], offer_notes)
+
+    if commit:
+        db.commit()
+        db.refresh(outreach)
+    else:
+        db.flush()
+    logger.info(
+        "Manually logged outreach id={} → {} (offer={})",
+        outreach.id,
+        outreach.status,
+        has_offer,
+    )
+    return outreach
+
+
 def _log_inbound_reply_activity(db: Session, *, outreach: ExcessOutreach, vr: VendorResponse) -> None:
     """Write one inbound ActivityLog for a buyer's reply on a resell outreach.
 

--- a/app/services/resell_outreach_service.py
+++ b/app/services/resell_outreach_service.py
@@ -1029,15 +1029,22 @@ def record_manual_response(
     ``record_response`` can never advance it — this is the manual counterpart. Advances the
     row to ``bid`` (when the buyer bid) or ``responded``, but NEVER regresses a row already
     in a terminal state (``bid`` / ``declined``) — same rule as ``record_response``. When
-    ``has_offer``, creates the inbound ExcessOffer via the SAME ``_link_inbound_offer`` path
-    an emailed bid uses (buyer-scoped, queued-never-dropped line matching, rollup recompute).
+    ``has_offer`` AND the row was not already terminal, creates the inbound ExcessOffer via
+    the SAME ``_link_inbound_offer`` path an emailed bid uses (buyer-scoped,
+    queued-never-dropped line matching, rollup recompute); a replayed Log-bid on an
+    already-terminal row is an idempotent no-op (no duplicate offer).
     ``commit`` (default True) commits + refreshes; pass False when the caller owns the txn.
     """
     _terminal = {ExcessOutreachStatus.BID, ExcessOutreachStatus.DECLINED}
-    if outreach.status not in _terminal:
+    already_terminal = outreach.status in _terminal
+    if not already_terminal:
         outreach.status = ExcessOutreachStatus.BID if has_offer else ExcessOutreachStatus.RESPONDED
 
-    if has_offer:
+    # Gate the offer link on the SAME terminal check as the status advance: a replayed
+    # Log-bid on an already-BID row (or a bid logged against a DECLINED row) must NOT
+    # create a SECOND ExcessOffer for the buyer's single manual bid — otherwise the line's
+    # offer_count / best_offer_id are silently inflated with no idempotency on the row.
+    if has_offer and not already_terminal:
         _link_inbound_offer(db, outreach, offer_lines or [], offer_notes)
 
     if commit:

--- a/app/templates/htmx/partials/resell/_lines.html
+++ b/app/templates/htmx/partials/resell/_lines.html
@@ -44,6 +44,23 @@
   {%- endif -%}
 {% endmacro %}
 
+{# Per-line draft-edit actions (finding #14): Edit opens the pre-filled modal; Delete
+   removes the line and re-renders the detail. Owner-only + draft-only (the caller gates). #}
+{% macro _line_edit_actions(el, item) %}
+  <div class="inline-flex items-center gap-1 whitespace-nowrap">
+    <button @click="$dispatch('open-modal')"
+            hx-get="/v2/partials/resell/{{ el.id }}/lines/{{ item.id }}/edit-form"
+            hx-target="#modal-content"
+            class="btn-ghost btn-sm text-gray-500 hover:text-gray-700">Edit</button>
+    <button hx-delete="/api/resell/{{ el.id }}/lines/{{ item.id }}"
+            hx-target="[data-resell-detail-root]"
+            hx-swap="outerHTML"
+            hx-confirm="Delete this line?"
+            data-loading-disable
+            class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Delete</button>
+  </div>
+{% endmacro %}
+
 <div class="space-y-4">
 
   {# ── Easy entry (owner, draft only — lines lock on post) ──────── #}
@@ -101,6 +118,9 @@
         {{ _line_offer_badge(el, item, is_owner) }}
       </div>
     </div>
+    {% if is_owner and is_draft %}
+    <div class="mt-2 flex justify-end">{{ _line_edit_actions(el, item) }}</div>
+    {% endif %}
     <div class="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
       <div><span class="block text-secondary uppercase tracking-wide">Qty</span><span class="font-medium tabular-nums">{{ "{:,}".format(item.quantity) }}</span></div>
       <div><span class="block text-secondary uppercase tracking-wide">Condition</span><span class="font-medium">{{ item.condition or '—' }}</span></div>
@@ -168,6 +188,7 @@
             <th class="text-left">Condition</th>
             <th class="text-right">Best offer</th>
             <th class="text-center">Offers</th>
+            {% if is_owner and is_draft %}<th class="text-right">Edit</th>{% endif %}
           </tr>
         </thead>
         <tbody>
@@ -198,6 +219,7 @@
                 {{ _line_offer_badge(el, item, is_owner) }}
               </div>
             </td>
+            {% if is_owner and is_draft %}<td class="text-right">{{ _line_edit_actions(el, item) }}</td>{% endif %}
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/htmx/partials/resell/_list_after_delete.html
+++ b/app/templates/htmx/partials/resell/_list_after_delete.html
@@ -1,0 +1,20 @@
+{#
+  resell/_list_after_delete.html — response after a draft list is deleted.
+  PRIMARY body = the refreshed My-Lists partial (the delete button's hx-target is
+  #resell-list-body), so the deleted row drops out. Out-of-band it RESETS the detail
+  pane (#split-right-resell) to the "select a list" placeholder — the just-deleted
+  detail is gone. A confirmation toast fires via HX-Trigger (see resell.resell_delete_list).
+  Receives: the _lists.html context (cards, lens, stage, needs, q, can_see_customer, can_post).
+  Called by: resell.resell_delete_list.
+#}
+{% include "htmx/partials/resell/_lists.html" %}
+<div id="split-right-resell" hx-swap-oob="innerHTML">
+  <div class="flex items-center justify-center h-full text-gray-400">
+    <div class="text-center px-6">
+      <svg class="mx-auto h-10 w-10 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/>
+      </svg>
+      <p class="text-sm">Select a list to view its lines and offers</p>
+    </div>
+  </div>
+</div>

--- a/app/templates/htmx/partials/resell/_offers.html
+++ b/app/templates/htmx/partials/resell/_offers.html
@@ -251,7 +251,7 @@
       Unmatched queue ({{ unmatched|length }}) — resolve manually
     </p>
     <table class="compact-table min-w-full">
-      <thead><tr><th class="text-left">Raw MPN</th><th class="text-right">Unit $</th><th class="text-right">Qty</th><th class="text-left">Broker</th></tr></thead>
+      <thead><tr><th class="text-left">Raw MPN</th><th class="text-right">Unit $</th><th class="text-right">Qty</th><th class="text-left">Broker</th><th class="text-left">Assign to</th></tr></thead>
       <tbody>
         {% for e in unmatched %}
         <tr>
@@ -259,6 +259,24 @@
           <td class="text-right tabular-nums">{% if e.line.unit_price is not none %}${{ "{:,.4f}".format(e.line.unit_price|float) }}{% else %}—{% endif %}</td>
           <td class="text-right tabular-nums">{{ "{:,}".format(e.line.quantity) }}</td>
           <td>{{ _broker_label(e.offer, is_owner) }}</td>
+          {# Manual resolution (finding #15): point the parked line at the intended posted
+             line — it becomes a matched, awardable bid. Same OOB re-render as award. #}
+          <td>
+            {% if line_items %}
+            <form hx-post="/api/resell/{{ el.id }}/offer-lines/{{ e.line.id }}/assign"
+                  hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+                  class="inline-flex items-center gap-1">
+              <select name="target_line_item_id" required aria-label="Assign to line"
+                      class="text-xs border border-amber-300 rounded px-1 py-0.5 bg-white">
+                <option value="">Choose line…</option>
+                {% for item in line_items %}
+                <option value="{{ item.id }}">{{ item.part_number }}</option>
+                {% endfor %}
+              </select>
+              <button type="submit" data-loading-disable class="btn-primary btn-sm">Assign</button>
+            </form>
+            {% else %}<span class="text-xs text-gray-400">no lines</span>{% endif %}
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/app/templates/htmx/partials/resell/_offers.html
+++ b/app/templates/htmx/partials/resell/_offers.html
@@ -55,13 +55,80 @@
 {% endmacro %}
 
 {% if not is_owner %}
-{# Offerer-facing: a non-owner never sees the collected offer stack. #}
-<div class="mx-auto max-w-sm text-center py-10">
-  <svg class="mx-auto mb-3 h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
-  </svg>
-  <p class="text-sm font-medium text-gray-600">Offers are private to the list owner</p>
-  <p class="text-secondary mt-1">Use “Submit offer” to send yours — the owner sees it, other brokers do not.</p>
+{# Offerer-facing: the broker sees ONLY their OWN offers on this list — never another
+   broker's bid, price, or coverage (Phase-3 anonymization). Each open/late own-offer is
+   Withdraw-able (the withdraw route authorizes the submitter). #}
+<div class="space-y-4">
+  <p class="text-secondary">Your offers on this list — private to you and the owner. Other brokers never see them.</p>
+  {% if own_offers %}
+  {% for offer in own_offers %}
+  {% set is_take_all = offer.scope == 'take_all' %}
+  {% set can_withdraw = offer.status in ['open', 'late'] %}
+  <div class="rounded-lg border border-brand-200 overflow-hidden">
+    <div class="flex items-center justify-between gap-2 px-3 py-2 bg-gray-50 border-b border-brand-100">
+      <span class="inline-flex items-center gap-2">
+        <span class="text-sm font-semibold text-gray-900">{{ 'Take-all offer' if is_take_all else 'Your offer' }}</span>
+        {% set badge = {
+          'open': 'bg-sky-50 text-sky-600 border-sky-200',
+          'late': 'bg-amber-50 text-amber-600 border-amber-200',
+          'won': 'bg-emerald-50 text-emerald-700 border-emerald-300',
+          'lost': 'bg-gray-50 text-gray-400 border-gray-200'
+        } %}
+        <span class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full border capitalize {{ badge.get(offer.status, 'bg-gray-50 text-gray-500 border-gray-200') }}">
+          {{ 'Not selected' if offer.status == 'lost' else offer.status }}
+        </span>
+      </span>
+      {% if can_withdraw %}
+      <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/withdraw"
+              hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+              hx-confirm="Withdraw your offer? It drops out of the running."
+              data-loading-disable
+              class="btn-ghost btn-sm text-gray-500 hover:text-gray-700">Withdraw</button>
+      {% endif %}
+    </div>
+    {% if is_take_all %}
+    <div class="flex items-center justify-between px-3 py-2 text-sm">
+      <span class="text-secondary">Whole-list lump offer</span>
+      {% if offer.take_all_total_price is not none %}
+      <span class="font-semibold text-violet-700 tabular-nums">${{ "{:,.2f}".format(offer.take_all_total_price|float) }}</span>
+      {% else %}<span class="text-gray-400 italic">Price TBD</span>{% endif %}
+    </div>
+    {% else %}
+    <table class="compact-table min-w-full">
+      <thead>
+        <tr>
+          <th class="text-left">Part</th>
+          <th class="text-right">Unit $</th>
+          <th class="text-right">Qty</th>
+          <th class="text-center">Lead</th>
+          <th class="text-left">Terms</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for line in offer.lines %}
+        <tr>
+          <td class="font-mono">{{ line.mpn_raw }}</td>
+          <td class="text-right tabular-nums">{% if line.unit_price is not none %}${{ "{:,.4f}".format(line.unit_price|float) }}{% else %}<span class="text-gray-400">TBD</span>{% endif %}</td>
+          <td class="text-right tabular-nums">{{ "{:,}".format(line.quantity) }}</td>
+          <td class="text-center">{{ (line.lead_time_days|string ~ 'd') if line.lead_time_days is not none else '—' }}</td>
+          <td class="text-gray-500">{{ line.terms_text or '—' }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+    {% if offer.notes %}<p class="text-secondary px-3 py-2 border-t border-brand-100">{{ offer.notes }}</p>{% endif %}
+  </div>
+  {% endfor %}
+  {% else %}
+  <div class="mx-auto max-w-sm text-center py-10">
+    <svg class="mx-auto mb-3 h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+    </svg>
+    <p class="text-sm font-medium text-gray-600">You haven't offered on this list yet</p>
+    <p class="text-secondary mt-1">Use “Submit offer” to send yours — the owner sees it, other brokers do not.</p>
+  </div>
+  {% endif %}
 </div>
 
 {% else %}

--- a/app/templates/htmx/partials/resell/_outreach.html
+++ b/app/templates/htmx/partials/resell/_outreach.html
@@ -124,6 +124,26 @@
                 Retry
               </button>
               {% endif %}
+              {# Manual-channel log actions (finding #12): a phone/teams/marketplace touch has
+                 no email thread, so the owner records the outcome directly on the row —
+                 Log response (→ responded) or Log their bid (→ bid + an ExcessOffer). Hidden
+                 once the row is terminal (bid/declined). #}
+              {% if row.channel != 'email' and row.status not in ('bid', 'declined') %}
+              {% if row.status == 'sent' %}
+              <button hx-post="/api/resell/{{ el.id }}/outreach/{{ row.id }}/log-response"
+                      hx-target="#tab-outreach-{{ el.id }}" hx-swap="innerHTML"
+                      data-loading-disable
+                      class="text-xs font-medium text-accent-600 hover:text-accent-700 hover:underline">
+                Log response
+              </button>
+              {% endif %}
+              <button @click="$dispatch('open-modal')"
+                      hx-get="/v2/partials/resell/{{ el.id }}/outreach/{{ row.id }}/log-bid-form"
+                      hx-target="#modal-content"
+                      class="text-xs font-medium text-accent-600 hover:text-accent-700 hover:underline">
+                Log bid
+              </button>
+              {% endif %}
             </div>
             {# Surface the persisted send_error so a delivered-but-degraded send is not
                indistinguishable from a healthy one, and a failed/interrupted row shows WHY.

--- a/app/templates/htmx/partials/resell/_reply_viewer.html
+++ b/app/templates/htmx/partials/resell/_reply_viewer.html
@@ -87,7 +87,7 @@
           hx-target="#tab-outreach-{{ el.id }}"
           hx-swap="innerHTML"
           data-loading-disable
-          @htmx:after-request.camel="if(event.detail.successful){ $dispatch('close-modal'); $store.toast.message='Offer created from reply'; $store.toast.type='success'; $store.toast.show=true; }"
+          @htmx:after-request.camel="if(event.detail.successful){ $dispatch('close-modal'); $store.toast.message='{{ 'Bid logged' if manual else 'Offer created from reply' }}'; $store.toast.type='success'; $store.toast.show=true; }"
           class="space-y-3 mt-3">
       <div>
         <label class="form-label">Part number <span class="text-rose-500">*</span></label>

--- a/app/templates/htmx/partials/resell/_reply_viewer.html
+++ b/app/templates/htmx/partials/resell/_reply_viewer.html
@@ -11,12 +11,17 @@
 #}
 {% set el = list %}
 {% set buyer = outreach.target_vendor_card.display_name if outreach.target_vendor_card else 'this buyer' %}
+{# Reused by BOTH the email reply viewer (default) and the manual Log-bid modal (finding
+   #12). ``manual`` swaps the email-thread framing for a manual-touch note; ``convert_url``
+   points the convert form at the right POST route (email-convert vs manual log-bid). #}
+{% set manual = manual|default(false) %}
+{% set convert_url = convert_url|default('/api/resell/' ~ el.id ~ '/outreach/' ~ outreach.id ~ '/offer') %}
 <div class="p-5" x-data="{ showConvert: {{ 'false' if outreach.status == 'bid' else 'true' }} }">
 
   {# ── Header ─────────────────────────────────────────────────────── #}
   <div class="flex items-start justify-between gap-3 mb-4">
     <div>
-      <h2 class="h2">Reply from {{ buyer }}</h2>
+      <h2 class="h2">{{ 'Log bid from' if manual else 'Reply from' }} {{ buyer }}</h2>
       <p class="text-sm text-gray-500">On <span class="font-medium text-gray-700">{{ el.title }}</span></p>
     </div>
     <button type="button" @click="$dispatch('close-modal')" aria-label="Close"
@@ -49,6 +54,13 @@
     </div>
     {% endfor %}
   </div>
+  {% elif manual %}
+  {# Manual-channel touch (phone/teams/marketplace) — there is no email thread to show.
+     Honest note, then the same convert form to record the buyer's bid. #}
+  <div class="rounded-lg border border-dashed border-brand-200 p-5 text-center text-sm text-gray-500">
+    <p class="font-medium text-gray-600">This was a {{ outreach.channel }} touch — no email thread.</p>
+    <p class="text-secondary mt-1">Record the buyer's bid below.</p>
+  </div>
   {% else %}
   {# The outreach advanced on a reply but no message body was captured (or it was purged).
      Honest note, not a silent blank — the convert form below still works off the thread. #}
@@ -62,16 +74,16 @@
   <div class="mt-5 pt-4 border-t border-gray-100">
     <div class="flex items-center justify-between">
       <h3 class="text-sm font-semibold text-gray-900">
-        {% if outreach.status == 'bid' %}Add another offer line{% else %}Convert reply to an offer{% endif %}
+        {% if outreach.status == 'bid' %}Add another offer line{% elif manual %}Record the buyer's bid{% else %}Convert reply to an offer{% endif %}
       </h3>
       <button type="button" @click="showConvert = !showConvert"
               class="text-xs font-medium text-accent-600 hover:text-accent-700"
               x-text="showConvert ? 'Hide' : 'Add offer'"></button>
     </div>
-    <p class="text-secondary mt-0.5">Read the reply, then record the buyer's price and quantity as a tracked offer.</p>
+    <p class="text-secondary mt-0.5">Record the buyer's price and quantity as a tracked offer.</p>
 
     <form x-show="showConvert" x-cloak
-          hx-post="/api/resell/{{ el.id }}/outreach/{{ outreach.id }}/offer"
+          hx-post="{{ convert_url }}"
           hx-target="#tab-outreach-{{ el.id }}"
           hx-swap="innerHTML"
           data-loading-disable

--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -87,6 +87,16 @@
                 class="btn-secondary btn-sm">
           Close
         </button>
+        {# D5: end a posting that drew no usable bid → the terminal CLOSED state (distinct
+           from the bid_out "bids went out" path above; no reopen). #}
+        <button hx-post="/api/resell/{{ el.id }}/close-without-bid"
+                hx-target="closest [data-resell-detail-root]"
+                hx-swap="outerHTML"
+                hx-confirm="Close this list without bidding? It ends for good — no bid goes out and it can't be reopened."
+                data-loading-disable
+                class="btn-ghost btn-sm text-gray-500 hover:text-gray-700">
+          Close (no bid)
+        </button>
         {% endif %}
         {% if can_offer %}
         <button @click="$dispatch('open-modal')"

--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -39,6 +39,23 @@
 
       {# Owner / offerer actions #}
       <div class="flex items-center gap-2 flex-shrink-0">
+        {# Draft-edit affordances (finding #14): while a list is a private draft the owner
+           can edit its header or delete it outright. Both vanish once posted (lines lock). #}
+        {% if can_see_customer and el.status == 'draft' %}
+        <button @click="$dispatch('open-modal')"
+                hx-get="/v2/partials/resell/{{ el.id }}/edit-form"
+                hx-target="#modal-content"
+                class="btn-ghost btn-sm text-gray-500 hover:text-gray-700">
+          <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+          Edit
+        </button>
+        <button hx-delete="/api/resell/{{ el.id }}"
+                hx-target="#resell-list-body"
+                hx-swap="innerHTML"
+                hx-confirm="Delete this draft list and all its lines? This can't be undone."
+                data-loading-disable
+                class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Delete</button>
+        {% endif %}
         {% if can_see_customer and el.status == 'draft' and line_count > 0 %}
         <button hx-post="/api/resell/{{ el.id }}/publish"
                 hx-target="closest [data-resell-detail-root]"

--- a/app/templates/htmx/partials/resell/edit_line_modal.html
+++ b/app/templates/htmx/partials/resell/edit_line_modal.html
@@ -1,0 +1,56 @@
+{#
+  resell/edit_line_modal.html — Edit-one-line modal (draft lists only).
+  PATCHes /api/resell/{id}/lines/{line_id} which re-renders the WHOLE detail panel
+  (so the Lines tab + header stay in step). Pre-filled from the line's current values.
+  Mirrors add_line_modal.html; the form lives in the global modal (outside the detail
+  root), so it targets the detail root by its document-wide marker attribute.
+  Receives: list_id, line (ExcessLineItem).
+  Called by: resell.resell_edit_line_form.
+#}
+<div class="p-5">
+  <h3 class="h2 mb-4">Edit line</h3>
+  <form hx-patch="/api/resell/{{ list_id }}/lines/{{ line.id }}"
+        hx-target="[data-resell-detail-root]"
+        hx-swap="outerHTML"
+        data-loading-disable
+        @htmx:after-request.camel="if(event.detail.successful){ $dispatch('close-modal'); $store.toast.message='Line updated'; $store.toast.type='success'; $store.toast.show=true; }"
+        class="space-y-4">
+    <div>
+      <label class="form-label">Part number <span class="text-rose-500">*</span></label>
+      <input type="text" name="part_number" required class="input" value="{{ line.part_number }}">
+    </div>
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label class="form-label">Manufacturer</label>
+        <input type="text" name="manufacturer" class="input" value="{{ line.manufacturer or '' }}">
+      </div>
+      <div>
+        <label class="form-label">Quantity <span class="text-rose-500">*</span></label>
+        <input type="number" name="quantity" required min="1" value="{{ line.quantity }}" class="input">
+      </div>
+    </div>
+    <div class="grid grid-cols-3 gap-3">
+      <div>
+        <label class="form-label">Condition</label>
+        <select name="condition" class="input">
+          {% for opt in ['New', 'Used', 'Refurbished'] %}
+          <option value="{{ opt }}" {{ 'selected' if (line.condition or 'New') == opt }}>{{ opt }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="form-label">Date code</label>
+        <input type="text" name="date_code" class="input" value="{{ line.date_code or '' }}">
+      </div>
+      <div>
+        <label class="form-label">Asking price</label>
+        <input type="number" name="asking_price" step="0.01" min="0" class="input"
+               value="{{ '%.2f'|format(line.asking_price|float) if line.asking_price is not none else '' }}">
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button type="button" @click="$dispatch('close-modal')" class="btn btn-secondary">Cancel</button>
+      <button type="submit" class="btn btn-primary">Save line</button>
+    </div>
+  </form>
+</div>

--- a/app/templates/htmx/partials/resell/edit_list_modal.html
+++ b/app/templates/htmx/partials/resell/edit_list_modal.html
@@ -1,0 +1,38 @@
+{#
+  resell/edit_list_modal.html — Edit-draft-header modal (draft lists only).
+  PATCHes /api/resell/{id} (title/customer/notes) which re-renders the WHOLE detail
+  panel. Pre-filled from the list's current values. Mirrors create_modal.html.
+  Receives: list (ExcessList), companies.
+  Called by: resell.resell_edit_list_form.
+#}
+{% set el = list %}
+<div class="p-5">
+  <h2 class="h2 mb-5">Edit list details</h2>
+
+  <form hx-patch="/api/resell/{{ el.id }}"
+        hx-target="[data-resell-detail-root]"
+        hx-swap="outerHTML"
+        data-loading-disable
+        @htmx:after-request.camel="if(event.detail.successful){ $dispatch('close-modal'); $store.toast.message='List updated'; $store.toast.type='success'; $store.toast.show=true; }"
+        class="space-y-4">
+    <div>
+      <label class="form-label">Title <span class="text-rose-500">*</span></label>
+      <input type="text" name="title" required class="input" value="{{ el.title }}">
+    </div>
+    <div>
+      <label class="form-label">Customer <span class="text-rose-500">*</span></label>
+      <select name="company_id" required class="input">
+        {% for c in companies %}<option value="{{ c.id }}" {{ 'selected' if c.id == el.company_id }}>{{ c.name }}</option>{% endfor %}
+      </select>
+      <p class="text-secondary mt-1">The customer is owner-only — never shown to brokers.</p>
+    </div>
+    <div>
+      <label class="form-label">Notes</label>
+      <textarea name="notes" rows="2" class="input" placeholder="Optional…">{{ el.notes or '' }}</textarea>
+    </div>
+    <div class="modal-footer">
+      <button type="button" @click="$dispatch('close-modal')" class="btn btn-secondary">Cancel</button>
+      <button type="submit" class="btn btn-primary">Save changes</button>
+    </div>
+  </form>
+</div>

--- a/app/templates/htmx/partials/resell/offer_buyers_modal.html
+++ b/app/templates/htmx/partials/resell/offer_buyers_modal.html
@@ -116,11 +116,16 @@
         </label>
         {% endfor %}
 
-        {# No-contact history buyers: dealt-with-before but no resolvable email — manual
-           log only, disabled checkbox, clear badge (mirrors the RFQ modal no-email row). #}
+        {# No-contact history buyers: dealt-with-before but no resolvable email. On the
+           EMAIL channel they can't be reached, so the checkbox stays disabled; on a manual
+           channel (phone/teams/marketplace) no email is needed, so the checkbox is enabled
+           and toggles the buyer into the selection (finding #12). #}
         {% for nc in no_contact_buyers %}
         <label class="flex items-center gap-3 px-3 py-2">
-          <input type="checkbox" disabled class="rounded border-gray-300 cursor-not-allowed">
+          <input type="checkbox" :disabled="channel === 'email'"
+                 :checked="isSel({{ nc.card.id }})" @change="toggle({{ nc.card.id }})"
+                 :class="channel === 'email' ? 'cursor-not-allowed' : ''"
+                 class="rounded border-gray-300">
           <div class="flex-1 min-w-0">
             <span class="text-sm font-medium text-gray-500">{{ nc.card.display_name }}</span>
             <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-gray-100 text-gray-500">no contact on file</span>

--- a/app/templates/htmx/partials/resell/offer_buyers_modal.html
+++ b/app/templates/htmx/partials/resell/offer_buyers_modal.html
@@ -25,10 +25,12 @@
        selected: {{ preselect_ids|default([])|tojson }},
        scope: {{ "per_line" | tojson if line_ids else "whole_list" | tojson }},
        channel: "email",
+       noContactIds: [{% for nc in no_contact_buyers %}{{ nc.card.id }}{{ "," if not loop.last }}{% endfor %}],
        query: "",
        results: [],
        searchOpen: false,
        addedCompanies: [],
+       setChannel(ch) { this.channel = ch; if (ch === "email") { this.selected = this.selected.filter(id => !this.noContactIds.includes(id)); } },
        toggle(id) { this.selected.includes(id) ? this.selected = this.selected.filter(x => x !== id) : this.selected.push(id); },
        isSel(id) { return this.selected.includes(id); },
        async search() {
@@ -182,7 +184,7 @@
       <label class="block font-medium text-secondary uppercase tracking-wider mb-1">Channel</label>
       <div class="flex flex-wrap gap-2 text-sm">
         {% for ch in channels %}
-        <button type="button" @click="channel = '{{ ch }}'"
+        <button type="button" @click="setChannel('{{ ch }}')"
                 :class="channel === '{{ ch }}' ? 'bg-accent-500 text-white border-accent-500' : 'bg-white text-gray-600 border-gray-200 hover:bg-accent-50'"
                 class="px-3 py-1.5 rounded-full border font-medium transition-colors capitalize">{{ ch }}</button>
         {% endfor %}

--- a/app/templates/htmx/partials/resell/workspace.html
+++ b/app/templates/htmx/partials/resell/workspace.html
@@ -63,7 +63,7 @@
       ('open', 'stage=open', 'Open', stats.open, 'Posted, awaiting offers'),
       ('offers', 'needs=offers', 'Offers to review', stats.offers_to_review, 'New, unactioned'),
       ('take_all', 'needs=take_all', 'Take-all', stats.take_all, 'Whole-list offers'),
-      ('bid_out', 'stage=bid_out', 'Bids out', stats.bids_out, 'Sent to the customer'),
+      ('bid_out', 'stage=bid_out', 'Bids out', stats.bids_out, 'Collection window closed'),
       ('awarded', 'stage=awarded', 'Awarded', stats.awarded, 'Closed deals')
     ] %}
     {% for token, query, label, value, sub in glance %}

--- a/app/templates/htmx/partials/resell/workspace.html
+++ b/app/templates/htmx/partials/resell/workspace.html
@@ -60,7 +60,7 @@
   <div x-show="lens === 'mine'" x-cloak
        class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2 mb-3 flex-shrink-0">
     {% set glance = [
-      ('open', 'stage=open', 'Open', stats.open, 'Posted, awaiting offers'),
+      ('open', 'stage=live', 'Open', stats.open, 'Open + collecting offers'),
       ('offers', 'needs=offers', 'Offers to review', stats.offers_to_review, 'New, unactioned'),
       ('take_all', 'needs=take_all', 'Take-all', stats.take_all, 'Whole-list offers'),
       ('bid_out', 'stage=bid_out', 'Bids out', stats.bids_out, 'Collection window closed'),

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2066,8 +2066,11 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     +-- GET /v2/partials/resell/{id}                    (right detail: breadcrumb + chips +
     |        lazy tabs Lines · Offers · Build Bid · Outreach(owner) · Activity; customer chip owner-only)
     |        +-- GET .../{id}/lines    (adaptive: 1 line → .card, ≥2 → compact-table)
-    |        +-- GET .../{id}/offers   (owner-only stack: pinned take-all banner +
-    |        |     per-line offer tables + unmatched queue; non-owner sees nothing)
+    |        +-- GET .../{id}/offers   (OWNER: pinned take-all banner + per-line offer tables +
+    |        |     unmatched queue [each row an "Assign to" select — finding #15]. NON-OWNER
+    |        |     (broker): their OWN offers ONLY + a Withdraw per open/late bid — NO competitor
+    |        |     data (Phase-3 anonymization); a submitter reaches it even after the window
+    |        |     closes — finding #13)
     |        +-- GET .../{id}/lines/{line_id}/offers  (per-line comparison: best emerald +
     |        |     price-spread bar, cloned from quote_builder/modal.html, NO auto-select)
     |        +-- GET .../{id}/offer-buyers-form  (owner-only buyer panel: ranked suggestions
@@ -2084,6 +2087,21 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     +-- POST /api/resell/{id}/lines                     (add line; resolves MaterialCard;
     |     re-renders the WHOLE detail via [data-resell-detail-root], not just Lines, so the
     |     header Post button appears once a fresh draft has lines — RS-5)
+    +-- DRAFT-EDIT set (finding #14 / D4 — all DRAFT-only + owner-only, guarded 404→403→409 in
+    |     the service; a draft has no offers/mirror so side-effect-free except total_line_items):
+    |        +-- PATCH  /api/resell/{id}/lines/{line_id}  (excess_service.update_line; re-validates
+    |        |     quantity>0 → 400 [the model @validates 500s otherwise]; re-resolves the
+    |        |     MaterialCard when MPN/manufacturer changes; re-renders detail)
+    |        +-- DELETE /api/resell/{id}/lines/{line_id}  (excess_service.delete_line; decrements
+    |        |     total_line_items; re-renders detail)
+    |        +-- PATCH  /api/resell/{id}                   (excess_service.update_excess_list;
+    |        |     title/notes/company_id[re-validates exists]/customer_site_id; re-renders detail)
+    |        +-- DELETE /api/resell/{id}                   (excess_service.delete_excess_list; cascade
+    |        |     cleans children → refreshes My-Lists [#resell-list-body] + OOB detail-pane reset
+    |        |     [#split-right-resell] + toast)
+    |        +-- GET .../{id}/edit-form, .../{id}/lines/{line_id}/edit-form (pre-filled modals)
+    |     [Honest 409 copy (×3): "Posted lists are locked. Close this list and create a new one
+    |      to make changes." replaces the false "revise as a new version".]
     +-- POST /api/resell/{id}/import-preview|import-confirm  (reuse excess parsers + preview grid;
     |     preview ALWAYS renders a re-upload/back affordance even for an all-errors file — RS-6;
     |     confirm re-renders the whole detail like add-line — RS-5)
@@ -2107,6 +2125,11 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |     (full-history recompute self-heals wins), steps the list back off awarded → bid_out
     |     (close_at set) else collecting FIRST, THEN re-mirrors (so a reverted-to-bid_out closed
     |     posting stays retired — M5). Same _award_response OOB)
+    +-- POST /api/resell/{id}/offer-lines/{offer_line_id}/assign (owner-only; finding #15;
+    |     excess_service.assign_offer_line: manual resolution of the unmatched queue — point a
+    |     parked ExcessOfferLine at a posted line [404 target/offer-line off this list], flips
+    |     match_status→matched + recomputes the target [+ old line on a re-assign] rollup so the
+    |     salvaged bid is awardable. Same _award_response OOB compose as award)
     +-- GET  /v2/partials/resell/{id}/build-bid          (owner-only Build-Bid tab: each line's
     |     best-offer planning price + editable "our offer"; once assembled, the clean
     |     bid_back_export_context summary + Download-PDF + the lifecycle action bar. Context
@@ -2127,6 +2150,11 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     +-- POST /api/resell/{id}/close                      (owner-only; excess_service.close_list:
     |     GUARDED to open/collecting [409 otherwise] → bid_out + close_at + RETIRES the Sighting
     |     mirror [sync_list_mirror on a now-closed posting] — M5)
+    +-- POST /api/resell/{id}/close-without-bid          (owner-only; D5; excess_service.
+    |     close_list_without_bid → the TERMINAL closed state [distinct from bid_out]: same
+    |     open/collecting guard + close_at + mirror retire, but CLOSED is never swept by the
+    |     nightly expiry [only open/collecting are] and never reopens. close_list and
+    |     close_list_without_bid share _end_posting_window(target_status))
     +-- POST /api/resell/{id}/outreach                  (owner-only; channel=email →
     |     resell_outreach_service.submit_outreach_email [RFQ send engine], else
     |     submit_outreach [manual log]; re-renders the Outreach tracker)
@@ -2135,10 +2163,25 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |     thread (_replies_context joins VendorResponse↔ExcessOutreach on graph_conversation_id,
     |     newest-first) + a "Convert to offer" quick-add. 404 when the outreach has no thread)
     +-- POST /api/resell/{id}/outreach/{oid}/offer      (RS-4, owner-only; human-reviewed
-          offer extraction — record_response(has_offer=True) creates the inbound ExcessOffer
-          via the SAME queued-never-dropped line matcher as an emailed bid + advances the
-          outreach →bid; re-renders the tracker into #tab-outreach-<id>)
+    |     offer extraction — record_response(has_offer=True) creates the inbound ExcessOffer
+    |     via the SAME queued-never-dropped line matcher as an emailed bid + advances the
+    |     outreach →bid; re-renders the tracker into #tab-outreach-<id>)
+    +-- MANUAL-CHANNEL log (finding #12, owner-only; a phone/teams/marketplace row is 'sent'
+          with NO email thread, so the conversation-keyed reply matcher can't advance it):
+          +-- POST .../{oid}/log-response  (resell_outreach_service.record_manual_response →
+          |     responded; never regresses a terminal bid/declined; 409 for an email row)
+          +-- GET  .../{oid}/log-bid-form  (reuses _reply_viewer.html — manual flag + convert_url
+          |     — as the Log-bid modal)
+          +-- POST .../{oid}/log-bid       (record_manual_response(has_offer=True) → bid + an
+                ExcessOffer via the SAME _link_inbound_offer path an emailed bid uses)
 ```
+
+**Triage filters (finding #16).** The left-list `stage` filter takes the usual status values
+(`open`/`collecting`/`bid_out`/`awarded`/`closed`/`expired`, each an exact `status=`) PLUS a
+synthetic `stage=live` token that widens to `[open, collecting]`. The workspace "Open" glance
+card counts open+collecting (a list flips open→collecting on its first offer but is still
+live), so it links to `stage=live` to match its count; the strict `open` pill in `_lists.html`
+keeps meaning EXACTLY `status=open`.
 
 **RS-4 reply tracking (inbound half).** The send path already stamps
 `ExcessOutreach.graph_conversation_id`/`graph_message_id` (migration 133); RS-4 wires the

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2098,10 +2098,13 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |        |     title/notes/company_id[re-validates exists]/customer_site_id; re-renders detail)
     |        +-- DELETE /api/resell/{id}                   (excess_service.delete_excess_list; cascade
     |        |     cleans children → refreshes My-Lists [#resell-list-body] + OOB detail-pane reset
-    |        |     [#split-right-resell] + toast)
+    |        |     [#split-right-resell] + toast + HX-Push-Url /v2/resell so a reload no longer
+    |        |     reopens the deleted list id [finding #8])
     |        +-- GET .../{id}/edit-form, .../{id}/lines/{line_id}/edit-form (pre-filled modals)
-    |     [Honest 409 copy (×3): "Posted lists are locked. Close this list and create a new one
-    |      to make changes." replaces the false "revise as a new version".]
+    |     [All four mutating routes call _get_list_for_user FIRST so a NON-owner probing a private
+    |      draft gets 404 [existence masked], not the service's 403 — matches the GET edit-form
+    |      path [finding #3]. Honest 409 copy (×3): "Posted lists are locked. Close this list and
+    |      create a new one to make changes." replaces the false "revise as a new version".]
     +-- POST /api/resell/{id}/import-preview|import-confirm  (reuse excess parsers + preview grid;
     |     preview ALWAYS renders a re-upload/back affordance even for an all-errors file — RS-6;
     |     confirm re-renders the whole detail like add-line — RS-5)
@@ -2111,7 +2114,8 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |     per_line|take_all; service enforces can_offer + the self-offer guard)
     +-- POST /api/resell/{id}/offers/{offer_id}/award   (owner-only; excess_service.award_offer:
     |     the single offer→won chokepoint; take_all awards ALL non-withdrawn lines, per_line
-    |     awards its matched lines; idempotent for an already-won offer; 409 unless the offer
+    |     awards its matched lines; idempotent for an already-won offer; 409 on a TERMINAL list
+    |     [closed/expired — awarding would reopen the dead list, finding #4]; 409 unless the offer
     |     is open/late [a lost/withdrawn offer is not awardable — guard runs BEFORE line scope];
     |     409 if a line is already awarded to another offer; recomputes rollups + buyer-score win-hook;
     |     retires the sold lines from the Sighting mirror (sync_list_mirror); derives the
@@ -2129,7 +2133,9 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |     excess_service.assign_offer_line: manual resolution of the unmatched queue — point a
     |     parked ExcessOfferLine at a posted line [404 target/offer-line off this list], flips
     |     match_status→matched + recomputes the target [+ old line on a re-assign] rollup so the
-    |     salvaged bid is awardable. Same _award_response OOB compose as award)
+    |     salvaged bid is awardable. GUARDED: 409 on a resolved/terminal list [awarded/closed/
+    |     expired] and 409 unless the parent offer is open/late [finding #2 + the finding #4
+    |     "second vector"]. Same _award_response OOB compose as award)
     +-- GET  /v2/partials/resell/{id}/build-bid          (owner-only Build-Bid tab: each line's
     |     best-offer planning price + editable "our offer"; once assembled, the clean
     |     bid_back_export_context summary + Download-PDF + the lifecycle action bar. Context
@@ -2171,9 +2177,12 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
           +-- POST .../{oid}/log-response  (resell_outreach_service.record_manual_response →
           |     responded; never regresses a terminal bid/declined; 409 for an email row)
           +-- GET  .../{oid}/log-bid-form  (reuses _reply_viewer.html — manual flag + convert_url
-          |     — as the Log-bid modal)
+          |     — as the Log-bid modal; honest 'Bid logged' toast, not 'Offer created from reply')
           +-- POST .../{oid}/log-bid       (record_manual_response(has_offer=True) → bid + an
-                ExcessOffer via the SAME _link_inbound_offer path an emailed bid uses)
+                ExcessOffer via the SAME _link_inbound_offer path an emailed bid uses; 400 unless
+                the qty is positive [finding #1]; _link_inbound_offer is GATED on the same terminal
+                check as the status advance, so a replayed Log-bid on an already-bid/declined row is
+                an idempotent no-op — no duplicate offer [finding #5/#9/#10])
 ```
 
 **Triage filters (finding #16).** The left-list `stage` filter takes the usual status values

--- a/docs/superpowers/plans/2026-07-18-resell-phase4-workflow-completion.md
+++ b/docs/superpowers/plans/2026-07-18-resell-phase4-workflow-completion.md
@@ -1,0 +1,89 @@
+# Resell Rework — Phase 4: Workflow Completion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Close the module's workflow dead-ends so it's a usable two-sided marketplace — give brokers a way to see/withdraw their own offers, give owners draft-editing + a true "close without bidding" + unmatched-line assignment + manual-channel logging, and fix the `stage=live` triage token. All 6 controls were **user-approved** (2026-07-18). **No migration** (all use existing schema/enum).
+
+**Architecture:** New routes are thin (`app/routers/resell.py`); logic in `app/services/`. Reuse the established patterns: the Withdraw button, the convert-to-offer form (`_reply_viewer.html`), the award `_offer_action` macro, and the filter-token mechanism. Gate every owner action with `_require_owner`; keep the `can_see_customer` anonymization discipline from Phase 3 (never leak competitor data into the broker own-offers view).
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 (2.0-style only — ratchet is down-only), HTMX/Alpine/Jinja2, pytest.
+
+## Global Constraints
+- Status/enum values ALWAYS from `app/constants.py`. `CLOSED = "closed"` already exists (Phase 1 kept it distinct, D5) — Task 3 gives it its first writer.
+- No new UI *conventions* — reuse existing controls/macros (approved set only; do not add unapproved elements).
+- Every new mutating route: `_get_list_for_user` (404) + `_require_owner` (403) where owner-only, draft/status guards as noted, 2.0-style DB access, `HTTPException` on guard failure.
+- After changes, update `docs/APP_MAP_INTERACTIONS.md` (the new workflows).
+- Re-verify every line number against the CURRENT worktree (Phases 1–3 moved things); work by symbol.
+
+---
+
+### Task 1: Broker own-offers view + Withdraw (finding #13)
+
+**Files:** `app/routers/resell.py` (`_offers_context` non-owner branch ~473-482; `resell_submit_offer` re-render ~1138; `_get_list_for_user` ~244 expired-access); `app/templates/htmx/partials/resell/_offers.html` (~57-65 non-owner branch); Test `tests/test_resell_offers.py` + `tests/test_resell_draft_offer_privacy.py`.
+
+**Interfaces:** Produces: a non-owner viewing a posted list's Offers tab sees ONLY their own offers (`submitted_by == user.id`, via 2.0 select) — no competitor data (keep `_broker_label`/anonymization) — each open/late own-offer with a **Withdraw** button (the withdraw route + submitter-authz already exist at ~1197-1227). The submitter can reach their own open offer even after the list expires (relax `_get_list_for_user` so a submitter with an offer isn't 404'd on a non-posted status). Post-submit re-render shows the submitter their own offers (not the empty state).
+
+- [ ] Failing tests: non-owner Offers tab shows their own offer + Withdraw, and shows NO other broker's offer/count; submitter can withdraw after expiry; owner view unchanged. → red → implement (hydrate own-offers in `_offers_context` for non-owner; render in `_offers.html`; relax expired access for a submitter-with-offer) → green → commit.
+
+---
+
+### Task 2: Draft-edit set + honest 409 copy (finding #14, decision D4)
+
+**Files:** `app/routers/resell.py` (4 NEW routes); `app/services/excess_service.py` (4 NEW functions); `_lines.html`, `detail.html` header, `_header_chips.html`; replace false copy at resell.py ~886/959/1036; Test `tests/test_resell_routes.py` + a new `tests/test_resell_draft_edit.py`.
+
+**Interfaces (all DRAFT-only, `_require_owner` + 409-unless-draft; a draft has no offers/mirror so these are side-effect-free except `total_line_items`):**
+- `DELETE /api/resell/{list_id}/lines/{line_id}` → `excess_service.delete_line` (delete + decrement `total_line_items`) → re-render `detail.html`.
+- `PATCH /api/resell/{list_id}/lines/{line_id}` → `excess_service.update_line` (fields part_number/quantity/manufacturer/condition/date_code/asking_price; **re-validate quantity>0** — the model `@validates` raises else 500; re-resolve material card if MPN/mfr changed) → re-render.
+- `PATCH /api/resell/{list_id}` → `excess_service.update_excess_list` (title/notes/company_id[+re-validate exists]/customer_site_id) → re-render `detail.html`.
+- `DELETE /api/resell/{list_id}` → `excess_service.delete_excess_list` (draft-only; cascade cleans children) → return My-Lists partial + detail-pane reset + toast.
+- **Honest 409 copy:** replace `"Posted lists are locked; revise as a new version"` (×3) with `"Posted lists are locked. Close this list and create a new one to make changes."`
+
+- [ ] Per-route TDD: failing test (guard rejections: non-owner 403, non-draft 409, cross-list line 404, quantity=0 rejected; happy path mutates + re-renders) → red → implement service+route+template affordance → green → commit (may group the 4 into 1–2 commits given shared files).
+
+---
+
+### Task 3: "Close without bidding" → CLOSED terminal state (decision D5)
+
+**Files:** `app/services/excess_service.py` (`close_list` gains a mode, or new `resolve_list_without_bid`); `app/routers/resell.py` (new/extended close route); `detail.html` header (~64-73, a second action alongside Close); `workspace.html` (~66 bid_out subtitle); `_lists.html`/`_header_chips.html` (CLOSED pill already styled); Test `tests/test_resell_list_lifecycle.py`.
+
+**Interfaces:** Produces: an owner action "Close without bidding" that flips `open`/`collecting` → **CLOSED** (guarded exactly like `close_list`: 409 unless open/collecting; stamps `close_at`; retires the mirror via `sync_list_mirror`); CLOSED is terminal (no reopen, no bid-out-from-closed — mirror Phase-1's terminal reader-set treatment). Keep the existing Close→`bid_out` path for "bids went out." Fix the `bid_out` "Sent to the customer" subtitle to be accurate.
+
+- [ ] Failing tests: close-without-bid on open/collecting → CLOSED + close_at + mirror retired; 409 on draft/terminal; CLOSED excluded from expiry/reopen. → red → implement → green → commit. **UI copy/affordance: mirror the existing Close button's confirm pattern; distinct label "Close (no bid)".**
+
+---
+
+### Task 4: "Assign to line" — unmatched-offer resolution (finding #15)
+
+**Files:** `app/services/excess_service.py` (NEW `assign_offer_line`); `app/routers/resell.py` (NEW owner-only POST); `_offers.html` (~180-199 unmatched queue — the read-only "resolve manually" card gains an assign control mirroring the `_offer_action` macro); Test `tests/test_resell_award.py` pattern + new cases.
+
+**Interfaces:** Produces: an owner assigns an unmatched/ambiguous `ExcessOfferLine` to a target posted `ExcessLineItem` — sets `excess_line_item_id`, flips `match_status` → MATCHED, recomputes the target line's rollup (`recompute_line_rollup`). Reject a target line not on this list (404). Now the salvaged offer is awardable.
+
+- [ ] Failing tests: assign unmatched→matched updates target rollup; cross-list target 404; non-owner 403; re-assign moves it (recompute both old+new). → red → implement → green → commit.
+
+---
+
+### Task 5: Manual-channel "Log response / Log their bid" + checkbox fix (finding #12)
+
+**Files:** `app/routers/resell.py` (NEW owner-only log routes keyed by outreach_id, reuse the convert-to-offer line form); `app/services/resell_outreach_service.py` (record manual RESPONSE/BID on the outreach row, create the ExcessOffer via the existing convert path); `_outreach.html` (manual-channel rows gain Log-response/Log-bid actions); `offer_buyers_modal.html` (~120-127 — enable the no-contact checkbox on phone/teams/marketplace channels); Test `tests/test_resell_outreach_*.py`.
+
+**Interfaces:** Produces: for a manual-channel (`phone`/`teams`/`marketplace`, no `graph_conversation_id`) outreach row stuck at `sent`, the owner can Log a response (→ RESPONDED) or Log their bid (→ BID + create the ExcessOffer via the reused `_reply_viewer.html` convert form). The no-contact checkbox is enabled for manual channels (email-only disable stays).
+
+- [ ] Failing tests: log-response flips status; log-bid creates the offer + flips BID; non-owner 403; checkbox enabled for manual channel. → red → implement → green → commit.
+
+---
+
+### Task 6: `stage=live` triage token (finding #16)
+
+**Files:** `app/routers/resell.py` (`resell_lists` stage filter ~376-377 — add a `live` token → `status in (open, collecting)`); `workspace.html` (~63 glance card: `stage=live` + truthful subtitle); Test `tests/test_nightly_resell_coverage.py` (the stage-filter tests strengthened in Phase 3).
+
+**Interfaces:** Produces: `stage=live` expands to `[open, collecting]`; the "Open" triage card links to `stage=live` (matching its open+collecting count) with an accurate subtitle. The strict `open` pill in `_lists.html` keeps meaning exactly `status=open` (do NOT overload it).
+
+- [ ] Failing tests: `?stage=live` includes both an open and a collecting list, excludes bid_out/awarded; the strict `?stage=open` still returns only open. → red → implement → green → commit. Update `docs/APP_MAP_INTERACTIONS.md`. Open PR; adversarial review workflow; live-verify.
+
+---
+
+## Self-Review
+- **Coverage:** #13 (T1), #14+D4 (T2), D5-CLOSE (T3), #15 (T4), #12 (T5), #16 (T6). ✓
+- **No migration** (existing schema/enum). ✓
+- **Anonymization preserved:** T1 own-offers view carries no competitor data (Phase-3 discipline). ✓
+- **Reuse over invent:** Withdraw button, convert-to-offer form, `_offer_action` macro, filter-token — only assign-to-line + inline-edit are net-new interactions. ✓

--- a/tests/test_nightly_resell_coverage.py
+++ b/tests/test_nightly_resell_coverage.py
@@ -333,6 +333,42 @@ class TestResellListFiltering:
         assert "Collecting-Widget-List" in body  # matching stage included
         assert "Awarded-Gizmo-List" not in body  # non-matching stage excluded
 
+    def test_stage_live_includes_open_and_collecting_only(self, _trader_client, db_session: Session, test_company):
+        """Task 6 (finding #16): ``stage=live`` expands to [open, collecting] — matching
+        the "Open" glance card's count — and excludes resolved (bid_out/awarded)
+        lists."""
+        client, trader = _trader_client
+        _titled_list(db_session, trader, test_company, "Live-Open-List", ExcessListStatus.OPEN)
+        _titled_list(db_session, trader, test_company, "Live-Collecting-List", ExcessListStatus.COLLECTING)
+        _titled_list(db_session, trader, test_company, "Live-BidOut-List", ExcessListStatus.BID_OUT)
+        _titled_list(db_session, trader, test_company, "Live-Awarded-List", ExcessListStatus.AWARDED)
+        db_session.commit()
+
+        body = client.get("/v2/partials/resell/lists?stage=live&lens=mine").text
+        assert "Live-Open-List" in body  # open is live
+        assert "Live-Collecting-List" in body  # collecting is live
+        assert "Live-BidOut-List" not in body  # resolved — excluded
+        assert "Live-Awarded-List" not in body  # resolved — excluded
+
+    def test_stage_open_stays_strict(self, _trader_client, db_session: Session, test_company: Company):
+        """The strict ``stage=open`` pill still means EXACTLY status=open — collecting
+        is NOT overloaded into it (only the ``live`` token widens to both)."""
+        client, trader = _trader_client
+        _titled_list(db_session, trader, test_company, "Strict-Open-List", ExcessListStatus.OPEN)
+        _titled_list(db_session, trader, test_company, "Strict-Collecting-List", ExcessListStatus.COLLECTING)
+        db_session.commit()
+
+        body = client.get("/v2/partials/resell/lists?stage=open&lens=mine").text
+        assert "Strict-Open-List" in body
+        assert "Strict-Collecting-List" not in body  # collecting is NOT status=open
+
+    def test_workspace_open_card_links_to_stage_live(self, _trader_client, db_session: Session):
+        """The "Open" glance card links to stage=live (matching its open+collecting
+        count), not the strict stage=open it mismatched before."""
+        client, _trader = _trader_client
+        body = client.get("/v2/partials/resell/workspace?lens=mine").text
+        assert "lens=mine&stage=live" in body
+
     def test_lists_q_filter(self, _trader_client, db_session: Session, test_company: Company):
         """Q matches the title in the mine lens — matching title included, non-matching
         excluded (proves the search actually filters, not just returns 200)."""

--- a/tests/test_resell_award.py
+++ b/tests/test_resell_award.py
@@ -1102,3 +1102,227 @@ class TestWithdrawOfferServiceGuard:
         excess_service.withdraw_offer(db_session, offer.id)
 
         assert calls == [(offer.id, excess_list.id)]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  assign_offer_line (Task 4 / finding #15) — salvage an unmatched offer line
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _unmatched_offer_line(
+    db: Session, *, excess_list: ExcessList, submitter: User, mpn_raw: str, unit_price: Decimal
+) -> ExcessOfferLine:
+    """An OPEN per-line offer carrying ONE unmatched line (excess_line_item_id=None)."""
+    offer = ExcessOffer(
+        excess_list_id=excess_list.id,
+        submitted_by=submitter.id,
+        scope="per_line",
+        status=ExcessOfferStatus.OPEN,
+    )
+    db.add(offer)
+    db.flush()
+    line = ExcessOfferLine(
+        offer_id=offer.id,
+        excess_line_item_id=None,
+        mpn_raw=mpn_raw,
+        quantity=50,
+        unit_price=unit_price,
+        match_status=OfferLineMatchStatus.UNMATCHED,
+    )
+    db.add(line)
+    db.flush()
+    return line
+
+
+class TestAssignOfferLineService:
+    def test_assign_matches_and_rolls_up_target(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """Assigning an unmatched line to a target line flips it MATCHED, links it, and
+        recomputes the target's best-price rollup (the salvaged bid now owns the
+        line)."""
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO-GRM188", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+        assert cap_line.best_offer_id is None  # nothing on the target yet
+
+        result = excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, cap_line.id, owner)
+
+        assert result.match_status == OfferLineMatchStatus.MATCHED
+        assert result.excess_line_item_id == cap_line.id
+        db_session.refresh(cap_line)
+        assert cap_line.best_offer_id == offer_line.offer_id
+        assert cap_line.best_offer_unit_price == Decimal("0.95")
+
+    def test_assigned_offer_becomes_awardable(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """The salvaged offer is now a real matched bid → the owner can award it."""
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO-GRM188", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+        excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, cap_line.id, owner)
+
+        awarded = excess_service.award_offer(db_session, offer_line.offer_id, owner)
+        assert awarded.status == ExcessOfferStatus.WON
+        db_session.refresh(cap_line)
+        assert cap_line.status == ExcessLineItemStatus.AWARDED
+
+    def test_target_line_on_other_list_404(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        cap_line: ExcessLineItem,
+        owner: User,
+        broker: User,
+        seller_company: Company,
+    ):
+        """A target line that belongs to a DIFFERENT list is rejected — 404."""
+        other_list = ExcessList(company_id=seller_company.id, owner_id=owner.id, title="Other")
+        db_session.add(other_list)
+        db_session.flush()
+        stray = _line(db_session, other_list, "STRAY-PART")
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, stray.id, owner)
+        assert exc.value.status_code == 404
+        db_session.refresh(offer_line)
+        assert offer_line.match_status == OfferLineMatchStatus.UNMATCHED  # untouched
+
+    def test_offer_line_on_other_list_404(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        cap_line: ExcessLineItem,
+        owner: User,
+        broker: User,
+        seller_company: Company,
+    ):
+        """An offer line whose offer is on a DIFFERENT list is not assignable here —
+        404."""
+        other_list = ExcessList(company_id=seller_company.id, owner_id=owner.id, title="Other")
+        db_session.add(other_list)
+        db_session.flush()
+        stray_line = _unmatched_offer_line(
+            db_session, excess_list=other_list, submitter=broker, mpn_raw="TYPO", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.assign_offer_line(db_session, excess_list.id, stray_line.id, cap_line.id, owner)
+        assert exc.value.status_code == 404
+
+    def test_non_owner_403(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        cap_line: ExcessLineItem,
+        owner: User,
+        broker: User,
+        outsider: User,
+    ):
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, cap_line.id, outsider)
+        assert exc.value.status_code == 403
+
+    def test_reassign_moves_and_recomputes_both_lines(
+        self, db_session: Session, excess_list: ExcessList, owner: User, broker: User
+    ):
+        """Re-assigning to a different line recomputes BOTH the old and the new target
+        (the old loses the bid, the new gains it)."""
+        a = _line(db_session, excess_list, "REASSIGN-A")
+        b = _line(db_session, excess_list, "REASSIGN-B")
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO", unit_price=Decimal("1.10")
+        )
+        db_session.commit()
+
+        excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, a.id, owner)
+        db_session.refresh(a)
+        assert a.best_offer_id == offer_line.offer_id  # A owns it after the first assign
+
+        excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, b.id, owner)
+
+        db_session.refresh(a)
+        db_session.refresh(b)
+        assert a.best_offer_id is None  # A recomputed — the bid moved away
+        assert a.offer_count == 0
+        assert b.best_offer_id == offer_line.offer_id  # B now owns it
+        assert b.best_offer_unit_price == Decimal("1.10")
+
+
+class TestAssignOfferLineRoute:
+    def test_assign_route_200_and_salvages(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        from app.dependencies import require_user
+        from app.main import app
+
+        excess_list.status = ExcessListStatus.COLLECTING
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO-GRM188", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+
+        app.dependency_overrides[require_user] = lambda: owner
+        try:
+            resp = client.post(
+                f"/api/resell/{excess_list.id}/offer-lines/{offer_line.id}/assign",
+                data={"target_line_item_id": str(cap_line.id)},
+            )
+        finally:
+            app.dependency_overrides.pop(require_user, None)
+
+        assert resp.status_code == 200
+        db_session.refresh(offer_line)
+        assert offer_line.match_status == OfferLineMatchStatus.MATCHED
+        assert offer_line.excess_line_item_id == cap_line.id
+
+    def test_assign_route_non_owner_403(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, broker: User
+    ):
+        """The default client user is not the owner → 403 (the line stays unmatched)."""
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+        resp = client.post(
+            f"/api/resell/{excess_list.id}/offer-lines/{offer_line.id}/assign",
+            data={"target_line_item_id": str(cap_line.id)},
+        )
+        assert resp.status_code == 403
+        db_session.refresh(offer_line)
+        assert offer_line.match_status == OfferLineMatchStatus.UNMATCHED
+
+    def test_offers_tab_renders_assign_control_for_unmatched(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """The unmatched queue surfaces an assign form pointed at the offer line + a
+        target option for the posted line (the manual-resolution affordance)."""
+        from app.dependencies import require_user
+        from app.main import app
+
+        excess_list.status = ExcessListStatus.COLLECTING
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO-GRM188", unit_price=Decimal("0.95")
+        )
+        db_session.commit()
+
+        app.dependency_overrides[require_user] = lambda: owner
+        try:
+            body = client.get(f"/v2/partials/resell/{excess_list.id}/offers").text
+        finally:
+            app.dependency_overrides.pop(require_user, None)
+
+        assert f"/offer-lines/{offer_line.id}/assign" in body
+        assert f'value="{cap_line.id}"' in body  # the posted line is an assign target

--- a/tests/test_resell_award.py
+++ b/tests/test_resell_award.py
@@ -294,6 +294,38 @@ class TestAwardOfferService:
             excess_service.award_offer(db_session, 999_999, owner)
         assert exc.value.status_code == 404
 
+    @pytest.mark.parametrize("terminal_status", [ExcessListStatus.CLOSED, ExcessListStatus.EXPIRED])
+    def test_award_on_terminal_list_409_no_reopen(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        cap_line: ExcessLineItem,
+        owner: User,
+        broker: User,
+        terminal_status,
+    ):
+        """A CLOSED (D5 'close without bid') or EXPIRED list is terminal — awarding a
+        still-open offer on it must 409, never flip it to AWARDED (finding #4).
+
+        Without the guard, award reopens the dead list to AWARDED and a subsequent
+        unaward steps it to BID_OUT — exactly the reopen the D5 contract forbids.
+        """
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        excess_list.status = terminal_status
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.award_offer(db_session, offer.id, owner)
+        assert exc.value.status_code == 409
+        db_session.refresh(offer)
+        db_session.refresh(excess_list)
+        assert offer.status == ExcessOfferStatus.OPEN  # not flipped to won
+        assert excess_list.status == terminal_status  # stayed terminal — no reopen
+        db_session.refresh(cap_line)
+        assert cap_line.status == ExcessLineItemStatus.AVAILABLE
+
     def test_award_take_all_marks_all_lines(
         self, db_session: Session, excess_list: ExcessList, owner: User, broker: User
     ):
@@ -1259,6 +1291,57 @@ class TestAssignOfferLineService:
         assert a.offer_count == 0
         assert b.best_offer_id == offer_line.offer_id  # B now owns it
         assert b.best_offer_unit_price == Decimal("1.10")
+
+    @pytest.mark.parametrize(
+        "blocked_status",
+        [ExcessListStatus.AWARDED, ExcessListStatus.CLOSED, ExcessListStatus.EXPIRED],
+    )
+    def test_assign_on_resolved_list_409(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        cap_line: ExcessLineItem,
+        owner: User,
+        broker: User,
+        blocked_status,
+    ):
+        """Assign is unmatched-queue resolution — a resolved/terminal list (awarded,
+        closed, expired) must reject it (finding #2), closing the 'second vector' to a
+        reopen (finding #4).
+
+        The line stays unmatched.
+        """
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO", unit_price=Decimal("0.95")
+        )
+        excess_list.status = blocked_status
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, cap_line.id, owner)
+        assert exc.value.status_code == 409
+        db_session.refresh(offer_line)
+        assert offer_line.match_status == OfferLineMatchStatus.UNMATCHED  # untouched
+
+    def test_assign_won_offer_line_409(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """A line whose parent offer is WON (awarded) can't be reassigned — that would
+        strand the award's line linkage (finding #2).
+
+        Only an open/late offer's line is assignable.
+        """
+        offer_line = _unmatched_offer_line(
+            db_session, excess_list=excess_list, submitter=broker, mpn_raw="TYPO", unit_price=Decimal("0.95")
+        )
+        db_session.get(ExcessOffer, offer_line.offer_id).status = ExcessOfferStatus.WON
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.assign_offer_line(db_session, excess_list.id, offer_line.id, cap_line.id, owner)
+        assert exc.value.status_code == 409
+        db_session.refresh(offer_line)
+        assert offer_line.match_status == OfferLineMatchStatus.UNMATCHED  # untouched
 
 
 class TestAssignOfferLineRoute:

--- a/tests/test_resell_draft_edit.py
+++ b/tests/test_resell_draft_edit.py
@@ -1,0 +1,384 @@
+"""test_resell_draft_edit.py — the draft-edit set (Phase 4 Task 2, finding #14 / D4).
+
+Before a list is posted it is a private working draft; the owner must be able to correct
+it in place — edit/delete a line, edit the list header, or delete the whole draft — instead
+of the module's old dead-end (post-then-locked with no undo). All four mutations are
+DRAFT-ONLY and owner-only (409 once posted, 403 for a non-owner, 404 across lists), and a
+draft carries no offers/mirror so they are side-effect-free except ``total_line_items``.
+
+Covers the four services (delete_line / update_line / update_excess_list /
+delete_excess_list), their routes, the re-validated ``quantity > 0`` on the edit path
+(the model ``@validates`` would 500 otherwise), and the honest 409 copy.
+
+Called by: pytest
+Depends on: app.services.excess_service, app.routers.resell, tests.conftest
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.constants import ExcessListStatus
+from app.models import Company, User
+from app.models.excess import ExcessLineItem, ExcessList
+from app.models.intelligence import MaterialCard
+from app.services import excess_service
+from app.services.excess_service import create_excess_list, import_line_items
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owner(db_session: Session) -> User:
+    u = User(email="de-owner@trioscs.com", name="Del Owner", role="trader", azure_id="de-owner-1")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def outsider(db_session: Session) -> User:
+    u = User(email="de-out@trioscs.com", name="Ora Outsider", role="trader", azure_id="de-out-1")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def company(db_session: Session) -> Company:
+    co = Company(name="Draft-Edit Seller Co")
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+def _draft_with_lines(db: Session, owner: User, company: Company, parts=("LM358N", "MAX232")) -> ExcessList:
+    el = create_excess_list(db, title="Draft to edit", company_id=company.id, owner_id=owner.id)
+    import_line_items(db, el.id, [{"part_number": p, "quantity": "100"} for p in parts])
+    db.refresh(el)
+    return el
+
+
+def _lines(db: Session, el: ExcessList) -> list[ExcessLineItem]:
+    return db.query(ExcessLineItem).filter_by(excess_list_id=el.id).order_by(ExcessLineItem.id).all()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  delete_line
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDeleteLine:
+    def test_deletes_line_and_decrements_counter(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        assert el.total_line_items == 2
+        line = _lines(db_session, el)[0]
+
+        excess_service.delete_line(db_session, el.id, line.id, owner)
+
+        remaining = _lines(db_session, el)
+        assert len(remaining) == 1
+        assert line.id not in {li.id for li in remaining}
+        db_session.refresh(el)
+        assert el.total_line_items == 1
+
+    def test_non_owner_403(self, db_session, owner, outsider, company):
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        with pytest.raises(HTTPException) as exc:
+            excess_service.delete_line(db_session, el.id, line.id, outsider)
+        assert exc.value.status_code == 403
+        assert len(_lines(db_session, el)) == 2  # untouched
+
+    def test_posted_list_409(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        el.status = ExcessListStatus.COLLECTING
+        db_session.commit()
+        line = _lines(db_session, el)[0]
+        with pytest.raises(HTTPException) as exc:
+            excess_service.delete_line(db_session, el.id, line.id, owner)
+        assert exc.value.status_code == 409
+        assert len(_lines(db_session, el)) == 2
+
+    def test_cross_list_line_404(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        other = _draft_with_lines(db_session, owner, company, parts=("NE555P",))
+        stray = _lines(db_session, other)[0]
+        with pytest.raises(HTTPException) as exc:
+            excess_service.delete_line(db_session, el.id, stray.id, owner)
+        assert exc.value.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  update_line
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestUpdateLine:
+    def test_updates_fields(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+
+        excess_service.update_line(
+            db_session,
+            el.id,
+            line.id,
+            owner,
+            part_number="LM358N",
+            quantity=250,
+            manufacturer="Texas Instruments",
+            condition="Used",
+            date_code="2024+",
+            asking_price=Decimal("1.75"),
+        )
+
+        db_session.refresh(line)
+        assert line.quantity == 250
+        assert line.manufacturer == "Texas Instruments"
+        assert line.condition == "Used"
+        assert line.date_code == "2024+"
+        assert line.asking_price == Decimal("1.75")
+
+    def test_zero_quantity_rejected_400_not_500(self, db_session, owner, company):
+        """Re-validate quantity > 0 in the service — the model @validates would 500."""
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        with pytest.raises(HTTPException) as exc:
+            excess_service.update_line(db_session, el.id, line.id, owner, part_number="LM358N", quantity=0)
+        assert exc.value.status_code == 400
+        db_session.refresh(line)
+        assert line.quantity == 100  # unchanged
+
+    def test_mpn_change_reresolves_material_card(self, db_session, owner, company):
+        """Editing the part number re-resolves the MaterialCard link (drops the stale
+        one)."""
+        # Seed the real target card so the new MPN resolves to a concrete row.
+        db_session.add(MaterialCard(normalized_mpn="max232", display_mpn="MAX232"))
+        db_session.commit()
+        el = _draft_with_lines(db_session, owner, company, parts=("LM358N",))
+        line = _lines(db_session, el)[0]
+        original_card_id = line.material_card_id
+
+        excess_service.update_line(db_session, el.id, line.id, owner, part_number="MAX232", quantity=100)
+
+        db_session.refresh(line)
+        assert line.part_number == "MAX232"
+        assert line.material_card_id != original_card_id
+        card = db_session.get(MaterialCard, line.material_card_id)
+        assert card is not None and card.normalized_mpn == "max232"
+
+    def test_non_owner_403(self, db_session, owner, outsider, company):
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        with pytest.raises(HTTPException) as exc:
+            excess_service.update_line(db_session, el.id, line.id, outsider, part_number="LM358N", quantity=5)
+        assert exc.value.status_code == 403
+
+    def test_posted_list_409(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        el.status = ExcessListStatus.COLLECTING
+        db_session.commit()
+        line = _lines(db_session, el)[0]
+        with pytest.raises(HTTPException) as exc:
+            excess_service.update_line(db_session, el.id, line.id, owner, part_number="LM358N", quantity=5)
+        assert exc.value.status_code == 409
+
+    def test_cross_list_line_404(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        other = _draft_with_lines(db_session, owner, company, parts=("NE555P",))
+        stray = _lines(db_session, other)[0]
+        with pytest.raises(HTTPException) as exc:
+            excess_service.update_line(db_session, el.id, stray.id, owner, part_number="X", quantity=5)
+        assert exc.value.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  update_excess_list
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestUpdateExcessList:
+    def test_updates_title_notes_company(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        other_co = Company(name="Reassigned Customer")
+        db_session.add(other_co)
+        db_session.commit()
+
+        excess_service.update_excess_list(
+            db_session, el.id, owner, title="Renamed draft", notes="new notes", company_id=other_co.id
+        )
+
+        db_session.refresh(el)
+        assert el.title == "Renamed draft"
+        assert el.notes == "new notes"
+        assert el.company_id == other_co.id
+
+    def test_bad_company_404(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        with pytest.raises(HTTPException) as exc:
+            excess_service.update_excess_list(db_session, el.id, owner, title="X", notes=None, company_id=999999)
+        assert exc.value.status_code == 404
+        db_session.refresh(el)
+        assert el.company_id == company.id  # unchanged
+
+    def test_non_owner_403(self, db_session, owner, outsider, company):
+        el = _draft_with_lines(db_session, owner, company)
+        with pytest.raises(HTTPException) as exc:
+            excess_service.update_excess_list(db_session, el.id, outsider, title="X", notes=None, company_id=company.id)
+        assert exc.value.status_code == 403
+
+    def test_posted_list_409(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        el.status = ExcessListStatus.COLLECTING
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            excess_service.update_excess_list(db_session, el.id, owner, title="X", notes=None, company_id=company.id)
+        assert exc.value.status_code == 409
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  delete_excess_list
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDeleteExcessList:
+    def test_deletes_list_and_cascades_lines(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        list_id = el.id
+
+        excess_service.delete_excess_list(db_session, list_id, owner)
+
+        assert db_session.get(ExcessList, list_id) is None
+        assert db_session.query(ExcessLineItem).filter_by(excess_list_id=list_id).count() == 0
+
+    def test_non_owner_403(self, db_session, owner, outsider, company):
+        el = _draft_with_lines(db_session, owner, company)
+        with pytest.raises(HTTPException) as exc:
+            excess_service.delete_excess_list(db_session, el.id, outsider)
+        assert exc.value.status_code == 403
+        assert db_session.get(ExcessList, el.id) is not None
+
+    def test_posted_list_409(self, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        el.status = ExcessListStatus.COLLECTING
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            excess_service.delete_excess_list(db_session, el.id, owner)
+        assert exc.value.status_code == 409
+        assert db_session.get(ExcessList, el.id) is not None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Routes (thin — HTTP wiring over the guarded services)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _as_owner(client, owner: User):
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: owner
+    return lambda: client.app.dependency_overrides.pop(require_user, None)
+
+
+class TestDraftEditRoutes:
+    def test_delete_line_route_200_and_rerenders_detail(self, client, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        restore = _as_owner(client, owner)
+        try:
+            resp = client.delete(f"/api/resell/{el.id}/lines/{line.id}")
+        finally:
+            restore()
+        assert resp.status_code == 200
+        assert "data-resell-detail-root" in resp.text  # the detail panel re-rendered
+        assert db_session.get(ExcessLineItem, line.id) is None
+
+    def test_update_line_route_200(self, client, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        restore = _as_owner(client, owner)
+        try:
+            resp = client.patch(
+                f"/api/resell/{el.id}/lines/{line.id}",
+                data={"part_number": "LM358N", "quantity": "500", "condition": "New"},
+            )
+        finally:
+            restore()
+        assert resp.status_code == 200
+        db_session.refresh(line)
+        assert line.quantity == 500
+
+    def test_update_line_route_zero_quantity_400(self, client, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        restore = _as_owner(client, owner)
+        try:
+            resp = client.patch(
+                f"/api/resell/{el.id}/lines/{line.id}",
+                data={"part_number": "LM358N", "quantity": "0"},
+            )
+        finally:
+            restore()
+        assert resp.status_code == 400
+
+    def test_update_list_route_200(self, client, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        restore = _as_owner(client, owner)
+        try:
+            resp = client.patch(
+                f"/api/resell/{el.id}",
+                data={"title": "Edited title", "company_id": str(company.id), "notes": "n"},
+            )
+        finally:
+            restore()
+        assert resp.status_code == 200
+        db_session.refresh(el)
+        assert el.title == "Edited title"
+
+    def test_delete_list_route_200_refreshes_left_and_toasts(self, client, db_session, owner, company):
+        el = _draft_with_lines(db_session, owner, company)
+        list_id = el.id
+        restore = _as_owner(client, owner)
+        try:
+            resp = client.delete(f"/api/resell/{list_id}")
+        finally:
+            restore()
+        assert resp.status_code == 200
+        assert db_session.get(ExcessList, list_id) is None
+        # The response resets the detail pane (OOB) and fires a toast.
+        assert 'id="split-right-resell"' in resp.text
+        assert "showToast" in resp.headers.get("HX-Trigger", "")
+
+    def test_non_owner_delete_line_403(self, client, db_session, owner, company):
+        """The default client user (a buyer, not the owner) cannot delete a draft
+        line."""
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        resp = client.delete(f"/api/resell/{el.id}/lines/{line.id}")
+        assert resp.status_code == 403
+        assert db_session.get(ExcessLineItem, line.id) is not None
+
+
+class TestHonest409Copy:
+    def test_add_line_on_posted_uses_honest_copy(self, client, db_session, owner, company):
+        """The false "revise as a new version" copy is replaced with actionable
+        guidance."""
+        el = _draft_with_lines(db_session, owner, company)
+        el.status = ExcessListStatus.COLLECTING
+        db_session.commit()
+        restore = _as_owner(client, owner)
+        try:
+            resp = client.post(f"/api/resell/{el.id}/lines", data={"part_number": "X", "quantity": "1"})
+        finally:
+            restore()
+        assert resp.status_code == 409
+        detail = resp.json()["error"]
+        assert "revise as a new version" not in detail
+        assert "Close this list and create a new one" in detail

--- a/tests/test_resell_draft_edit.py
+++ b/tests/test_resell_draft_edit.py
@@ -356,14 +356,61 @@ class TestDraftEditRoutes:
         assert 'id="split-right-resell"' in resp.text
         assert "showToast" in resp.headers.get("HX-Trigger", "")
 
-    def test_non_owner_delete_line_403(self, client, db_session, owner, company):
-        """The default client user (a buyer, not the owner) cannot delete a draft
-        line."""
+    def test_non_owner_delete_line_404_masks_draft(self, client, db_session, owner, company):
+        """A non-owner probing a draft line gets 404 (not 403) — a private draft's
+        existence is masked, mirroring the GET edit-form's _get_list_for_user (finding
+        #3).
+
+        A 403 would reveal which sequential ids are live private drafts.
+        """
         el = _draft_with_lines(db_session, owner, company)
         line = _lines(db_session, el)[0]
         resp = client.delete(f"/api/resell/{el.id}/lines/{line.id}")
-        assert resp.status_code == 403
+        assert resp.status_code == 404
         assert db_session.get(ExcessLineItem, line.id) is not None
+
+    def test_non_owner_patch_line_404_masks_draft(self, client, db_session, owner, company):
+        """A non-owner PATCHing a draft line gets 404 (existence masked, finding #3)."""
+        el = _draft_with_lines(db_session, owner, company)
+        line = _lines(db_session, el)[0]
+        resp = client.patch(
+            f"/api/resell/{el.id}/lines/{line.id}",
+            data={"part_number": "LM358N", "quantity": "5"},
+        )
+        assert resp.status_code == 404
+
+    def test_non_owner_patch_list_404_masks_draft(self, client, db_session, owner, company):
+        """A non-owner PATCHing a draft header gets 404 (existence masked, finding
+        #3)."""
+        el = _draft_with_lines(db_session, owner, company)
+        resp = client.patch(
+            f"/api/resell/{el.id}",
+            data={"title": "Hijacked", "company_id": str(company.id)},
+        )
+        assert resp.status_code == 404
+        db_session.refresh(el)
+        assert el.title == "Draft to edit"  # untouched
+
+    def test_non_owner_delete_list_404_masks_draft(self, client, db_session, owner, company):
+        """A non-owner DELETEing a draft list gets 404 (existence masked, finding
+        #3)."""
+        el = _draft_with_lines(db_session, owner, company)
+        list_id = el.id
+        resp = client.delete(f"/api/resell/{list_id}")
+        assert resp.status_code == 404
+        assert db_session.get(ExcessList, list_id) is not None  # not deleted
+
+    def test_delete_list_route_pushes_workspace_url(self, client, db_session, owner, company):
+        """Deleting a draft rewrites the address bar to the workspace root so a reload
+        does not reopen the now-deleted list id (finding #8)."""
+        el = _draft_with_lines(db_session, owner, company)
+        restore = _as_owner(client, owner)
+        try:
+            resp = client.delete(f"/api/resell/{el.id}")
+        finally:
+            restore()
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Push-Url") == "/v2/resell"
 
 
 class TestHonest409Copy:

--- a/tests/test_resell_draft_offer_privacy.py
+++ b/tests/test_resell_draft_offer_privacy.py
@@ -13,6 +13,7 @@ app.routers.resell, app.services.excess_service.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import pytest
 from sqlalchemy.orm import Session
@@ -112,6 +113,138 @@ def test_non_owner_submit_offer_on_posted_200(client, db_session, posted_list, o
     assert resp.status_code == 200
     offers = db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).all()
     assert len(offers) == 1
+
+
+# ── Task 1 (finding #13): the broker own-offers view + Withdraw ──────────────
+# A non-owner viewing a posted list's Offers tab sees ONLY their own offers (never
+# another broker's) — each open/late own-offer with a Withdraw button — and NO
+# competitor data (Phase-3 anonymization discipline held). The submitter can still
+# reach their own offer to withdraw it after the posting window closes (expired).
+
+
+def _broker_offer(db_session, el, broker, *, mpn="XCVU9P-2FLGA2104I", unit_price="5.00", notes=None):
+    """Submit a per-line inbound offer as *broker* via the service (the real path)."""
+    from app.services.excess_service import submit_offer
+
+    return submit_offer(
+        db_session,
+        list_id=el.id,
+        user=broker,
+        scope="per_line",
+        notes=notes,
+        lines=[{"mpn_raw": mpn, "quantity": 10, "unit_price": Decimal(unit_price)}],
+    )
+
+
+def test_non_owner_offers_tab_shows_own_offer_with_withdraw(client, db_session, posted_list, owner_user, test_user):
+    """The broker (non-owner) viewing a posted list's Offers tab sees their OWN offer
+    line + a Withdraw button pointed at that offer — not the owner's private full
+    view."""
+    assert test_user.id != owner_user.id
+    offer = _broker_offer(db_session, posted_list, test_user, mpn="XCVU9P-2FLGA2104I")
+
+    body = client.get(f"/v2/partials/resell/{posted_list.id}/offers").text
+    assert "XCVU9P-2FLGA2104I" in body  # the broker sees their own bid line
+    assert f"/offers/{offer.id}/withdraw" in body  # ...with a Withdraw action
+    # The owner-only "Offers are private" prompt is gone for a broker who has bid.
+    assert "Offers are private to the list owner" not in body
+
+
+def test_non_owner_offers_tab_hides_other_brokers_offer(
+    client, db_session, posted_list, owner_user, test_user, sales_user
+):
+    """RS-1 / Phase-3: broker A must see ONLY their own offer — never broker B's bid,
+    price, or a withdraw handle on it."""
+    # sales_user has no can_offer; make a real second BROKER instead.
+    broker_b = User(email="broker-b@trioscs.com", name="Bram Broker", role="buyer", azure_id="az-broker-b")
+    db_session.add(broker_b)
+    db_session.commit()
+
+    mine = _broker_offer(db_session, posted_list, test_user, unit_price="5.00")
+    theirs = _broker_offer(db_session, posted_list, broker_b, unit_price="999.99", notes="BROKER-B-SECRET")
+
+    body = client.get(f"/v2/partials/resell/{posted_list.id}/offers").text
+    # My own offer is present + withdrawable.
+    assert f"/offers/{mine.id}/withdraw" in body
+    # The competitor's offer, its price, its notes, and any handle on it are all absent.
+    assert "999.99" not in body, "competitor offer price leaked into the broker own-offers view"
+    assert "BROKER-B-SECRET" not in body, "competitor offer notes leaked into the broker own-offers view"
+    assert f"/offers/{theirs.id}/withdraw" not in body
+    assert f"/offers/{theirs.id}/award" not in body
+
+
+def test_non_owner_offers_view_carries_no_competitor_aggregates(client, db_session, posted_list, owner_user, test_user):
+    """The broker own-offers view must not carry owner-only aggregates: no best-price
+    marker, no Export CSV, no per-line award controls (those are the owner's view)."""
+    _broker_offer(db_session, posted_list, test_user)
+    # A competing owner-side rollup exists on the line (best price + count) — must not surface.
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
+    line.best_offer_unit_price = Decimal("77.7700")
+    line.offer_count = 4
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/resell/{posted_list.id}/offers").text
+    assert "77.77" not in body, "owner best-price rollup leaked to the broker"
+    assert "Export CSV" not in body, "owner-only export leaked to the broker view"
+    assert "/award" not in body, "owner award control leaked to the broker view"
+
+
+def test_submitter_reaches_and_withdraws_offer_after_expiry(client, db_session, posted_list, owner_user, test_user):
+    """A submitter with an open offer is NOT 404'd once the posting window closes
+    (expired) — they can still view AND withdraw their own bid (relaxed
+    _get_list_for_user)."""
+    offer = _broker_offer(db_session, posted_list, test_user)
+    posted_list.status = ExcessListStatus.EXPIRED
+    db_session.commit()
+
+    # The submitter reaches the (now non-posted) Offers tab instead of a 404.
+    view = client.get(f"/v2/partials/resell/{posted_list.id}/offers")
+    assert view.status_code == 200
+    assert f"/offers/{offer.id}/withdraw" in view.text
+
+    # ...and can actually withdraw it.
+    resp = client.post(f"/api/resell/{posted_list.id}/offers/{offer.id}/withdraw")
+    assert resp.status_code == 200
+    db_session.refresh(offer)
+    assert offer.status == ExcessOfferStatus.WITHDRAWN
+
+
+def test_non_submitter_still_404_on_expired_list(client, db_session, owner_user, test_company, test_user):
+    """Control: a non-owner with NO offer stays 404 on a non-posted list — the relaxation
+    only admits the actual submitter, never a general reader."""
+    assert test_user.id != owner_user.id
+    el = _list_with_line(db_session, owner_user, test_company, ExcessListStatus.EXPIRED)
+    resp = client.get(f"/v2/partials/resell/{el.id}/offers")
+    assert resp.status_code == 404
+
+
+def test_post_submit_offer_shows_own_offer_not_empty_state(client, db_session, posted_list, owner_user, test_user):
+    """Post-submit re-render shows the submitter their own offer (not the empty
+    state)."""
+    resp = client.post(
+        f"/api/resell/{posted_list.id}/offers",
+        data={"scope": "per_line", "mpn_raw": "XCVU9P-2FLGA2104I", "quantity": "10", "unit_price": "5.00"},
+    )
+    assert resp.status_code == 200
+    offer = db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).one()
+    assert f"/offers/{offer.id}/withdraw" in resp.text
+    assert "XCVU9P-2FLGA2104I" in resp.text
+
+
+def test_owner_offers_view_unchanged_by_broker_view(client, db_session, posted_list, owner_user, test_user):
+    """Control: the OWNER still gets the full owner offers view (Export CSV present, broker
+    empty-state absent) — Task 1 only reshapes the NON-owner branch."""
+    _broker_offer(db_session, posted_list, test_user, unit_price="5.00")
+
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: owner_user
+    try:
+        body = client.get(f"/v2/partials/resell/{posted_list.id}/offers").text
+    finally:
+        client.app.dependency_overrides.pop(require_user, None)
+    assert "Export CSV" in body  # owner-only affordance
+    assert "Offers are private to the list owner" not in body
 
 
 def _posted_list_with_best_offer(db_session, owner, company):

--- a/tests/test_resell_list_lifecycle.py
+++ b/tests/test_resell_list_lifecycle.py
@@ -129,6 +129,131 @@ def test_close_retires_mirror(db_session, owner, company):
     assert _sightings(db_session, company.id) == []  # closed → retired
 
 
+# ── close_list_without_bid → CLOSED terminal state (Task 3, D5) ──────
+
+
+def test_close_without_bid_on_open_flips_to_closed(db_session, owner, company):
+    """Closing an OPEN list without bidding flips it to CLOSED + stamps close_at."""
+    el = _make_list(db_session, owner, company)
+    publish_list(db_session, el.id, owner)  # → open
+    assert el.status == ExcessListStatus.OPEN
+
+    closed = excess_service.close_list_without_bid(db_session, el.id, owner)
+    assert closed.status == ExcessListStatus.CLOSED
+    assert closed.close_at is not None
+
+
+def test_close_without_bid_on_collecting_flips_to_closed(db_session, owner, company):
+    """A collecting list closes without bidding → CLOSED (distinct from the bid_out
+    path)."""
+    el = _make_list(db_session, owner, company)
+    publish_list(db_session, el.id, owner)
+    el.status = ExcessListStatus.COLLECTING
+    db_session.commit()
+
+    closed = excess_service.close_list_without_bid(db_session, el.id, owner)
+    assert closed.status == ExcessListStatus.CLOSED
+
+
+def test_close_without_bid_retires_mirror(db_session, owner, company):
+    """Closing without bidding retires the live-supply Sighting mirror (terminal)."""
+    el = _make_list(db_session, owner, company)
+    publish_list(db_session, el.id, owner)
+    assert len(_sightings(db_session, company.id)) == 1
+
+    excess_service.close_list_without_bid(db_session, el.id, owner)
+
+    assert _sightings(db_session, company.id) == []
+
+
+def test_close_without_bid_rejects_draft(db_session, owner, company):
+    """A draft can't be closed-without-bid — 409, no mutation (mirrors close_list)."""
+    el = _make_list(db_session, owner, company)
+    assert el.status == ExcessListStatus.DRAFT
+    with pytest.raises(HTTPException) as exc:
+        excess_service.close_list_without_bid(db_session, el.id, owner)
+    assert exc.value.status_code == 409
+    db_session.refresh(el)
+    assert el.status == ExcessListStatus.DRAFT
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    [ExcessListStatus.BID_OUT, ExcessListStatus.AWARDED, ExcessListStatus.CLOSED, ExcessListStatus.EXPIRED],
+)
+def test_close_without_bid_rejects_terminal(db_session, owner, company, terminal_status):
+    """An already-resolved (incl.
+
+    already-CLOSED) list can't be re-closed — 409.
+    """
+    el = _make_list(db_session, owner, company)
+    el.status = terminal_status
+    db_session.commit()
+    with pytest.raises(HTTPException) as exc:
+        excess_service.close_list_without_bid(db_session, el.id, owner)
+    assert exc.value.status_code == 409
+
+
+def test_close_without_bid_non_owner_403(db_session, owner, other_user, company):
+    """Only the owner can close a list without bidding — 403 otherwise."""
+    el = _make_list(db_session, owner, company)
+    publish_list(db_session, el.id, owner)
+    with pytest.raises(HTTPException) as exc:
+        excess_service.close_list_without_bid(db_session, el.id, other_user)
+    assert exc.value.status_code == 403
+
+
+def test_closed_list_is_not_auto_expired(db_session, owner, company):
+    """CLOSED is terminal — a past-close_at CLOSED list is NOT swept to expired."""
+    from datetime import timedelta
+
+    el = _make_list(db_session, owner, company)
+    el.status = ExcessListStatus.CLOSED
+    el.close_at = datetime.now(UTC) - timedelta(days=2)
+    db_session.commit()
+
+    assert excess_service.expire_overdue_lists(db_session) == 0
+    db_session.refresh(el)
+    assert el.status == ExcessListStatus.CLOSED
+
+
+def test_close_without_bid_route_200_and_forbidden(client, db_session, owner, company):
+    """Owner POST closes without bidding → 200 + CLOSED; a non-owner is 403."""
+    from app.dependencies import require_user
+    from app.main import app
+
+    el = _make_list(db_session, owner, company)
+    publish_list(db_session, el.id, owner)
+    el.status = ExcessListStatus.COLLECTING
+    db_session.commit()
+    el_id = el.id
+
+    # The default client user is not the owner → 403.
+    assert client.post(f"/api/resell/{el_id}/close-without-bid").status_code == 403
+
+    app.dependency_overrides[require_user] = lambda: owner
+    try:
+        resp = client.post(f"/api/resell/{el_id}/close-without-bid")
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+    assert resp.status_code == 200
+    assert db_session.get(ExcessList, el_id).status == ExcessListStatus.CLOSED
+
+
+def test_workspace_bid_out_subtitle_is_accurate(client, db_session, owner):
+    """The bid_out glance card no longer overstates 'Sent to the customer' (closing ends
+    the collection window — the bid-back send is a separate, later action)."""
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[require_user] = lambda: owner
+    try:
+        body = client.get("/v2/partials/resell/workspace?lens=mine").text
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+    assert "Sent to the customer" not in body
+
+
 # ── expire_overdue_lists (the nightly service) ───────────────────────
 
 

--- a/tests/test_resell_outreach_routes.py
+++ b/tests/test_resell_outreach_routes.py
@@ -689,6 +689,100 @@ def test_log_bid_never_regresses_terminal_row(client, db_session, trader_user, p
     assert row.status == ExcessOutreachStatus.BID  # not regressed to responded
 
 
+def test_log_bid_negative_quantity_400_not_500(client, db_session, trader_user, posted_list):
+    """A negative quantity is rejected 400 at the route — never reaches the
+    ExcessOfferLine @validates('quantity') ValueError as an unhandled 500 (finding #1).
+
+    A negative qty is NOT None, so the old ``qty is None`` guard passed it through; the
+    missing ``qty <= 0`` clause let it flow into a partial write + 500. No ExcessOffer may
+    be created and the row stays ``sent``.
+    """
+    buyer = _reachable_buyer(db_session, "Fat Finger Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="phone")
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.post(
+            f"/api/resell/{posted_list.id}/outreach/{row.id}/log-bid",
+            data={"mpn_raw": "GRM188R", "quantity": "-5", "unit_price": "0.88"},
+        )
+    finally:
+        restore()
+    assert resp.status_code == 400
+    db_session.refresh(row)
+    assert row.status == ExcessOutreachStatus.SENT  # untouched — no partial write
+    assert db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).count() == 0
+
+
+def test_log_bid_double_submit_creates_no_duplicate_offer(client, db_session, trader_user, posted_list):
+    """A replayed/duplicated Log-bid POST on a now-BID row records NO second ExcessOffer
+    (finding #5/#9/#10).
+
+    The first submit advances the manual row ``sent`` → ``bid`` and links one inbound
+    offer. A second submit (double-click / racing re-render) must be idempotent: the
+    status stays ``bid`` AND ``_link_inbound_offer`` does NOT run again, so the buyer's
+    single manual bid is never inflated to two offers.
+    """
+    buyer = _reachable_buyer(db_session, "Replay Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="teams")
+    restore = _own(db_session, None, trader_user)
+    try:
+        payload = {"mpn_raw": "GRM188R", "quantity": "500", "unit_price": "0.88"}
+        first = client.post(f"/api/resell/{posted_list.id}/outreach/{row.id}/log-bid", data=payload)
+        second = client.post(f"/api/resell/{posted_list.id}/outreach/{row.id}/log-bid", data=payload)
+    finally:
+        restore()
+    assert first.status_code == 200 and second.status_code == 200
+    db_session.refresh(row)
+    assert row.status == ExcessOutreachStatus.BID
+    # Exactly ONE inbound offer — the replay did not create a second.
+    assert db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).count() == 1
+
+
+def test_log_bid_on_declined_row_creates_no_offer(client, db_session, trader_user, posted_list):
+    """Log-bid on an already-DECLINED terminal row creates NO ExcessOffer and leaves the
+    row ``declined`` (finding #9/#10 — the named 'terminal-row log-bid' case).
+
+    ``record_manual_response`` protects the status from terminal regression; the offer
+    link must be gated on the same terminal check, or a declined row silently sprouts an
+    inbound bid that reads ``declined`` in the tracker.
+    """
+    buyer = _reachable_buyer(db_session, "Declined Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(
+        db_session, posted_list, trader_user, buyer, channel="marketplace", status=ExcessOutreachStatus.DECLINED
+    )
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.post(
+            f"/api/resell/{posted_list.id}/outreach/{row.id}/log-bid",
+            data={"mpn_raw": "GRM188R", "quantity": "500", "unit_price": "0.88"},
+        )
+    finally:
+        restore()
+    assert resp.status_code == 200
+    db_session.refresh(row)
+    assert row.status == ExcessOutreachStatus.DECLINED  # not regressed to bid
+    assert db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).count() == 0
+
+
+def test_manual_log_bid_form_uses_honest_toast_copy(client, db_session, trader_user, posted_list):
+    """The manual Log-bid modal's success toast reads honestly ('Bid logged') — NOT the
+    email-thread copy 'Offer created from reply' (finding #7).
+
+    The reply viewer is reused for the manual modal (manual=True); its convert form's
+    after-request toast must reflect the manual framing the template itself renders.
+    """
+    buyer = _reachable_buyer(db_session, "Toast Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="phone")
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/outreach/{row.id}/log-bid-form")
+    finally:
+        restore()
+    assert resp.status_code == 200
+    assert "Bid logged" in resp.text
+    assert "Offer created from reply" not in resp.text
+
+
 def test_manual_log_rejects_email_channel_row(client, db_session, trader_user, posted_list):
     """An EMAIL-channel row must use the reply viewer, not the manual-log route →
     409."""
@@ -761,3 +855,49 @@ def test_no_contact_checkbox_enabled_for_manual_channel(client, db_session, trad
         restore()
     # The checkbox is now Alpine-gated on the channel rather than hard-disabled.
     assert ":disabled=\"channel === 'email'\"" in body
+
+
+def test_no_contact_selection_purged_on_switch_back_to_email(client, db_session, trader_user, posted_list):
+    """Switching channel back to email PURGES any no-contact buyer already ticked on a
+    manual channel, so they are not silently emailed as a spurious failed outreach
+    (finding #6).
+
+    The channel buttons must route through a ``setChannel`` handler that drops the
+    no-contact card ids from ``selected`` (seeded as ``noContactIds``); a bare
+    ``channel = '...'`` assignment leaves the id in the hidden ``vendor_card_ids``.
+    """
+    no_contact = VendorCard(normalized_name="purge me buyer", display_name="Purge Me Buyer", emails=[])
+    no_contact.commodity_tags = [_CAP]
+    db_session.add(no_contact)
+    db_session.flush()
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
+    offer = ExcessOffer(
+        excess_list_id=posted_list.id,
+        submitted_by=trader_user.id,
+        offerer_vendor_card_id=no_contact.id,
+        scope="per_line",
+        status=ExcessOfferStatus.WON,
+    )
+    db_session.add(offer)
+    db_session.flush()
+    db_session.add(
+        ExcessOfferLine(
+            offer_id=offer.id,
+            excess_line_item_id=line.id,
+            mpn_raw=line.part_number,
+            quantity=10,
+            unit_price=Decimal("0.90"),
+            match_status=OfferLineMatchStatus.MATCHED,
+        )
+    )
+    db_session.commit()
+    restore = _own(db_session, None, trader_user)
+    try:
+        body = client.get(f"/v2/partials/resell/{posted_list.id}/offer-buyers-form").text
+    finally:
+        restore()
+    # The no-contact id is seeded for the purge, and channel switches route through it.
+    assert f"noContactIds: [{no_contact.id}]" in body or f"noContactIds: [{no_contact.id}," in body
+    assert "setChannel(" in body
+    # The bare assignment that skipped the purge is gone.
+    assert "@click=\"channel = '" not in body

--- a/tests/test_resell_outreach_routes.py
+++ b/tests/test_resell_outreach_routes.py
@@ -591,3 +591,173 @@ def test_submit_outreach_draft_list_409(client, db_session, trader_user, draft_l
 # redundant assertion theater — the posted-list success path is covered with real
 # outcome assertions by ``test_submit_outreach_log_path`` (rows/channel/target created)
 # and ``test_submit_outreach_email_path`` (sending rows + background job dispatched).
+
+
+# ── Task 5 (finding #12): manual-channel Log response / Log their bid ─────────
+# A manual-channel (phone/teams/marketplace) outreach row is created at 'sent' with no
+# graph_conversation_id, so the email reply-viewer/convert path (keyed on the thread) can
+# never advance it — it was a dead-end. The owner can now log the outcome directly on the
+# row: Log response (-> responded) or Log their bid (-> bid + an ExcessOffer via the SAME
+# convert path an emailed bid uses). The no-contact checkbox is enabled for manual channels.
+
+
+def _manual_outreach(db_session, el, owner, card, *, channel="phone", status=None):
+    from app.constants import ExcessOutreachStatus
+
+    row = ExcessOutreach(
+        excess_list_id=el.id,
+        submitted_by=owner.id,
+        target_vendor_card_id=card.id,
+        channel=channel,
+        status=status or ExcessOutreachStatus.SENT,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(row)
+    db_session.commit()
+    db_session.refresh(row)
+    return row
+
+
+def test_log_response_flips_manual_row_to_responded(client, db_session, trader_user, posted_list):
+    buyer = _reachable_buyer(db_session, "Phone Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="phone")
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.post(f"/api/resell/{posted_list.id}/outreach/{row.id}/log-response")
+    finally:
+        restore()
+    assert resp.status_code == 200
+    db_session.refresh(row)
+    assert row.status == ExcessOutreachStatus.RESPONDED
+    # The returned partial is the tracker (shows the buyer + summary).
+    assert "Phone Buyer" in resp.text
+
+
+def test_log_bid_creates_offer_and_flips_bid(client, db_session, trader_user, posted_list):
+    buyer = _reachable_buyer(db_session, "Teams Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="teams")
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.post(
+            f"/api/resell/{posted_list.id}/outreach/{row.id}/log-bid",
+            data={"mpn_raw": "GRM188R", "quantity": "500", "unit_price": "0.88"},
+        )
+    finally:
+        restore()
+    assert resp.status_code == 200
+    db_session.refresh(row)
+    assert row.status == ExcessOutreachStatus.BID
+    # The bid was recorded as a real inbound ExcessOffer scoped to the buyer card.
+    offers = db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).all()
+    assert len(offers) == 1
+    assert offers[0].offerer_vendor_card_id == buyer.id
+    offer_line = db_session.query(ExcessOfferLine).filter_by(offer_id=offers[0].id).one()
+    assert offer_line.unit_price == Decimal("0.88")
+    # The matched line got its rollup recomputed (the salvaged bid owns it).
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
+    assert line.best_offer_id == offers[0].id
+
+
+def test_log_bid_form_renders_convert_form(client, db_session, trader_user, posted_list):
+    """The Log-bid modal reuses the convert-to-offer form, pointed at the manual log-bid
+    route."""
+    buyer = _reachable_buyer(db_session, "Marketplace Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="marketplace")
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/outreach/{row.id}/log-bid-form")
+    finally:
+        restore()
+    assert resp.status_code == 200
+    assert f"/api/resell/{posted_list.id}/outreach/{row.id}/log-bid" in resp.text
+    assert 'name="mpn_raw"' in resp.text  # the reused convert line form
+
+
+def test_log_bid_never_regresses_terminal_row(client, db_session, trader_user, posted_list):
+    """A row already at 'bid' is not regressed by a stray log-response."""
+    buyer = _reachable_buyer(db_session, "Done Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(
+        db_session, posted_list, trader_user, buyer, channel="phone", status=ExcessOutreachStatus.BID
+    )
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.post(f"/api/resell/{posted_list.id}/outreach/{row.id}/log-response")
+    finally:
+        restore()
+    assert resp.status_code == 200
+    db_session.refresh(row)
+    assert row.status == ExcessOutreachStatus.BID  # not regressed to responded
+
+
+def test_manual_log_rejects_email_channel_row(client, db_session, trader_user, posted_list):
+    """An EMAIL-channel row must use the reply viewer, not the manual-log route →
+    409."""
+    buyer = _reachable_buyer(db_session, "Email Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="email")
+    restore = _own(db_session, None, trader_user)
+    try:
+        resp = client.post(f"/api/resell/{posted_list.id}/outreach/{row.id}/log-response")
+    finally:
+        restore()
+    assert resp.status_code == 409
+
+
+def test_log_response_owner_gated(client, db_session, trader_user, posted_list):
+    """The default client user is not the owner → 403 (the row is untouched)."""
+    buyer = _reachable_buyer(db_session, "Guard Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="phone")
+    resp = client.post(f"/api/resell/{posted_list.id}/outreach/{row.id}/log-response")
+    assert resp.status_code == 403
+    db_session.refresh(row)
+    assert row.status == ExcessOutreachStatus.SENT
+
+
+def test_tracker_shows_log_actions_for_manual_sent_row(client, db_session, trader_user, posted_list):
+    """A manual 'sent' row surfaces Log-response + Log-bid affordances in the
+    tracker."""
+    buyer = _reachable_buyer(db_session, "Log Actions Buyer", engagement=10.0, commodity=_CAP)
+    row = _manual_outreach(db_session, posted_list, trader_user, buyer, channel="phone")
+    restore = _own(db_session, None, trader_user)
+    try:
+        body = client.get(f"/v2/partials/resell/{posted_list.id}/outreach").text
+    finally:
+        restore()
+    assert f"/outreach/{row.id}/log-response" in body
+    assert f"/outreach/{row.id}/log-bid-form" in body
+
+
+def test_no_contact_checkbox_enabled_for_manual_channel(client, db_session, trader_user, posted_list):
+    """The no-contact buyer checkbox is disabled ONLY for the email channel — manual
+    channels (phone/teams/marketplace) can log a touch without an email on file."""
+    no_contact = VendorCard(normalized_name="no email log buyer", display_name="No Email Log Buyer", emails=[])
+    no_contact.commodity_tags = [_CAP]
+    db_session.add(no_contact)
+    db_session.flush()
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
+    offer = ExcessOffer(
+        excess_list_id=posted_list.id,
+        submitted_by=trader_user.id,
+        offerer_vendor_card_id=no_contact.id,
+        scope="per_line",
+        status=ExcessOfferStatus.WON,
+    )
+    db_session.add(offer)
+    db_session.flush()
+    db_session.add(
+        ExcessOfferLine(
+            offer_id=offer.id,
+            excess_line_item_id=line.id,
+            mpn_raw=line.part_number,
+            quantity=10,
+            unit_price=Decimal("0.90"),
+            match_status=OfferLineMatchStatus.MATCHED,
+        )
+    )
+    db_session.commit()
+    restore = _own(db_session, None, trader_user)
+    try:
+        body = client.get(f"/v2/partials/resell/{posted_list.id}/offer-buyers-form").text
+    finally:
+        restore()
+    # The checkbox is now Alpine-gated on the channel rather than hard-disabled.
+    assert ":disabled=\"channel === 'email'\"" in body

--- a/tests/test_sightings_resell_density.py
+++ b/tests/test_sightings_resell_density.py
@@ -88,8 +88,10 @@ def test_resell_triage_tiles_keep_filter_links(client, db_session, test_user):
     # Offer-based tiles keep their needs= filters ...
     assert "needs=offers" in body
     assert "needs=take_all" in body
-    # ... and the status tiles keep their stage= filters.
-    assert "stage=open" in body
+    # ... and the status tiles keep their stage= filters. The "Open" tile links to the
+    # synthetic stage=live token ([open, collecting]) so its filter matches its
+    # open+collecting count (finding #16), not the strict stage=open it mismatched before.
+    assert "stage=live" in body
     assert "stage=bid_out" in body
     assert "stage=awarded" in body
     # No tile regressed to an empty stage value (the old dead-control bug).


### PR DESCRIPTION
**Phase 4 of the Resell rework** (`docs/superpowers/plans/2026-07-18-resell-phase4-workflow-completion.md`) — closes the module's workflow dead-ends so it's a usable two-sided marketplace. All 6 controls user-approved. **No migration.**

## What changed (6 controls)
1. **Broker own-offers view + Withdraw** (#13) — a broker can finally see/withdraw their own offer (own offers only, zero competitor data; reaches it even after expiry).
2. **Draft-edit set + honest 409** (#14/D4) — delete line, inline-edit line, edit title/notes/customer, delete/cancel draft; the false "revise as a new version" copy replaced.
3. **"Close without bidding" → CLOSED** (D5) — a real terminal state for a posting that got no usable offers, distinct from "bids out."
4. **Assign to line** (#15) — the unmatched-offer queue's "resolve manually" now has a control; salvaged offers become awardable.
5. **Manual-channel Log response / Log bid** (#12) — phone/Teams/marketplace outreach rows can record a response or bid (reusing the convert-to-offer form); no-contact checkbox enabled for manual channels.
6. **`stage=live` triage token** (#16) — the Open card links to open+collecting instead of yielding "no lists match."

## Adversarial review (ultracode) — 9 findings caught & fixed
The build passed its own tests, but a 6-dimension review + 3-skeptic verify found **13 findings, 9 confirmed**, all fixed at root cause — most importantly:
- **CLOSED not enforced terminal** (critical): an owner could Award a still-open offer on a closed list, reopening it AWARDED→BID_OUT — violating the D5 "no reopen" contract. `award_offer` + `assign_offer_line` now reject terminal/resolved lists.
- log-bid `qty<=0` → 500 (now 400); no-contact selection surviving a channel switch (now purged); draft-route 403→404 existence masking; duplicate-offer on log-bid replay; toast/URL polish.

## Verification
- 192 affected tests green under xdist; pre-commit + query-API + assertion-theater ratchets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)