### PR TITLE
Fix contact-row expand/collapse (Alpine sibling-scope) + Expand/Collapse-all

### DIFF
--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1044,13 +1044,17 @@ Alpine.data('resizableModal', () => ({
 Alpine.data('contactsView', () => ({
   q: '',
   siteFilter: '',
+  // Label state for the Expand/Collapse-all toggle. The actual per-row `open` state
+  // lives on each <tbody data-contact-row>; the toggle drives them via window events.
+  allOpen: false,
   init() {
     // Pre-select site filter when the tab was opened via a "View N contacts →" link.
     const initialSite = this.$root.getAttribute('data-initial-site');
     if (initialSite) this.siteFilter = initialSite;
     this.apply();
-    // Re-filter after a CRUD swap replaces the inner #contacts-tab-list rows.
-    this._onSettle = () => this.apply();
+    // Re-filter after a CRUD swap replaces the inner #contacts-tab-list rows. The
+    // fresh rows render collapsed, so reset the toggle label to match.
+    this._onSettle = () => { this.allOpen = false; this.apply(); };
     this.$root.addEventListener('htmx:afterSettle', this._onSettle);
   },
   destroy() {

--- a/app/templates/htmx/partials/customers/_contact_macros.html
+++ b/app/templates/htmx/partials/customers/_contact_macros.html
@@ -115,7 +115,9 @@
                    reports-to · LinkedIn · management actions (kebab)
 
    Clock honesty: NULL last_outbound_at → "—"  (NEVER "never replied").
-   Alpine: x-data='{open:false}' on the outer <tr> wrapper (single-quoted attr).
+   Alpine: the `open` drawer state is owned by the enclosing <tbody data-contact-row>
+   (see _contacts_grouped_list.html) because the summary row and the drawer row are
+   siblings — a <tr>-local x-data would not reach the sibling drawer.
 #}
 {% if legacy %}
   {# ── Legacy site-level row ─────────────────────────────────────── #}
@@ -123,7 +125,7 @@
   {% set _ltitle = site.contact_title or '' %}
   {% set _lphone = site.contact_phone %}
   {% set _lemail = site.contact_email %}
-  <tr x-data='{open:false}' class='group cursor-pointer' @click='open=!open'>
+  <tr class='group cursor-pointer' @click='open=!open'>
     <td class='td-label font-medium text-gray-900 whitespace-nowrap'>
       <span class='flex items-center gap-1'>
         {{ _lname }}
@@ -227,7 +229,7 @@
     'operations':     'bg-gray-100 text-gray-600'
   } %}
 
-  <tr x-data='{open:false}' class='group cursor-pointer' @click='open=!open'>
+  <tr class='group cursor-pointer' @click='open=!open'>
     {# Name cell — name · primary star · role chip · status badges #}
     <td class='td-label'>
       <div class='flex items-center gap-1.5 min-w-0'>

--- a/app/templates/htmx/partials/customers/tabs/_contacts_grouped_list.html
+++ b/app/templates/htmx/partials/customers/tabs/_contacts_grouped_list.html
@@ -90,10 +90,19 @@
              classList.toggle('hidden') on the data-contact-row element.
              Multiple <tbody> per table is valid HTML5.
              data-contact-search must be lowercase (JS does .includes(needle) on it).
-             data-site-id enables the per-site dropdown filter. #}
+             data-site-id enables the per-site dropdown filter.
+
+             x-data='{open:false}' lives HERE (not on the inner <tr>) because the
+             contact_row macro emits the summary row and the detail-drawer row as two
+             SIBLING <tr>s — Alpine scope reaches descendants, not siblings, so `open`
+             must be owned by the element that contains BOTH. @expand-all/@collapse-all
+             window events let the toolbar's Expand/Collapse-all toggle drive every row. #}
           {% for row in sorted_rows %}
             {% set _cname = (row.contact.full_name if row.contact else row.site.contact_name) or '' %}
             <tbody data-contact-row
+                   x-data="{open:false}"
+                   @expand-all.window="open=true"
+                   @collapse-all.window="open=false"
                    data-site-id="{{ grp_site.id if grp_site else 0 }}"
                    data-contact-search="{{ _cname | lower }}">
               {{ contact_row(company, row.contact, row.site, row.legacy, now_utc, row.cadence if not row.legacy else 'new', _roles, row.recent_note) }}

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -61,6 +61,13 @@
         {% endif %}
       </div>
       <div class="flex items-center gap-2 flex-shrink-0">
+        {# Expand / collapse every contact's detail drawer at once. Dispatches window
+           events the per-row <tbody> listens for (@expand-all / @collapse-all). #}
+        <button type="button"
+                @click="allOpen = !allOpen; $dispatch(allOpen ? 'expand-all' : 'collapse-all')"
+                class="btn-secondary btn-sm"
+                :aria-pressed="allOpen ? 'true' : 'false'"
+                x-text="allOpen ? 'Collapse all' : 'Expand all'">Expand all</button>
         {# "Find contacts" — only shown when a domain/website is available #}
         {% set company_domain = company.domain or company.website %}
         {% if company_domain %}


### PR DESCRIPTION
## What
The contact-row drawer never expanded (chevron rotated but nothing opened) because the drawer `<tr>` was a *sibling* of the `x-data` row — Alpine scope reaches descendants, not siblings, so `open` never reached the drawer. Broken since the per-row expand landed (2026-06-24).

- Hoist `x-data="{open:false}"` onto the `<tbody data-contact-row>` that wraps both the summary row and the drawer.
- Add an **Expand-all / Collapse-all** toolbar toggle (dispatches `@expand-all`/`@collapse-all` window events each `<tbody>` listens for).

Verified end-to-end with a headless browser: per-row chevron and name-cell open only that row; expand-all/collapse-all open/close all with the label flipping; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)