### PR TITLE
Repair 4 functionality-sim defects (form reset, auto-select, typeahead)

### DIFF
--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -12,8 +12,7 @@
    height cap). autoSelectFirst loads the first account into the detail pane on mount
    when nothing is selected. #}
 <div id="cdm-workspace" class="flex flex-col"
-     x-data="{ selectedId: null, autoSelectFirst() { if (this.selectedId !== null) return; const detail = this.$el.querySelector('#cdm-detail'); if (!detail || !detail.querySelector('[data-cdm-empty]')) return; const first = this.$el.querySelector('#cdm-list [role=\'button\'][hx-get]'); if (first) first.click() } }"
-     x-init="$nextTick(() => autoSelectFirst())">
+     x-data="{ selectedId: {{ companies[0].id if companies else 'null' }} }">
 
   {# List-refresh hook — the create/edit-account modals fire HX-Trigger=cdmListRefresh on
      success; this hidden element reloads the left account list (honoring the live filters)
@@ -246,9 +245,21 @@
          @keydown.left.prevent="leftWidth = Math.max(20, leftWidth - 2); localStorage.setItem('avail_split_cdm', leftWidth)"
          @keydown.right.prevent="leftWidth = Math.min(70, leftWidth + 2); localStorage.setItem('avail_split_cdm', leftWidth)"></div>
 
-    {# Right panel: account detail #}
+    {# Right panel: account detail. When the workspace has accounts, deterministically
+       auto-load the first one on mount via an htmx load trigger (fires reliably after
+       htmx processes the swapped-in content — no Alpine x-init/htmx-binding race). The
+       row's selectedId is pre-set in the x-data above so it highlights to match. #}
     <div id="cdm-detail" class="w-full md:w-auto md:flex-1 bg-white min-w-0 p-4">
+      {% if companies %}
+      <div hx-get="/v2/partials/customers/{{ companies[0].id }}"
+           hx-trigger="load"
+           hx-target="#cdm-detail"
+           hx-swap="innerHTML">
+        {% include "htmx/partials/customers/_detail_empty.html" %}
+      </div>
+      {% else %}
       {% include "htmx/partials/customers/_detail_empty.html" %}
+      {% endif %}
     </div>
 
   </div>

--- a/app/templates/htmx/partials/customers/tabs/sites_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/sites_tab.html
@@ -26,7 +26,7 @@
           hx-target="#sites-list"
           hx-swap="beforeend"
           data-loading-disable
-          @htmx:after-request="if(event.detail.successful) { this.reset(); showForm = false }"
+          @htmx:after-request="if(event.detail.successful) { $el.reset(); showForm = false }"
           class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4 p-3 bg-gray-50 rounded-lg border border-gray-200">
       <input aria-label="Site Name" type="text" name="site_name" required placeholder="Site Name"
              class="px-2 py-1.5 text-sm border border-gray-300 rounded input-focus">

--- a/app/templates/htmx/partials/manufacturers/search_results.html
+++ b/app/templates/htmx/partials/manufacturers/search_results.html
@@ -22,12 +22,16 @@
   {% endfor %}
 {% elif q %}
   <div class="px-3 py-1.5 text-xs text-gray-400">No match for "{{ q }}"</div>
+  {# q|tojson emits wrapping double-quotes that would close a double-quoted onclick attr
+     (breaking the whole handler — 'Unexpected token }'), so stash it in a single-quoted
+     data- attr and JSON.parse it in the handler — the same pattern the match rows use. #}
   <div class="px-3 py-1.5 text-xs text-brand-600 hover:bg-brand-50 cursor-pointer transition-colors"
        hx-post="/v2/partials/manufacturers/add"
-       hx-vals='{"name": "{{ q }}"}'
+       hx-vals='{"name": {{ q|tojson }}}'
        hx-swap="outerHTML"
        data-loading-disable
-       onclick="var self=this, qVal={{ q|tojson }}; setTimeout(function(){ {{ mfr_picker_apply('self', 'qVal') }} }, 100)">
+       data-mfr-q='{{ q|tojson }}'
+       onclick="var self=this, qVal=JSON.parse(this.dataset.mfrQ); setTimeout(function(){ {{ mfr_picker_apply('self', 'qVal') }} }, 100)">
     + Add "{{ q }}" as new manufacturer
   </div>
 {% else %}

--- a/app/templates/htmx/partials/vendors/tabs/contacts.html
+++ b/app/templates/htmx/partials/vendors/tabs/contacts.html
@@ -24,7 +24,7 @@
           hx-target="#contacts-table-body"
           hx-swap="beforeend"
           data-loading-disable
-          @htmx:after-request="if(event.detail.successful) { this.reset(); showForm = false; Alpine.store('toast').message='Contact added'; Alpine.store('toast').type='success'; Alpine.store('toast').show=true; }"
+          @htmx:after-request="if(event.detail.successful) { $el.reset(); showForm = false; Alpine.store('toast').message='Contact added'; Alpine.store('toast').type='success'; Alpine.store('toast').show=true; }"
           class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4 p-3 bg-brand-50 rounded-lg border border-brand-200">
       <input aria-label="Contact email" type="email" name="email" required placeholder="email@vendor.com"
              class="px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500">

--- a/tests/test_crm_sim_defect_fixes.py
+++ b/tests/test_crm_sim_defect_fixes.py
@@ -1,0 +1,75 @@
+"""Regression guards for the 4 functionality-sim defects (2026-07-20).
+
+D1/D2: Alpine @htmx:after-request must reset the form via $el.reset(), not
+       this.reset() (this = component scope, not the form -> TypeError).
+D3:    /v2/customers must deterministically auto-load the first account's detail
+       via an htmx load trigger (not a racy Alpine x-init click).
+D4:    the manufacturer "add new" typeahead option must read q from a single-quoted
+       data- attr, never inline {{ q|tojson }} into the double-quoted onclick
+       (tojson's quotes close the attribute -> 'Unexpected token }').
+"""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import Company, User
+
+TPL = Path("app/templates/htmx/partials")
+
+
+class TestFormResetHandlers:
+    """D1 + D2: the @htmx (Alpine) reset handlers use $el.reset(), never
+    this.reset()."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "customers/tabs/sites_tab.html",
+            "vendors/tabs/contacts.html",
+        ],
+    )
+    def test_alpine_reset_uses_el_not_this(self, path):
+        src = (TPL / path).read_text()
+        assert "@htmx:after-request" in src
+        # The Alpine binding must not call this.reset() (fails silently, form never closes).
+        assert "this.reset()" not in src, f"{path}: Alpine @htmx handler still uses this.reset()"
+        assert "$el.reset()" in src, f"{path}: expected $el.reset() in the Alpine reset handler"
+
+
+class TestManufacturerAddNewOnclick:
+    """D4: the add-new option must not inline q|tojson into the double-quoted onclick."""
+
+    def test_add_new_reads_q_from_data_attr(self):
+        src = (TPL / "manufacturers/search_results.html").read_text()
+        # The safe pattern: single-quoted data attr + JSON.parse in the handler.
+        assert "data-mfr-q='{{ q|tojson }}'" in src
+        assert "JSON.parse(this.dataset.mfrQ)" in src
+        # The broken pattern (tojson inlined into the onclick) must be gone.
+        assert "qVal={{ q|tojson }}" not in src
+
+    def test_add_new_option_renders_wellformed(self, client, db_session: Session, test_user: User):
+        resp = client.get("/v2/partials/manufacturers/search?q=Zephyr%20Semi")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "as new manufacturer" in body
+        assert "JSON.parse(this.dataset.mfrQ)" in body
+        # No attribute-breaking bare quote: the literal onclick with an inlined "Zephyr..." must not appear.
+        assert 'qVal="Zephyr' not in body
+
+
+class TestCustomersAutoLoadFirstAccount:
+    """D3: the detail pane auto-loads the first account via an htmx load trigger."""
+
+    def test_detail_pane_has_load_trigger_when_companies_exist(self, client, db_session: Session, test_user: User):
+        company = Company(name="AutoLoad Co", is_active=True, account_owner_id=test_user.id)
+        db_session.add(company)
+        db_session.commit()
+
+        resp = client.get("/v2/partials/customers")
+        assert resp.status_code == 200
+        body = resp.text
+        # The #cdm-detail loader must target the detail with a deterministic load trigger.
+        assert 'hx-trigger="load"' in body
+        assert f"/v2/partials/customers/{company.id}" in body

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -4207,15 +4207,17 @@ class TestFullWidthContactsForwardLayout:
         assert "data-outreach-log" in html
 
     def test_workspace_auto_select_marker_present(self, client: TestClient, db_session: Session, test_user: User):
-        """The workspace auto-selects the first account over the untouched empty state
-        only — gated on the [data-cdm-empty] marker and a null selectedId."""
-        c = Company(name="AutoSelect Co", is_active=True)
+        """The workspace deterministically auto-loads the first account's detail on
+        mount via an htmx load trigger (replaced the racy Alpine autoSelectFirst) — the
+        [data-cdm-empty] placeholder stays inside the loader until it fires."""
+        c = Company(name="AutoSelect Co", is_active=True, account_owner_id=test_user.id)
         db_session.add(c)
         db_session.commit()
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
         html = resp.text
-        assert "autoSelectFirst" in html
+        assert 'hx-trigger="load"' in html
+        assert f"/v2/partials/customers/{c.id}" in html
         assert "data-cdm-empty" in html
 
     def test_vendor_detail_drops_max_width_cap(self, client: TestClient, db_session: Session, test_user: User):


### PR DESCRIPTION
## What
Four functional defects found by the browser-driven functionality simulation, each re-verified live + covered by 5 regression tests.

- **D1/D2** — vendor add-contact & add-site forms: Alpine `@htmx:after-request` called `this.reset()` (in an Alpine binding `this` is the component, not the form) → threw, form never closed, no toast. Use `$el.reset()`.
- **D3** — customers workspace didn't auto-load the first account (racy Alpine `x-init` click). Replaced with a deterministic htmx `load` trigger + pre-set row highlight.
- **D4** — requisition "add new manufacturer" typeahead threw `Unexpected token }` (tojson inlined into a double-quoted onclick). Read `q` from a single-quoted `data-` attr via `JSON.parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)