### PR TITLE
CRM: edit contacts from the global contacts list + readability upgrades

### DIFF
--- a/app/routers/htmx/companies/contacts.py
+++ b/app/routers/htmx/companies/contacts.py
@@ -104,19 +104,24 @@ def _form_int(form, key: str, default: int = 0) -> int:
     return int(raw) if raw.isdigit() else default
 
 
-def _contacts_list_response(request: Request, user: User, db: Session, form) -> HTMLResponse:
-    """Re-render the global contacts list from the hx-included filter fields."""
+def _contacts_list_response(request: Request, user: User, db: Session, form, prefix: str = "") -> HTMLResponse:
+    """Re-render the global contacts list from the hx-included filter fields.
+
+    prefix: read filter values from prefixed form keys (e.g. "filter_search") — used by
+    the origin=contacts edit-modal save, whose form carries its own contact_role field
+    and so namespaces the list filters to avoid the name collision.
+    """
     ctx = _base_ctx(request, user, "crm")
     ctx.update(
         customer_contacts_list_ctx(
             db,
             user,
-            search=(form.get("search") or "").strip(),
-            company_id=_form_int(form, "company_id"),
-            contact_role=(form.get("contact_role") or "").strip(),
-            cadence_state=(form.get("cadence_state") or "").strip(),
-            limit=_form_int(form, "limit", 50),
-            offset=_form_int(form, "offset", 0),
+            search=(form.get(f"{prefix}search") or "").strip(),
+            company_id=_form_int(form, f"{prefix}company_id"),
+            contact_role=(form.get(f"{prefix}contact_role") or "").strip(),
+            cadence_state=(form.get(f"{prefix}cadence_state") or "").strip(),
+            limit=_form_int(form, f"{prefix}limit", 50),
+            offset=_form_int(form, f"{prefix}offset", 0),
         )
     )
     ctx["contact_roles"] = CANONICAL_ROLES
@@ -1329,6 +1334,13 @@ async def contact_edit_form_company_scoped(
     request: Request,
     company_id: int,
     contact_id: int,
+    origin: str = "",
+    filter_search: str = "",
+    filter_company_id: int = Query(0, ge=0),
+    filter_contact_role: str = "",
+    filter_cadence_state: str = "",
+    filter_limit: int = Query(50, ge=1, le=200),
+    filter_offset: int = Query(0, ge=0),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -1339,6 +1351,10 @@ async def contact_edit_form_company_scoped(
     /contacts/{contact_id}/edit and targets #contacts-tab-list — the canonical swap
     target for the Contacts tab. The former site-scoped edit-form route and
     contact_edit_modal.html have been retired.
+
+    origin=contacts: called from the global /v2/contacts list's per-row Edit button. The
+    form then targets #main-content and carries the filter_* values as hidden inputs so
+    the save re-renders the global list with the caller's filters intact.
     """
     # Validate the contact belongs to a site that belongs to this company
     contact = (
@@ -1376,6 +1392,15 @@ async def contact_edit_form_company_scoped(
             "sites": [],
             "roles": CANONICAL_ROLES,
             "site_contacts_for_select": site_contacts_for_select,
+            "origin": origin if origin == "contacts" else "",
+            "list_filters": {
+                "search": filter_search,
+                "company_id": filter_company_id,
+                "contact_role": filter_contact_role,
+                "cadence_state": filter_cadence_state,
+                "limit": filter_limit,
+                "offset": filter_offset,
+            },
         },
     )
 
@@ -1561,8 +1586,10 @@ async def edit_site_contact(
     """Update editable contact fields and return refreshed Contacts tab grouped list.
 
     Writes contact_role (validated via _validate_role; blank→NULL, unknown→400),
-    is_priority, and linkedin_url. Always renders #contacts-tab-list — the Sites tab no
-    longer carries a contact editor.
+    is_priority, and linkedin_url. Renders #contacts-tab-list — the Sites tab no longer
+    carries a contact editor. When the form carries origin=contacts (the global
+    /v2/contacts list's Edit modal), re-renders the global contacts list instead, scoped
+    to the filter_* fields the modal carried through.
     """
     contact = (
         db.query(SiteContact).filter(SiteContact.id == contact_id, SiteContact.customer_site_id == site_id).first()
@@ -1623,4 +1650,8 @@ async def edit_site_contact(
     db.commit()
     logger.info("Contact {} edited by {}", contact_id, user.email)
 
+    if (form.get("origin") or "") == "contacts":
+        resp = _contacts_list_response(request, user, db, form, prefix="filter_")
+        resp.headers["HX-Trigger"] = json.dumps({"showToast": {"message": f"Updated {contact.full_name or 'contact'}"}})
+        return resp
     return _render_contacts_list(request, user, company, db)

--- a/app/templates/htmx/partials/customers/contacts_list.html
+++ b/app/templates/htmx/partials/customers/contacts_list.html
@@ -8,6 +8,9 @@
    Depends on: brand palette, timeago filter, .table-cell / .compact-cell utilities,
                _saved_views.html.
    Power-UX (P4): bulk select + actions (archive/DNC), Saved Views, filtered CSV export.
+   Per-row Edit: pencil button opens the shared _contact_form.html edit modal with
+   origin=contacts + the current filter_* values, so the save re-renders THIS list
+   (filters intact) instead of the company Contacts tab.
 #}
 {% from "htmx/partials/shared/_macros.html" import cadence_dot, CADENCE_DOT %}
 <div class="page-fluid">
@@ -137,6 +140,7 @@
             <th class="table-cell--head text-left text-xs font-medium text-gray-600 uppercase tracking-wider">Email</th>
             <th class="table-cell--head text-left text-xs font-medium text-gray-600 uppercase tracking-wider">Phone</th>
             <th class="table-cell--head text-right text-xs font-medium text-gray-600 uppercase tracking-wider">Last outbound</th>
+            <th class="compact-cell--head w-8"><span class="sr-only">Edit</span></th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
@@ -163,15 +167,47 @@
               {{ cadence_dot(c.cadence_state) }}
             </td>
             <td class="table-cell">
-              <p class="text-sm font-semibold text-gray-900">{{ c.full_name or "—" }}</p>
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <p class="text-sm font-semibold text-gray-900">{{ c.full_name or "—" }}</p>
+                {% if c.is_priority %}
+                <svg class="h-3.5 w-3.5 text-amber-400 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-label="Priority contact" role="img">
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118L2.077 10.1c-.783-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+                </svg>
+                {% endif %}
+                {% if c.do_not_contact %}<span class="badge-danger">DNC</span>{% endif %}
+                {% if c.is_archived %}<span class="badge-neutral">Archived</span>{% endif %}
+              </div>
               {% if c.title %}<p class="text-xs text-gray-600">{{ c.title }}</p>{% endif %}
             </td>
-            <td class="table-cell text-sm text-gray-700">{{ company.name if company else "—" }}</td>
+            <td class="table-cell">
+              <p class="text-sm text-gray-700">{{ company.name if company else "—" }}</p>
+              {% if site and site.site_name %}<p class="text-xs text-gray-500">{{ site.site_name }}</p>{% endif %}
+            </td>
             <td class="table-cell text-sm">{% if c.contact_role %}<span class="chip">{{ c.contact_role|replace('_', ' ')|title }}</span>{% else %}<span class="text-gray-400">—</span>{% endif %}</td>
-            <td class="table-cell text-secondary">{{ c.email or "—" }}</td>
-            <td class="table-cell text-secondary">{{ c.phone or "—" }}</td>
+            <td class="table-cell text-secondary">
+              {% if c.email %}<a href="mailto:{{ c.email }}" @click.stop class="hover:text-brand-600 hover:underline">{{ c.email }}</a>{% else %}—{% endif %}
+            </td>
+            <td class="table-cell text-secondary">
+              {% if c.phone %}<a href="tel:{{ c.phone }}" @click.stop class="hover:text-brand-600 hover:underline whitespace-nowrap">{{ c.phone }}</a>{% else %}—{% endif %}
+            </td>
             <td class="table-cell text-right text-[11px] tabular-nums {% if c.cadence_state == 'overdue' %}text-rose-600 font-medium{% elif c.cadence_state == 'due' %}text-amber-600{% else %}text-gray-400{% endif %}">
               {{ c.last_outbound_at|timeago if c.last_outbound_at else "never" }}
+            </td>
+            {# Edit — opens the shared contact edit modal with origin=contacts + the live
+               filter values so the save re-renders this list with filters intact.
+               @click.stop keeps the row's navigate-to-account handler from firing. #}
+            <td class="compact-cell text-right">
+              {% if company %}
+              <button type="button"
+                      @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/{{ c.id }}/edit-form?origin=contacts&filter_search={{ search|urlencode }}&filter_company_id={{ company_id }}&filter_contact_role={{ contact_role|urlencode }}&filter_cadence_state={{ cadence_state|urlencode }}&filter_limit={{ limit }}&filter_offset={{ offset }}'})"
+                      class="p-1.5 rounded-lg text-gray-400 hover:text-brand-600 hover:bg-brand-100"
+                      aria-label="Edit {{ c.full_name or c.email or 'contact' }}"
+                      title="Edit contact">
+                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                </svg>
+              </button>
+              {% endif %}
             </td>
           </tr>
           {% endfor %}

--- a/app/templates/htmx/partials/customers/tabs/_contact_form.html
+++ b/app/templates/htmx/partials/customers/tabs/_contact_form.html
@@ -13,6 +13,10 @@
    In edit mode: hx-posts to /v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit
    Both target #contacts-tab-list + swap=innerHTML + close-modal on success.
 
+   origin=contacts (edit mode, from the global /v2/contacts list): targets
+   #main-content instead and carries hidden origin + filter_* inputs (list_filters)
+   so edit_site_contact re-renders the global contacts list with filters intact.
+
    Called by:
      GET /v2/partials/customers/{company_id}/contacts/add-form
      GET /v2/partials/customers/{company_id}/contacts/{contact_id}/edit-form
@@ -32,12 +36,19 @@
         x-data='{"newSite": false}'
         class='space-y-3'>
   {% else %}
+  {% set _from_contacts = origin is defined and origin == 'contacts' %}
   <form hx-post='/v2/partials/customers/{{ company.id }}/sites/{{ site.id }}/contacts/{{ contact.id }}/edit'
-        hx-target='#contacts-tab-list'
+        hx-target='{{ "#main-content" if _from_contacts else "#contacts-tab-list" }}'
         hx-swap='innerHTML'
         hx-on::after-request='if(event.detail.successful) $dispatch("close-modal")'
         data-loading-disable
         class='space-y-3'>
+    {% if _from_contacts %}
+    <input type='hidden' name='origin' value='contacts'>
+    {% for k, v in (list_filters or {}).items() %}
+    <input type='hidden' name='filter_{{ k }}' value='{{ v }}'>
+    {% endfor %}
+    {% endif %}
   {% endif %}
 
     {# ── Site selection (add mode only) ─────────────────────────────────── #}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -3305,6 +3305,13 @@ UI for uploading a vendor's stock list. All three are thin routes in
   dropdown is built from the
   same visibility scope. `require_user`. Reached via the "All contacts" link in
   `customers/list.html`.
+  Rows surface priority (star) / DNC / Archived flags, the contact's site under the
+  company name, and mailto:/tel: links. A per-row Edit (pencil) button opens the shared
+  `customers/tabs/_contact_form.html` edit modal with `origin=contacts` + the live
+  `filter_*` values (namespaced to dodge the form's own `contact_role` field);
+  `edit_site_contact` detects `origin=contacts` and re-renders THIS list via
+  `_contacts_list_response(..., prefix="filter_")` (filters + paging intact, toast via
+  `HX-Trigger`) instead of the company Contacts-tab grouped list.
 - **`GET /v2/vendor-contacts`** (`vendor_contacts_partial` → `vendors/contacts_list.html`)
   — global vendor-contacts list, the HTML twin of `GET /api/vendor-contacts/bulk`
   (`vendor_contacts.py`). View-open (`require_user`; vendor data is not tenant-scoped);

--- a/tests/test_contacts_list_edit.py
+++ b/tests/test_contacts_list_edit.py
@@ -1,0 +1,158 @@
+"""tests/test_contacts_list_edit.py — Edit-from-the-global-contacts-list flow.
+
+Covers the origin=contacts mode added to the shared contact edit modal:
+  - GET edit-form?origin=contacts renders hidden origin + filter_* inputs and
+    targets #main-content (so the save swaps the global list, not the tab).
+  - POST .../edit with origin=contacts persists the change and re-renders the
+    global contacts list scoped to the carried filter_* values.
+  - POST .../edit without origin still renders the Contacts-tab grouped list
+    (regression guard for the company-tab path).
+  - contacts_list.html readability affordances: per-row Edit button, mailto/tel
+    links, priority/DNC/Archived flags, site line under company.
+
+Depends on: conftest client/test_user/test_company fixtures;
+app/routers/htmx/companies/contacts.py; customers/contacts_list.html;
+customers/tabs/_contact_form.html.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import Company, CustomerSite, SiteContact, User
+
+
+@pytest.fixture()
+def owned_contact(db_session: Session, test_company: Company, test_user: User) -> SiteContact:
+    """A site + contact under test_company, owned by test_user (can_manage passes)."""
+    test_company.account_owner_id = test_user.id
+    site = CustomerSite(company_id=test_company.id, site_name="HQ", site_type="hq", is_active=True)
+    db_session.add(site)
+    db_session.flush()
+    contact = SiteContact(
+        customer_site_id=site.id,
+        full_name="Jane Doe",
+        first_name="Jane",
+        last_name="Doe",
+        email="jane@acme-electronics.com",
+        phone="+1-555-0101",
+        title="Buyer",
+        is_priority=True,
+        do_not_contact=True,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(contact)
+    db_session.commit()
+    db_session.refresh(contact)
+    return contact
+
+
+class TestEditFormOriginContacts:
+    def test_edit_form_carries_origin_and_filters(self, client, test_company, owned_contact):
+        resp = client.get(
+            f"/v2/partials/customers/{test_company.id}/contacts/{owned_contact.id}/edit-form"
+            "?origin=contacts&filter_search=jane&filter_company_id=0"
+            "&filter_contact_role=&filter_cadence_state=overdue&filter_limit=50&filter_offset=0"
+        )
+        assert resp.status_code == 200
+        body = resp.text
+        assert "name='origin' value='contacts'" in body
+        assert "name='filter_search' value='jane'" in body
+        assert "name='filter_cadence_state' value='overdue'" in body
+        assert "#main-content" in body
+        assert "#contacts-tab-list" not in body
+
+    def test_edit_form_without_origin_targets_tab_list(self, client, test_company, owned_contact):
+        resp = client.get(f"/v2/partials/customers/{test_company.id}/contacts/{owned_contact.id}/edit-form")
+        assert resp.status_code == 200
+        assert "#contacts-tab-list" in resp.text
+        assert "name='origin'" not in resp.text
+
+    def test_edit_form_unknown_origin_ignored(self, client, test_company, owned_contact):
+        resp = client.get(f"/v2/partials/customers/{test_company.id}/contacts/{owned_contact.id}/edit-form?origin=evil")
+        assert resp.status_code == 200
+        assert "name='origin'" not in resp.text
+        assert "#contacts-tab-list" in resp.text
+
+
+class TestEditSaveOriginContacts:
+    def test_save_persists_and_rerenders_global_list(self, client, db_session, test_company, owned_contact, test_user):
+        site_id = owned_contact.customer_site_id
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/sites/{site_id}/contacts/{owned_contact.id}/edit",
+            data={
+                "origin": "contacts",
+                "first_name": "Janet",
+                "last_name": "Doe",
+                "title": "Senior Buyer",
+                "filter_search": "",
+                "filter_company_id": "0",
+                "filter_contact_role": "",
+                "filter_cadence_state": "",
+                "filter_limit": "50",
+                "filter_offset": "0",
+            },
+        )
+        assert resp.status_code == 200
+        db_session.refresh(owned_contact)
+        assert owned_contact.first_name == "Janet"
+        assert owned_contact.full_name == "Janet Doe"
+        # Global list markers — heading + the edited contact rendered as a row.
+        assert "Customer Contacts" in resp.text
+        assert "Janet Doe" in resp.text
+        assert "showToast" in resp.headers.get("HX-Trigger", "")
+
+    def test_save_honors_carried_filters(self, client, db_session, test_company, owned_contact):
+        # A second contact that the carried search filter must exclude from the re-render.
+        other = SiteContact(
+            customer_site_id=owned_contact.customer_site_id,
+            full_name="Zed Other",
+            email="zed@acme-electronics.com",
+        )
+        db_session.add(other)
+        db_session.commit()
+        site_id = owned_contact.customer_site_id
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/sites/{site_id}/contacts/{owned_contact.id}/edit",
+            data={
+                "origin": "contacts",
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "filter_search": "Jane",
+                "filter_limit": "50",
+                "filter_offset": "0",
+            },
+        )
+        assert resp.status_code == 200
+        assert "Jane Doe" in resp.text
+        assert "Zed Other" not in resp.text
+
+    def test_save_without_origin_renders_tab_list(self, client, db_session, test_company, owned_contact):
+        site_id = owned_contact.customer_site_id
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/sites/{site_id}/contacts/{owned_contact.id}/edit",
+            data={"first_name": "Jane", "last_name": "Doe"},
+        )
+        assert resp.status_code == 200
+        # Grouped Contacts-tab list, not the global workspace.
+        assert "Customer Contacts" not in resp.text
+
+
+class TestContactsListReadability:
+    def test_row_renders_edit_button_and_links(self, client, test_company, owned_contact):
+        resp = client.get("/v2/partials/contacts")
+        assert resp.status_code == 200
+        body = resp.text
+        assert f"/v2/partials/customers/{test_company.id}/contacts/{owned_contact.id}/edit-form?origin=contacts" in body
+        assert "mailto:jane@acme-electronics.com" in body
+        assert "tel:+1-555-0101" in body
+        assert "Edit Jane Doe" in body
+
+    def test_row_renders_flags_and_site(self, client, owned_contact):
+        resp = client.get("/v2/partials/contacts")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "DNC" in body
+        assert "Priority contact" in body
+        assert "HQ" in body


### PR DESCRIPTION
## What

The global Customer Contacts workspace (`/v2/contacts`) was read-only — editing a contact meant clicking through to each company's Contacts tab. This PR makes contacts editable directly from the CRM list and makes the list easier to read and manage.

### Edit from the list
- Per-row **Edit** (pencil) button opens the existing shared contact edit modal (`customers/tabs/_contact_form.html`) — no new form was built.
- The modal is opened with `origin=contacts` plus the live filter values (search / company / role / cadence / paging), carried as namespaced `filter_*` hidden inputs to avoid colliding with the form's own `contact_role` field (follows the codebase's established `origin=` re-render pattern).
- On save, `edit_site_contact` detects `origin=contacts` and re-renders the **global list with filters and paging intact** via `_contacts_list_response(prefix="filter_")`, plus a confirmation toast. The company Contacts-tab path is unchanged.

### Readability / manage
- Priority (star), **DNC**, and **Archived** flags now render on the name cell — previously invisible in this list even though bulk actions set them.
- Site name shown under the company for multi-site accounts.
- Email and phone are now clickable `mailto:` / `tel:` links (`@click.stop` so they don't trigger row navigation).

## Files
- `app/routers/htmx/companies/contacts.py` — `origin=contacts` mode on the edit-form GET + save POST; `_contacts_list_response` gains a `prefix` param.
- `app/templates/htmx/partials/customers/contacts_list.html` — Edit column, flags, links, site line.
- `app/templates/htmx/partials/customers/tabs/_contact_form.html` — origin-aware target + hidden filter carry-through.
- `tests/test_contacts_list_edit.py` — 8 new tests (form mode, save paths, filter carry-through, list affordances).
- `docs/APP_MAP_INTERACTIONS.md` — §10a updated.

## Testing
- 8 new tests pass; 426 tests across the neighboring CRM/contact suites pass (`test_contact_fields*`, `test_crm_p4_power_ux`, `test_rubric_h3_validation_lists`, `test_contact_merge_move`, `test_site_contact_idor`, `test_contacts_tab_quotes`, `test_crm_views`, `test_contacts_cadence_perf`).
- `pre-commit` (ruff, ruff-format, docformatter, mypy) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzN6kSk7C1nq5rTaxmhFb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzN6kSk7C1nq5rTaxmhFb1)_