### PR TITLE
Wave 1: gate 23 ungated CRM read endpoints (authz/IDOR hardening)

### DIFF
--- a/app/routers/crm/companies.py
+++ b/app/routers/crm/companies.py
@@ -12,7 +12,7 @@ from ...cache.decorators import cached_endpoint, invalidate_prefix
 from ...config import settings
 from ...constants import RequisitionStatus
 from ...database import get_db
-from ...dependencies import can_manage_account, require_user
+from ...dependencies import can_manage_account, is_manager_or_admin, require_user
 from ...models import Company, CustomerSite, Requisition, User
 from ...schemas.crm import CompanyCreate, CompanyUpdate
 from ...services.credential_service import get_credential_cached
@@ -102,8 +102,16 @@ async def list_companies(
     @cached_endpoint(
         prefix="company_list", ttl_hours=0.5, key_params=["search", "owner_id", "unassigned", "tag", "limit", "offset"]
     )
-    def _fetch(search, owner_id, unassigned, tag, limit, offset, db):
+    def _fetch(search, owner_id, unassigned, tag, limit, offset, db, user):
         query = db.query(Company).filter(Company.is_active.is_(True)).options(joinedload(Company.account_owner))
+        # Rep-scoped visibility: non-managers see only accounts they own or collaborate on
+        # (mirrors the /v2/contacts list + cdm_company_query). Managers/admins see all.
+        # `user` is a real _fetch param (not a closure) so @cached_endpoint folds user.id
+        # into the cache key and reps never receive each other's scoped result set.
+        from ...services.crm_service import company_visibility_predicate
+
+        if not is_manager_or_admin(user):
+            query = query.filter(company_visibility_predicate(user))
         if search.strip():
             sb = SearchBuilder(search.strip())
             query = query.filter(sb.ilike_filter(Company.name))
@@ -189,6 +197,7 @@ async def list_companies(
         limit=limit,
         offset=offset,
         db=db,
+        user=user,
     )
 
 
@@ -229,6 +238,9 @@ async def get_company(
         .first()
     )
     if not company:
+        raise HTTPException(404, "Company not found")
+    # Match company_detail_partial: out-of-scope accounts are indistinguishable from missing.
+    if not can_manage_account(user, company, db):
         raise HTTPException(404, "Company not found")
 
     @cached_endpoint(prefix="company_detail", ttl_hours=1, key_params=["company_id"])

--- a/app/routers/crm/enrichment.py
+++ b/app/routers/crm/enrichment.py
@@ -257,7 +257,7 @@ async def enrich_vendor_card(
     card_id: int,
     request: Request,
     payload: EnrichDomainRequest = EnrichDomainRequest(),
-    user: User = Depends(require_user),
+    user: User = Depends(require_buyer),
     db: Session = Depends(get_db),
 ):
     """Enrich a vendor card with external data.
@@ -302,7 +302,7 @@ async def get_suggested_contacts(
     domain: str = "",
     name: str = "",
     title: str = "",
-    user: User = Depends(require_user),
+    user: User = Depends(require_buyer),
     db: Session = Depends(get_db),
 ):
     """Find suggested contacts at a company from enrichment providers."""

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -14,7 +14,13 @@ from ...constants import (
     UserRole,
 )
 from ...database import get_db
-from ...dependencies import require_access, require_buyer, require_requisition_access, require_user
+from ...dependencies import (
+    is_manager_or_admin,
+    require_access,
+    require_buyer,
+    require_requisition_access,
+    require_user,
+)
 from ...models import (
     ActivityLog,
     ChangeLog,
@@ -779,6 +785,24 @@ async def get_changelog(
     """Fetch change history for an entity."""
     if entity_type not in ("offer", "requirement", "requisition"):
         raise HTTPException(400, "Invalid entity_type")
+    from ...models import Requisition
+
+    # Gate on the owning requisition so change history (which may include pricing,
+    # terms and PII) isn't readable across requisitions by restricted roles.
+    if entity_type == "offer":
+        offer = db.get(Offer, entity_id)
+        if not offer:
+            raise HTTPException(404, "Not found")
+        require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
+    elif entity_type == "requirement":
+        requirement = db.get(Requirement, entity_id)
+        if not requirement:
+            raise HTTPException(404, "Not found")
+        require_requisition_access(db, requirement.requisition_id, user, label="Requirement")
+    else:
+        if db.get(Requisition, entity_id) is None:
+            raise HTTPException(404, "Not found")
+        require_requisition_access(db, entity_id, user, label="Requisition")
     rows = (
         db.query(ChangeLog)
         .filter(ChangeLog.entity_type == entity_type, ChangeLog.entity_id == entity_id)
@@ -816,6 +840,7 @@ async def list_offer_attachments(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     return attachment_service.attachment_list_response(
         request, kind="offer", entity_id=offer_id, rows=offer.attachments
     )
@@ -952,6 +977,8 @@ async def list_review_queue(
     Called by: frontend review queue panel
     Depends on: Offer model with evidence_tier column
     """
+    if not is_manager_or_admin(user):
+        raise HTTPException(403, "Forbidden")
     offers = (
         db.query(Offer)
         .filter(

--- a/app/routers/htmx/companies/contacts.py
+++ b/app/routers/htmx/companies/contacts.py
@@ -547,6 +547,11 @@ async def contacts_tab_add_form(
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
         raise HTTPException(404, "Company not found")
+    # 404 (not 403) to match contact_edit_form_company_scoped: this form leaks the
+    # company/site roster and the full user list, so out-of-scope accounts must be
+    # indistinguishable from missing ones.
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
 
     active_sites = (
         db.query(CustomerSite)
@@ -810,6 +815,11 @@ async def contacts_tab_suggested(
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
         raise HTTPException(404, "Company not found")
+    # 404 (not 403) to match contact_edit_form_company_scoped: this trigger spends paid
+    # enrichment credits and returns contact PII, so gate it to account managers and keep
+    # out-of-scope accounts indistinguishable from missing ones.
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
 
     if not domain:
         domain = company.domain or company.website or ""
@@ -854,6 +864,11 @@ async def contacts_tab_suggested_status(
     if not company:
         # Polling sub-resource: htmx neither swaps nor cancels an `every 2s` poll on a 4xx,
         # so a 404 would leave the panel hammering this route. 286 stops it; empty clears it.
+        return HTMLResponse("", status_code=286)
+    if not can_manage_account(user, company, db):
+        # Out-of-scope poller: this route streams discovered contact PII. Deny by stopping
+        # the poll with an empty body — indistinguishable from a missing/consumed run (286),
+        # never leaking whether a run exists for someone else's account.
         return HTMLResponse("", status_code=286)
 
     if contact_discovery_runs.is_running(company_id):
@@ -1042,6 +1057,11 @@ async def contact_field_edit_form(
     )
     if not contact:
         raise HTTPException(404, "Contact not found")
+    company = db.get(Company, company_id)
+    # 404 (not 403) to match contact_edit_form_company_scoped: this widget leaks the
+    # contact field value, so out-of-scope accounts must be indistinguishable from missing.
+    if company is None or not can_manage_account(user, company, db):
+        raise HTTPException(404, "Contact not found")
     meta = EDITABLE_CONTACT_FIELDS[field]
     extra: dict = {}
     return template_response(
@@ -1081,6 +1101,11 @@ async def contact_field_display(
         .first()
     )
     if not contact:
+        raise HTTPException(404, "Contact not found")
+    company = db.get(Company, company_id)
+    # 404 (not 403) to match contact_edit_form_company_scoped: this span leaks the
+    # contact field value, so out-of-scope accounts must be indistinguishable from missing.
+    if company is None or not can_manage_account(user, company, db):
         raise HTTPException(404, "Contact not found")
     meta = EDITABLE_CONTACT_FIELDS[field]
     return template_response(
@@ -1425,7 +1450,12 @@ async def contact_files_modal(
     if not contact:
         raise HTTPException(404, "Contact not found")
     site = db.get(CustomerSite, contact.customer_site_id)
-    if not site or not db.get(Company, site.company_id):
+    company = db.get(Company, site.company_id) if site else None
+    if not site or company is None:
+        raise HTTPException(404, "Contact not found")
+    # 404 (not 403) to match contact_edit_form_company_scoped: this modal shell leaks
+    # contact PII, so out-of-scope accounts must be indistinguishable from missing.
+    if not can_manage_account(user, company, db):
         raise HTTPException(404, "Contact not found")
     return template_response(
         "htmx/partials/customers/_contact_files_modal.html",
@@ -1495,8 +1525,13 @@ async def contact_notes_modal(
     company = db.get(Company, company_id)
     if not company:
         raise HTTPException(404, "Company not found")
+    # 404 (not 403) to match contact_edit_form_company_scoped: the notes feed is contact
+    # PII, so out-of-scope accounts must be indistinguishable from missing. can_manage_account
+    # was previously only a display flag, leaving the feed readable cross-tenant.
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
     contact = _contact_under_company(db, company_id, contact_id)
-    return _render_contact_notes_modal(request, company, contact, db, can_manage=can_manage_account(user, company, db))
+    return _render_contact_notes_modal(request, company, contact, db, can_manage=True)
 
 
 @router.get(
@@ -1517,6 +1552,10 @@ async def contact_history_modal(
     """
     company = db.get(Company, company_id)
     if not company:
+        raise HTTPException(404, "Company not found")
+    # 404 (not 403) to match contact_edit_form_company_scoped: field-change history holds
+    # old/new contact PII, so out-of-scope accounts must be indistinguishable from missing.
+    if not can_manage_account(user, company, db):
         raise HTTPException(404, "Company not found")
     contact = _contact_under_company(db, company_id, contact_id)
     history = field_history_for(db, ENTITY_CONTACT, contact.id)

--- a/app/routers/htmx/companies/core.py
+++ b/app/routers/htmx/companies/core.py
@@ -810,6 +810,8 @@ async def company_dup_suggestion(
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
 
     # Scan, then pick the highest-scoring pair that INVOLVES this company. The scanner
     # already honors the auto_keep heuristic; here we only need the OTHER side as the
@@ -853,6 +855,8 @@ async def company_name_suggestion(
     """
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
+        raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
         raise HTTPException(404, "Company not found")
 
     suggested = suggest_clean_company_name(company.name or "")
@@ -1165,6 +1169,8 @@ async def company_edit_form(
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
     users = (
         db.query(User).filter(User.role.in_((UserRole.BUYER, UserRole.TRADER, UserRole.MANAGER, UserRole.ADMIN))).all()
     )
@@ -1280,6 +1286,8 @@ async def company_field_edit_form(
     company = db.get(Company, company_id)
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
     meta = EDITABLE_ACCOUNT_FIELDS[field]
     return template_response(
         "htmx/partials/customers/_field_edit.html",
@@ -1311,6 +1319,8 @@ async def company_field_display(
         raise HTTPException(404, f"Unknown editable field: {field!r}")
     company = db.get(Company, company_id)
     if not company:
+        raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
         raise HTTPException(404, "Company not found")
     meta = EDITABLE_ACCOUNT_FIELDS[field]
     return template_response(

--- a/app/routers/htmx/companies/sites.py
+++ b/app/routers/htmx/companies/sites.py
@@ -173,6 +173,8 @@ async def site_contacts_list(
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
     return _render_contacts_list(request, user, company, db)
 
 
@@ -349,6 +351,9 @@ async def site_edit_form(
     """Return modal edit form for a customer site."""
     site = db.query(CustomerSite).filter(CustomerSite.id == site_id, CustomerSite.company_id == company_id).first()
     if not site:
+        raise HTTPException(404, "Site not found")
+    company = db.get(Company, company_id)
+    if company is None or not can_manage_account(user, company, db):
         raise HTTPException(404, "Site not found")
     users = db.query(User).order_by(User.name).all()
     return template_response(

--- a/app/routers/htmx/companies/tags.py
+++ b/app/routers/htmx/companies/tags.py
@@ -39,6 +39,8 @@ async def company_segment_tags_partial(
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")
     tags = list_company_segment_tags(company_id=company_id, db=db)
     all_segment_tags = list_all_segment_tags(db=db)
     return template_response(

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -3087,6 +3087,25 @@ rep's requisition name/customer/MPNs/vendor contacts by crafting a direct GET. E
 isn't leaked), matching their mutating siblings in the same submodule. Regression coverage:
 `tests/test_authz_offers_partials_idor.py`.
 
+**Read-IDOR closure — CRM read endpoints (Wave 1, `fix/crm-authz-wave1`).** A module-wide sweep
+found 23 CRM GET/read endpoints returning scoped data (contact/company/site PII, financials) with
+only `require_user` while their mutating peers gated. Each now gates: the company/site/contact
+read partials (`company_edit_form`, `company_field_edit_form`/`_display`, `company_dup_suggestion`,
+`company_name_suggestion` in core.py; `site_contacts_list`, `site_edit_form` in sites.py;
+`contacts_tab_add_form`, `contact_field_edit_form`/`_display`, `contact_notes_modal`,
+`contact_history_modal`, `contact_files_modal`, and the `suggested-contacts` trigger/status in
+contacts.py; `company_segment_tags_partial` in tags.py) load the owning `Company` and
+`can_manage_account(user, company, db)` → **404** (matching `company_detail_partial`; the
+suggested-contacts *poller* returns an empty `286` to stop polling instead). The JSON API
+`GET /api/companies/{id}` → 404 via `can_manage_account`; `GET /api/companies` list filters on
+`company_visibility_predicate` for non-managers (and threads `user` into the cached `_fetch` so
+`@cached_endpoint` folds `user.id` into the key — no cross-rep cache bleed); `crm/offers.py`
+`get_changelog`/`list_offer_attachments` require `require_requisition_access`, `list_review_queue`
+is `is_manager_or_admin`-only; `crm/enrichment.py` `enrich_vendor_card`/`get_suggested_contacts`
+require `require_buyer`. Managers/admins bypass throughout. Regression coverage: seven new
+`tests/test_*_idor.py` / `test_enrichment_authz.py` modules (stranger 404/403/286 + owner 200 with
+content asserts).
+
 **Disposition (Increment 1, migration 118).** Salespeople dispose of accounts +
 contacts via setter routes in `htmx_views.py` (all owner-or-admin where they touch
 ownership/disposition; `is_admin = user.role == UserRole.ADMIN`, mirroring

--- a/tests/test_company_api_idor.py
+++ b/tests/test_company_api_idor.py
@@ -1,0 +1,160 @@
+"""tests/test_company_api_idor.py — Cross-tenant IDOR regression guard for the JSON
+companies API.
+
+Mirrors tests/test_site_contact_idor.py.
+
+Guards:
+  - GET /api/companies/{id}  must 404 for an unrelated rep, 200 for the owner.
+  - GET /api/companies (list) must NOT leak an out-of-scope company to an unrelated
+    rep (rep-scoped visibility), while the owner still sees it.
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, db_session, test_user), app.main, app.dependencies
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.auth import User
+from app.models.crm import Company, CustomerSite, SiteContact
+
+# ── shared fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owned_company(db_session: Session, test_user: User) -> Company:
+    """A company owned by test_user, carrying PII the API would leak."""
+    co = Company(
+        name="Owned Corp API IDOR",
+        is_active=True,
+        account_owner_id=test_user.id,
+        notes="private account notes",
+        tax_id="SECRET-TAX-99",
+        credit_terms="NET-30 confidential",
+        phone="+1-555-0100",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+@pytest.fixture()
+def owned_site(db_session: Session, owned_company: Company) -> CustomerSite:
+    site = CustomerSite(
+        company_id=owned_company.id,
+        site_name="Owner HQ",
+        is_active=True,
+    )
+    db_session.add(site)
+    db_session.commit()
+    db_session.refresh(site)
+    return site
+
+
+@pytest.fixture()
+def owned_contact(db_session: Session, owned_site: CustomerSite) -> SiteContact:
+    contact = SiteContact(
+        customer_site_id=owned_site.id,
+        full_name="Alice Owner",
+        first_name="Alice",
+        last_name="Owner",
+        email="alice@owned-corp.com",
+    )
+    db_session.add(contact)
+    db_session.commit()
+    db_session.refresh(contact)
+    return contact
+
+
+@pytest.fixture()
+def unrelated_client(db_session: Session) -> TestClient:
+    """TestClient authenticated as a buyer who owns NO companies/sites."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    stranger = User(
+        email="stranger_company_idor@example.com",
+        name="Stranger Company IDOR",
+        role="buyer",
+        azure_id="stranger-azure-company-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(stranger)
+    db_session.commit()
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: stranger
+    app.dependency_overrides[require_admin] = lambda: stranger
+    app.dependency_overrides[require_buyer] = lambda: stranger
+    app.dependency_overrides[require_fresh_token] = lambda: "mock-token"
+
+    with TestClient(app) as c:
+        yield c
+
+    for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
+        app.dependency_overrides.pop(dep, None)
+
+
+# ── GET /api/companies/{id} — detail leak ────────────────────────────────────
+
+
+class TestGetCompanyIDOR:
+    """get_company must 404 an out-of-scope account (indistinguishable from missing)."""
+
+    def test_unrelated_rep_gets_404(
+        self,
+        unrelated_client: TestClient,
+        owned_company: Company,
+        owned_site: CustomerSite,
+        owned_contact: SiteContact,
+    ):
+        resp = unrelated_client.get(f"/api/companies/{owned_company.id}")
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(
+        self,
+        client: TestClient,
+        owned_company: Company,
+        owned_site: CustomerSite,
+        owned_contact: SiteContact,
+    ):
+        resp = client.get(f"/api/companies/{owned_company.id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == owned_company.id
+        assert body["tax_id"] == "SECRET-TAX-99"
+
+
+# ── GET /api/companies — list leak ───────────────────────────────────────────
+
+
+class TestListCompaniesIDOR:
+    """list_companies must scope to rep-visible accounts for non-managers."""
+
+    def test_unrelated_rep_cannot_see_company(
+        self,
+        unrelated_client: TestClient,
+        owned_company: Company,
+    ):
+        resp = unrelated_client.get("/api/companies")
+        assert resp.status_code == 200
+        ids = [item["id"] for item in resp.json()["items"]]
+        assert owned_company.id not in ids
+
+    def test_owner_sees_company(
+        self,
+        client: TestClient,
+        owned_company: Company,
+    ):
+        resp = client.get("/api/companies")
+        assert resp.status_code == 200
+        ids = [item["id"] for item in resp.json()["items"]]
+        assert owned_company.id in ids

--- a/tests/test_company_core_idor.py
+++ b/tests/test_company_core_idor.py
@@ -1,0 +1,224 @@
+"""tests/test_company_core_idor.py — Cross-tenant IDOR guard for the company core read
+endpoints (app/routers/htmx/companies/core.py).
+
+Companion to tests/test_site_contact_idor.py. Each ungated GET read must reject a
+stranger (a buyer owning nothing) with 404 — matching company_detail_partial, so an
+out-of-scope account is indistinguishable from a missing one — while the account
+owner still gets 200.
+
+Covered endpoints:
+  - company_edit_form        GET /v2/partials/customers/{id}/edit-form
+  - company_field_edit_form  GET /v2/partials/customers/{id}/field/edit/{field}
+  - company_field_display    GET /v2/partials/customers/{id}/field/display/{field}
+  - company_dup_suggestion   GET /v2/partials/customers/{id}/dup-suggestion
+  - company_name_suggestion  GET /v2/partials/customers/{id}/name-suggestion
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, db_session, test_user), app.main.app,
+    app.dependencies
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.auth import User
+from app.models.crm import Company
+
+# A field guaranteed to be in EDITABLE_ACCOUNT_FIELDS and to carry sensitive PII.
+_PII_FIELD = "credit_terms"
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owned_company(db_session: Session, test_user: User) -> Company:
+    """A company owned by test_user (account_owner_id set), with sensitive fields."""
+    co = Company(
+        name="Owned Corp CoreIDOR",
+        is_active=True,
+        account_owner_id=test_user.id,
+        credit_terms="NET-30 SECRET",
+        tax_id="TAX-SECRET-001",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+@pytest.fixture()
+def unrelated_client(db_session: Session) -> TestClient:
+    """TestClient authenticated as a user who owns NO companies/sites."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    stranger = User(
+        email="stranger_core_idor@example.com",
+        name="Stranger Core IDOR",
+        role="buyer",
+        azure_id="stranger-azure-core-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(stranger)
+    db_session.commit()
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: stranger
+    app.dependency_overrides[require_admin] = lambda: stranger
+    app.dependency_overrides[require_buyer] = lambda: stranger
+    app.dependency_overrides[require_fresh_token] = lambda: "mock-token"
+
+    with TestClient(app) as c:
+        yield c
+
+    for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
+        app.dependency_overrides.pop(dep, None)
+
+
+# ── company_edit_form ─────────────────────────────────────────────────────────
+
+
+class TestCompanyEditFormIDOR:
+    """GET .../edit-form must not leak credit_terms/tax_id + rosters to strangers."""
+
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_company: Company):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/edit-form",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_company: Company):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/edit-form",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner sees the credit_terms value the stranger's 404 hid.
+        assert "NET-30 SECRET" in resp.text
+
+
+# ── company_field_edit_form ───────────────────────────────────────────────────
+
+
+class TestCompanyFieldEditFormIDOR:
+    """GET .../field/edit/{field} must not render another account's field widget."""
+
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_company: Company):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/field/edit/{_PII_FIELD}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_company: Company):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/field/edit/{_PII_FIELD}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner's edit widget is pre-filled with the value the stranger was denied.
+        assert "NET-30 SECRET" in resp.text
+
+
+# ── company_field_display ─────────────────────────────────────────────────────
+
+
+class TestCompanyFieldDisplayIDOR:
+    """GET .../field/display/{field} must not return another account's field value."""
+
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_company: Company):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/field/display/{_PII_FIELD}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_company: Company):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/field/display/{_PII_FIELD}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner's display span shows the field value the stranger's 404 hid.
+        assert "NET-30 SECRET" in resp.text
+
+
+# ── company_dup_suggestion ────────────────────────────────────────────────────
+
+
+class TestCompanyDupSuggestionIDOR:
+    """GET .../dup-suggestion must 404 (before the org-wide scan) for strangers."""
+
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_company: Company):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/dup-suggestion",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, db_session: Session, test_user: User):
+        # Seed two near-duplicate accounts the owner manages so the scan yields a match.
+        keeper = Company(
+            name="Acme Widgets Inc",
+            is_active=True,
+            account_owner_id=test_user.id,
+            created_at=datetime.now(UTC),
+        )
+        dup = Company(
+            name="Acme Widgets LLC",
+            is_active=True,
+            account_owner_id=test_user.id,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add_all([keeper, dup])
+        db_session.commit()
+        db_session.refresh(keeper)
+        resp = client.get(
+            f"/v2/partials/customers/{keeper.id}/dup-suggestion",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner receives the duplicate-account banner the stranger's 404 withheld.
+        assert "Possible duplicate account" in resp.text
+
+
+# ── company_name_suggestion ───────────────────────────────────────────────────
+
+
+class TestCompanyNameSuggestionIDOR:
+    """GET .../name-suggestion must not confirm existence / leak the name."""
+
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_company: Company):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/name-suggestion",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, db_session: Session, test_user: User):
+        # Seed an owned account whose name carries a legal suffix so a suggestion renders.
+        co = Company(
+            name="Suggestible Systems Inc",
+            is_active=True,
+            account_owner_id=test_user.id,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(co)
+        db_session.commit()
+        db_session.refresh(co)
+        resp = client.get(
+            f"/v2/partials/customers/{co.id}/name-suggestion",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner receives the suffix-stripped name suggestion the stranger's 404 withheld.
+        assert "Suggested name:" in resp.text
+        assert "Suggestible Systems" in resp.text

--- a/tests/test_company_segment_tags_idor.py
+++ b/tests/test_company_segment_tags_idor.py
@@ -1,0 +1,110 @@
+"""tests/test_company_segment_tags_idor.py — Cross-tenant IDOR regression guard.
+
+company_segment_tags_partial (GET /v2/partials/customers/{company_id}/segment-tags)
+must not leak a company's segment tags to an unrelated buyer. It must gate on
+can_manage_account like its POST/DELETE peers, returning 404 for out-of-scope
+companies (read convention: indistinguishable from missing).
+
+Called by: pytest
+Depends on: conftest.py fixtures, app.routers.htmx.companies.tags, app.dependencies
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.auth import User
+from app.models.crm import Company
+
+# ── shared fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owned_company(db_session: Session, test_user: User) -> Company:
+    """A company owned by test_user (account_owner_id set)."""
+    co = Company(
+        name="Owned Corp SegTags IDOR",
+        is_active=True,
+        account_owner_id=test_user.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+@pytest.fixture()
+def unrelated_client(db_session: Session) -> TestClient:
+    """TestClient authenticated as a user who owns NO companies/sites."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    stranger = User(
+        email="stranger_segtags_idor@example.com",
+        name="Stranger SegTags IDOR",
+        role="buyer",
+        azure_id="stranger-azure-segtags-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(stranger)
+    db_session.commit()
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: stranger
+    app.dependency_overrides[require_admin] = lambda: stranger
+    app.dependency_overrides[require_buyer] = lambda: stranger
+    app.dependency_overrides[require_fresh_token] = lambda: "mock-token"
+
+    with TestClient(app) as c:
+        yield c
+
+    for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
+        app.dependency_overrides.pop(dep, None)
+
+
+# ── company_segment_tags_partial ─────────────────────────────────────────────
+
+
+class TestCompanySegmentTagsPartialIDOR:
+    """company_segment_tags_partial must gate on can_manage_account."""
+
+    def test_unrelated_rep_gets_404(
+        self,
+        unrelated_client: TestClient,
+        owned_company: Company,
+    ):
+        """Unrelated rep reading another company's segment tags must get 404."""
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/segment-tags",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        owned_company: Company,
+    ):
+        """Account owner reading their own company's segment tags must get 200."""
+        # test_user IS already set as account_owner_id on owned_company via fixture.
+        # Seed a segment tag so the chip (denied to the stranger) actually renders.
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag
+
+        tag = get_or_create_segment_tag("Strategic-OEM", db_session)
+        assign_segment_tag(company_id=owned_company.id, tag_id=tag.id, db=db_session)
+        db_session.commit()
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/segment-tags",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner sees the segment tag the stranger's 404 hid.
+        assert "Strategic-OEM" in resp.text

--- a/tests/test_contact_fields.py
+++ b/tests/test_contact_fields.py
@@ -418,8 +418,12 @@ class TestContactInlineEdit:
 class TestContactFormOwnerSelect:
     """Phase 1 ownership cleanup: per-contact owner picker is removed from add/edit forms."""
 
-    def test_add_form_does_not_render_owner_picker(self, client: TestClient, test_company: Company, test_user: User):
+    def test_add_form_does_not_render_owner_picker(
+        self, client: TestClient, db_session: Session, test_company: Company, test_user: User
+    ):
         """Add-form GET must NOT contain contact_owner_id (picker removed)."""
+        test_company.account_owner_id = test_user.id  # owner passes can_manage_account gate
+        db_session.commit()
         resp = client.get(f"/v2/partials/customers/{test_company.id}/contacts/add-form")
         assert resp.status_code == 200
         assert "contact_owner_id" not in resp.text
@@ -437,8 +441,12 @@ class TestContactFormOwnerSelect:
         assert resp.status_code == 200
         assert "contact_owner_id" not in resp.text
 
-    def test_add_form_renders_first_last_inputs(self, client: TestClient, test_company: Company):
+    def test_add_form_renders_first_last_inputs(
+        self, client: TestClient, db_session: Session, test_company: Company, test_user: User
+    ):
         """Add form renders first_name and last_name inputs (not full_name)."""
+        test_company.account_owner_id = test_user.id  # owner passes can_manage_account gate
+        db_session.commit()
         resp = client.get(f"/v2/partials/customers/{test_company.id}/contacts/add-form")
         assert resp.status_code == 200
         # Template uses single-quoted attributes

--- a/tests/test_contacts_tab_idor.py
+++ b/tests/test_contacts_tab_idor.py
@@ -1,0 +1,273 @@
+"""tests/test_contacts_tab_idor.py — Cross-tenant IDOR regression guard for the
+Contacts-tab HTMX partials in app/routers/htmx/companies/contacts.py.
+
+Every endpoint below returns company/site/contact data (roster, field values, notes,
+change history, discovered-contact PII) and previously depended only on require_user.
+A stranger who owns nothing must be denied (404, or an empty 286 for the poller); the
+account owner must still get 200.
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, test_user, db_session), app.main.app,
+    app.dependencies, app.models.crm
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.auth import User
+from app.models.crm import Company, CustomerSite, SiteContact
+
+# ── shared fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owned_company(db_session: Session, test_user: User) -> Company:
+    """A company owned by test_user (account_owner_id set), with a domain so the
+    suggested-contacts trigger reaches its 200 path for the owner."""
+    co = Company(
+        name="Owned Corp Contacts IDOR",
+        is_active=True,
+        account_owner_id=test_user.id,
+        domain="owned-corp-idor.com",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+@pytest.fixture()
+def owned_site(db_session: Session, owned_company: Company) -> CustomerSite:
+    """An HQ site under owned_company."""
+    site = CustomerSite(
+        company_id=owned_company.id,
+        site_name="Owner HQ",
+        site_type="hq",
+        is_active=True,
+    )
+    db_session.add(site)
+    db_session.commit()
+    db_session.refresh(site)
+    return site
+
+
+@pytest.fixture()
+def owned_contact(db_session: Session, owned_site: CustomerSite) -> SiteContact:
+    """A contact under owned_site, with PII fields populated."""
+    contact = SiteContact(
+        customer_site_id=owned_site.id,
+        full_name="Alice Owner",
+        first_name="Alice",
+        last_name="Owner",
+        email="alice@owned-corp-idor.com",
+        is_active=True,
+    )
+    db_session.add(contact)
+    db_session.commit()
+    db_session.refresh(contact)
+    return contact
+
+
+@pytest.fixture()
+def unrelated_client(db_session: Session) -> TestClient:
+    """TestClient authenticated as a buyer who owns NO companies/sites."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    stranger = User(
+        email="stranger_contacts_idor@example.com",
+        name="Stranger Contacts IDOR",
+        role="buyer",
+        azure_id="stranger-azure-contacts-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(stranger)
+    db_session.commit()
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: stranger
+    app.dependency_overrides[require_admin] = lambda: stranger
+    app.dependency_overrides[require_buyer] = lambda: stranger
+    app.dependency_overrides[require_fresh_token] = lambda: "mock-token"
+
+    with TestClient(app) as c:
+        yield c
+
+    for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
+        app.dependency_overrides.pop(dep, None)
+
+
+HX = {"HX-Request": "true"}
+
+
+# ── contacts_tab_add_form ────────────────────────────────────────────────────
+
+
+class TestContactsTabAddFormIDOR:
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_company: Company):
+        resp = unrelated_client.get(f"/v2/partials/customers/{owned_company.id}/contacts/add-form", headers=HX)
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_company: Company, owned_site: CustomerSite):
+        resp = client.get(f"/v2/partials/customers/{owned_company.id}/contacts/add-form", headers=HX)
+        assert resp.status_code == 200
+        # The owner's add-form exposes the site roster (dropdown) the stranger's 404 hid.
+        assert "Owner HQ" in resp.text
+
+
+# ── contact_field_edit_form / contact_field_display ──────────────────────────
+
+
+class TestContactFieldFormsIDOR:
+    def test_edit_form_unrelated_rep_gets_404(
+        self, unrelated_client: TestClient, owned_company: Company, owned_contact: SiteContact
+    ):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/field/edit/email",
+            headers=HX,
+        )
+        assert resp.status_code == 404
+
+    def test_edit_form_owner_gets_200(self, client: TestClient, owned_company: Company, owned_contact: SiteContact):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/field/edit/email",
+            headers=HX,
+        )
+        assert resp.status_code == 200
+        # The owner's edit widget is pre-filled with the contact email the stranger was denied.
+        assert "alice@owned-corp-idor.com" in resp.text
+
+    def test_display_unrelated_rep_gets_404(
+        self, unrelated_client: TestClient, owned_company: Company, owned_contact: SiteContact
+    ):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/field/display/email",
+            headers=HX,
+        )
+        assert resp.status_code == 404
+
+    def test_display_owner_gets_200(self, client: TestClient, owned_company: Company, owned_contact: SiteContact):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/field/display/email",
+            headers=HX,
+        )
+        assert resp.status_code == 200
+        # The owner's display span shows the contact email the stranger's 404 hid.
+        assert "alice@owned-corp-idor.com" in resp.text
+
+
+# ── contact_notes_modal ──────────────────────────────────────────────────────
+
+
+class TestContactNotesModalIDOR:
+    def test_unrelated_rep_gets_404(
+        self, unrelated_client: TestClient, owned_company: Company, owned_contact: SiteContact
+    ):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/notes-modal",
+            headers=HX,
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_company: Company, owned_contact: SiteContact):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/notes-modal",
+            headers=HX,
+        )
+        assert resp.status_code == 200
+        # The owner's notes modal is headed by the contact identity the stranger's 404 hid.
+        assert "Alice Owner" in resp.text
+
+
+# ── contact_history_modal ────────────────────────────────────────────────────
+
+
+class TestContactHistoryModalIDOR:
+    def test_unrelated_rep_gets_404(
+        self, unrelated_client: TestClient, owned_company: Company, owned_contact: SiteContact
+    ):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/history-modal",
+            headers=HX,
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_company: Company, owned_contact: SiteContact):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/contacts/{owned_contact.id}/history-modal",
+            headers=HX,
+        )
+        assert resp.status_code == 200
+        # The owner's history modal is headed by the contact identity the stranger's 404 hid.
+        assert "Alice Owner" in resp.text
+
+
+# ── contact_files_modal (contact-scoped route, no company_id in path) ─────────
+
+
+class TestContactFilesModalIDOR:
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_contact: SiteContact):
+        resp = unrelated_client.get(f"/v2/partials/contacts/{owned_contact.id}/files-modal", headers=HX)
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_contact: SiteContact):
+        resp = client.get(f"/v2/partials/contacts/{owned_contact.id}/files-modal", headers=HX)
+        assert resp.status_code == 200
+        # The owner's files modal is headed by the contact identity the stranger's 404 hid.
+        assert "Alice Owner" in resp.text
+
+
+# ── suggested-contacts trigger (paid spend + PII) ────────────────────────────
+
+
+class TestSuggestedContactsTriggerIDOR:
+    def test_unrelated_rep_gets_404(self, unrelated_client: TestClient, owned_company: Company):
+        # Denied BEFORE any enrichment credits are enqueued.
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/suggested-contacts?domain=owned-corp-idor.com",
+            headers=HX,
+        )
+        assert resp.status_code == 404
+
+    def test_owner_gets_200(self, client: TestClient, owned_company: Company, monkeypatch: pytest.MonkeyPatch):
+        # Stub the discovery waterfall so the owner path never touches paid providers.
+        import app.routers.htmx.companies as pkg
+
+        async def _noop(company_id: int, domain: str, name: str) -> None:
+            return None
+
+        monkeypatch.setattr(pkg, "_run_contact_discovery", _noop)
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/suggested-contacts?domain=owned-corp-idor.com",
+            headers=HX,
+        )
+        assert resp.status_code == 200
+        # The owner receives the "finding contacts" poller (wired to this company's status
+        # route) that the stranger's 404 withheld.
+        assert f"/v2/partials/customers/{owned_company.id}/suggested-contacts/status" in resp.text
+
+
+# ── suggested-contacts status poller (streams discovered PII) ────────────────
+
+
+class TestSuggestedContactsStatusIDOR:
+    def test_unrelated_rep_denied_no_leak(self, unrelated_client: TestClient, owned_company: Company):
+        # Poller: denial stops the poll with an empty 286 body (never a 4xx that would
+        # leave htmx hammering, never any discovered-contact PII).
+        resp = unrelated_client.get(f"/v2/partials/customers/{owned_company.id}/suggested-contacts/status", headers=HX)
+        assert resp.status_code == 286
+        assert resp.text == ""
+
+    def test_owner_not_denied(self, client: TestClient, owned_company: Company):
+        # Owner is not denied: with no run in flight the poller returns its normal
+        # empty 286 (stop polling) rather than the cross-tenant empty response — the key
+        # assertion is that the owner is never blocked by the new gate.
+        resp = client.get(f"/v2/partials/customers/{owned_company.id}/suggested-contacts/status", headers=HX)
+        assert resp.status_code in (200, 286)

--- a/tests/test_crm_aiorg.py
+++ b/tests/test_crm_aiorg.py
@@ -198,9 +198,10 @@ class TestDataOpsReviewQueue:
 
 
 class TestDupSuggestionRoute:
-    def test_returns_merge_affordance_when_near_dup(self, client: TestClient, db_session: Session):
+    def test_returns_merge_affordance_when_near_dup(self, client: TestClient, db_session: Session, test_user: User):
         keep = _make_company(db_session, "Beta Corporation", sites=2)
         _make_company(db_session, "Beta Corp", sites=1)
+        keep.account_owner_id = test_user.id  # owner passes can_manage_account gate
         db_session.commit()
 
         resp = client.get(f"/v2/partials/customers/{keep.id}/dup-suggestion", headers={"HX-Request": "true"})
@@ -209,8 +210,9 @@ class TestDupSuggestionRoute:
         # Reuses the merge-form flow.
         assert "/merge-form" in resp.text or "merge-preview" in resp.text
 
-    def test_empty_when_no_dup(self, client: TestClient, db_session: Session):
+    def test_empty_when_no_dup(self, client: TestClient, db_session: Session, test_user: User):
         solo = _make_company(db_session, "Singular Unique Industries")
+        solo.account_owner_id = test_user.id  # owner passes can_manage_account gate
         db_session.commit()
         resp = client.get(f"/v2/partials/customers/{solo.id}/dup-suggestion", headers={"HX-Request": "true"})
         assert resp.status_code == 200
@@ -227,9 +229,10 @@ class TestDupSuggestionRoute:
 
 
 class TestNameSuggestionChip:
-    def test_surfaces_suggestion_for_suffix_heavy_name(self, client: TestClient, db_session: Session):
+    def test_surfaces_suggestion_for_suffix_heavy_name(self, client: TestClient, db_session: Session, test_user: User):
         # "Inc." is stripped but the rest of the (multi-word, display-cased) name is kept.
         c = _make_company(db_session, "Mouser Electronics, Inc.")
+        c.account_owner_id = test_user.id  # owner passes can_manage_account gate
         db_session.commit()
         resp = client.get(f"/v2/partials/customers/{c.id}/name-suggestion", headers={"HX-Request": "true"})
         assert resp.status_code == 200
@@ -237,8 +240,9 @@ class TestNameSuggestionChip:
         assert "Mouser Electronics" in resp.text
         assert f"/v2/partials/customers/{c.id}/apply-name" in resp.text
 
-    def test_empty_when_name_already_clean(self, client: TestClient, db_session: Session):
+    def test_empty_when_name_already_clean(self, client: TestClient, db_session: Session, test_user: User):
         c = _make_company(db_session, "Phoenix Trading")
+        c.account_owner_id = test_user.id  # owner passes can_manage_account gate
         db_session.commit()
         resp = client.get(f"/v2/partials/customers/{c.id}/name-suggestion", headers={"HX-Request": "true"})
         assert resp.status_code == 200

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -2394,7 +2394,7 @@ class TestEditSite:
 
     def test_get_site_edit_form_returns_200(self, client: TestClient, db_session: Session, test_user: User):
         """GET edit-form route renders a form pre-populated with site fields."""
-        company, site = self._make_company_with_site(db_session)
+        company, site = self._make_company_with_site(db_session, owner=test_user)
         resp = client.get(f"/v2/partials/customers/{company.id}/sites/{site.id}/edit-form")
         assert resp.status_code == 200
         assert "HQ" in resp.text
@@ -4395,6 +4395,7 @@ class TestCompanyPhase0FormFields:
         co = Company(
             name="EditFields Co",
             is_active=True,
+            account_owner_id=test_user.id,
             legal_name="EditFields Corporation",
             employee_size="51-200",
             revenue_range="$1M-$10M",
@@ -4431,6 +4432,7 @@ class TestCompanyPhase0FormFields:
         co = Company(
             name="Prefill Co",
             is_active=True,
+            account_owner_id=test_user.id,
             legal_name="Prefill Legal LLC",
             hq_city="Portland",
             credit_terms="Net 45",
@@ -5153,21 +5155,21 @@ class TestWS4AccountModalFields:
 
     def test_edit_form_renders_domain_input(self, client: TestClient, db_session: Session, test_user: User):
         """GET edit-form contains input[name=domain]."""
-        co = self._make_company(db_session)
+        co = self._make_company(db_session, account_owner_id=test_user.id)
         resp = client.get(f"/v2/partials/customers/{co.id}/edit-form")
         assert resp.status_code == 200
         assert 'name="domain"' in resp.text
 
     def test_edit_form_renders_linkedin_url_input(self, client: TestClient, db_session: Session, test_user: User):
         """GET edit-form contains input[name=linkedin_url]."""
-        co = self._make_company(db_session)
+        co = self._make_company(db_session, account_owner_id=test_user.id)
         resp = client.get(f"/v2/partials/customers/{co.id}/edit-form")
         assert resp.status_code == 200
         assert 'name="linkedin_url"' in resp.text
 
     def test_edit_form_renders_account_type_select(self, client: TestClient, db_session: Session, test_user: User):
         """GET edit-form contains select[name=account_type] with canonical options."""
-        co = self._make_company(db_session)
+        co = self._make_company(db_session, account_owner_id=test_user.id)
         resp = client.get(f"/v2/partials/customers/{co.id}/edit-form")
         assert resp.status_code == 200
         assert 'name="account_type"' in resp.text
@@ -5176,7 +5178,7 @@ class TestWS4AccountModalFields:
 
     def test_edit_form_prefills_domain(self, client: TestClient, db_session: Session, test_user: User):
         """Edit form pre-fills domain with existing value."""
-        co = self._make_company(db_session, domain="prefill-domain.com")
+        co = self._make_company(db_session, domain="prefill-domain.com", account_owner_id=test_user.id)
         resp = client.get(f"/v2/partials/customers/{co.id}/edit-form")
         assert resp.status_code == 200
         assert "prefill-domain.com" in resp.text
@@ -5243,6 +5245,8 @@ class TestWS4SiteEditModal:
     def test_site_edit_modal_renders_owner_select(self, client: TestClient, db_session: Session, test_user: User):
         """GET site edit-form contains select[name=owner_id]."""
         co, site = self._make_company_with_site(db_session)
+        co.account_owner_id = test_user.id
+        db_session.commit()
         resp = client.get(f"/v2/partials/customers/{co.id}/sites/{site.id}/edit-form")
         assert resp.status_code == 200
         assert "name='owner_id'" in resp.text or 'name="owner_id"' in resp.text

--- a/tests/test_edit_company_name_validation.py
+++ b/tests/test_edit_company_name_validation.py
@@ -18,9 +18,14 @@ from app.models import Company, User
 
 
 class TestEditCompanyNameRequiredAttr:
-    def test_edit_form_name_input_has_required(self, client: TestClient, test_company: Company):
+    def test_edit_form_name_input_has_required(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
         """The rendered edit form's name input must include ``required`` so a blank name
         can't be silently submitted (parity with the create form)."""
+        # test_user owns test_company so can_manage_account passes.
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         resp = client.get(
             f"/v2/partials/customers/{test_company.id}/edit-form",
             headers={"HX-Request": "true"},

--- a/tests/test_enrichment_authz.py
+++ b/tests/test_enrichment_authz.py
@@ -1,0 +1,173 @@
+"""tests/test_enrichment_authz.py — Role-parity regression guard for enrichment
+endpoints.
+
+Two enrichment routes returned/mutated provider data (paid spend + contact PII)
+behind only ``require_user`` while their sibling vendor-write route gates with
+``require_buyer``:
+
+  E1: enrich_vendor_card       (POST /api/enrich/vendor/{card_id})
+  E2: get_suggested_contacts   (GET  /api/suggested-contacts)
+
+These are role-parity gaps, NOT object-scoped IDOR — the data is freshly pulled
+from external providers for an arbitrary card/domain, so there is no owned row to
+scope with can_manage_account. The correct gate is require_buyer, mirroring
+add_suggested_to_vendor. The "stranger" that proves the gap is therefore the
+non-interactive AGENT service account (the only role require_user admits but
+require_buyer rejects — see require_buyer's docstring), NOT a buyer-owning-nothing
+(a plain buyer legitimately passes a role gate).
+
+Each endpoint asserts:
+  * AGENT service account  -> 403 (require_buyer rejects it before any provider spend)
+  * a real buyer           -> 200 (passes the role gate; provider calls are mocked)
+
+Called by: pytest
+Depends on: conftest.py fixtures (db_session), app.routers.crm.enrichment, app.dependencies
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import UserRole
+from app.models.auth import User
+from app.models.vendors import VendorCard
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+def _client_for(db_session: Session, user: User) -> Iterator[TestClient]:
+    """A TestClient authenticated as *user*.
+
+    Overrides require_user to return *user*, and re-implements require_buyer's REAL role
+    check against *user* (require_buyer calls require_user directly, not via DI, so it
+    cannot be exercised through a plain require_user override — we must model the gate
+    itself). This lets an agent-role user be rejected (403) while a buyer passes,
+    exactly as the production dependency would behave.
+    """
+    from app.database import get_db
+    from app.dependencies import has_buyer_role, require_buyer, require_user
+    from app.main import app
+
+    def _require_buyer_override() -> User:
+        if not has_buyer_role(user):
+            raise HTTPException(403, "Buyer role required for this action")
+        return user
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: user
+    app.dependency_overrides[require_buyer] = _require_buyer_override
+
+    with TestClient(app) as c:
+        yield c
+
+    for dep in [get_db, require_user, require_buyer]:
+        app.dependency_overrides.pop(dep, None)
+
+
+@pytest.fixture()
+def agent_user(db_session: Session) -> User:
+    """The non-interactive AGENT service account — reaches require_user routes only."""
+    u = User(
+        email="agent_authz@example.com",
+        name="Agent Authz",
+        role=UserRole.AGENT,
+        azure_id="agent-azure-authz",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(u)
+    db_session.commit()
+    return u
+
+
+@pytest.fixture()
+def buyer_user(db_session: Session) -> User:
+    """A plain buyer — the legitimately-allowed caller for buyer-tier actions."""
+    u = User(
+        email="buyer_authz@example.com",
+        name="Buyer Authz",
+        role=UserRole.BUYER,
+        azure_id="buyer-azure-authz",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(u)
+    db_session.commit()
+    return u
+
+
+@pytest.fixture()
+def agent_client(db_session: Session, agent_user: User) -> Iterator[TestClient]:
+    yield from _client_for(db_session, agent_user)
+
+
+@pytest.fixture()
+def buyer_client(db_session: Session, buyer_user: User) -> Iterator[TestClient]:
+    yield from _client_for(db_session, buyer_user)
+
+
+@pytest.fixture()
+def vendor_card(db_session: Session) -> VendorCard:
+    """A vendor card with a domain set, so enrich_vendor_card proceeds past the 400."""
+    card = VendorCard(
+        normalized_name="authz-vendor-co",
+        display_name="Authz Vendor Co",
+        domain="vendor-authz.com",
+        is_active=True,
+    )
+    db_session.add(card)
+    db_session.commit()
+    db_session.refresh(card)
+    return card
+
+
+# ── E1: enrich_vendor_card ───────────────────────────────────────────────────
+
+
+class TestEnrichVendorCardRoleParity:
+    """enrich_vendor_card must gate on require_buyer (parity with
+    add_suggested_to_vendor)."""
+
+    def test_agent_gets_403(self, agent_client: TestClient, vendor_card: VendorCard):
+        """The agent service account must be rejected before any provider spend."""
+        resp = agent_client.post(f"/api/enrich/vendor/{vendor_card.id}")
+        assert resp.status_code == 403
+
+    def test_buyer_gets_200(self, buyer_client: TestClient, vendor_card: VendorCard):
+        """A buyer passes the role gate (external providers mocked)."""
+        with (
+            patch("app.routers.crm.enrichment._require_enrichment_provider", return_value=None),
+            patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock, return_value={}),
+            patch("app.enrichment_service.apply_enrichment_to_vendor", return_value=[]),
+        ):
+            resp = buyer_client.post(f"/api/enrich/vendor/{vendor_card.id}")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+
+# ── E2: get_suggested_contacts ───────────────────────────────────────────────
+
+
+class TestGetSuggestedContactsRoleParity:
+    """get_suggested_contacts must gate on require_buyer — paid provider PII lookup."""
+
+    def test_agent_gets_403(self, agent_client: TestClient):
+        """The agent service account must not pull provider contact PII for any
+        domain."""
+        resp = agent_client.get("/api/suggested-contacts", params={"domain": "example.com"})
+        assert resp.status_code == 403
+
+    def test_buyer_gets_200(self, buyer_client: TestClient):
+        """A buyer passes the role gate (provider lookup mocked)."""
+        with (
+            patch("app.routers.crm.enrichment._require_enrichment_provider", return_value=None),
+            patch("app.enrichment_service.find_suggested_contacts", new_callable=AsyncMock, return_value=[]),
+        ):
+            resp = buyer_client.get("/api/suggested-contacts", params={"domain": "example.com"})
+        assert resp.status_code == 200
+        assert resp.json()["domain"] == "example.com"

--- a/tests/test_htmx_views_nightly3.py
+++ b/tests/test_htmx_views_nightly3.py
@@ -458,6 +458,7 @@ class TestCustomerSites:
         assert resp.status_code == 200
 
     def test_site_contacts_list(self, client, db_session: Session, test_user: User, test_company):
+        test_company.account_owner_id = test_user.id  # owner passes can_manage_account gate
         site = _company_site(db_session, test_company)
         db_session.commit()
 

--- a/tests/test_integration_crm.py
+++ b/tests/test_integration_crm.py
@@ -32,9 +32,16 @@ def test_create_company_missing_name(client):
     assert resp.status_code == 422  # Pydantic validation rejects missing required field
 
 
-def test_list_companies(client):
-    client.post("/api/companies", json={"name": "ListCo Alpha"})
-    client.post("/api/companies?force=true", json={"name": "ListCo Beta"})
+def test_list_companies(client, db_session, test_user):
+    from app.models import Company
+
+    alpha = client.post("/api/companies", json={"name": "ListCo Alpha"}).json()
+    beta = client.post("/api/companies?force=true", json={"name": "ListCo Beta"}).json()
+    # create_company assigns no owner; own both so they pass the rep-scoped visibility
+    # filter on the list endpoint (phase1-authz IDOR fix), matching test_update_company.
+    for created in (alpha, beta):
+        db_session.get(Company, created["id"]).account_owner_id = test_user.id
+    db_session.commit()
     resp = client.get("/api/companies")
     assert resp.status_code == 200
     names = [c["name"] for c in resp.json()["items"]]

--- a/tests/test_offers_idor.py
+++ b/tests/test_offers_idor.py
@@ -1,0 +1,272 @@
+"""tests/test_offers_idor.py — Cross-requisition IDOR regression guard for offers.
+
+Covers three read endpoints in app/routers/crm/offers.py that previously depended
+only on require_user and leaked requisition/offer-scoped data:
+
+  F1: GET /api/changelog/{entity_type}/{entity_id}  — change history (may include
+      pricing, terms, PII) must gate on require_requisition_access.
+  F2: GET /api/offers/{offer_id}/attachments        — attachment listing must gate
+      on require_requisition_access (parity with upload/delete peers).
+  F3: GET /api/offers/review-queue                  — cross-requisition aggregate of
+      pending-review offers must be restricted to managers/admins.
+
+require_requisition_access only restricts SALES/TRADER roles (buyers/managers/admins
+are unrestricted), so the "stranger" for F1/F2 is a SALES user who owns nothing and
+the "owner" is the SALES user who created the requisition. For F3 the aggregate is
+manager/admin-only, so a SALES stranger is rejected and a MANAGER is allowed.
+
+Called by: pytest
+Depends on: conftest.py fixtures (db_session), app.main.app, app.dependencies
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import ChangeLog, Offer, Requisition, User
+
+# ── client helper ────────────────────────────────────────────────────────────
+
+
+def _client_for(db_session: Session, user: User) -> TestClient:
+    """Build a TestClient authenticated as *user* with the test db session."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: user
+    app.dependency_overrides[require_admin] = lambda: user
+    app.dependency_overrides[require_buyer] = lambda: user
+    app.dependency_overrides[require_fresh_token] = lambda: "mock-token"
+
+    client = TestClient(app)
+    client.__exit__wrapped_deps = [  # type: ignore[attr-defined]
+        get_db,
+        require_user,
+        require_admin,
+        require_buyer,
+        require_fresh_token,
+    ]
+    return client
+
+
+def _teardown_client(client: TestClient) -> None:
+    from app.main import app
+
+    for dep in getattr(client, "__exit__wrapped_deps", []):
+        app.dependency_overrides.pop(dep, None)
+
+
+# ── users ────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def sales_owner(db_session: Session) -> User:
+    """SALES user who will own the requisition/offer under test."""
+    u = User(
+        email="sales_owner_idor@example.com",
+        name="Sales Owner",
+        role="sales",
+        azure_id="sales-owner-azure-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def sales_stranger(db_session: Session) -> User:
+    """SALES user who owns nothing (the attacker)."""
+    u = User(
+        email="sales_stranger_idor@example.com",
+        name="Sales Stranger",
+        role="sales",
+        azure_id="sales-stranger-azure-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def manager(db_session: Session) -> User:
+    """MANAGER user — allowed to see the review-queue aggregate."""
+    u = User(
+        email="manager_idor@example.com",
+        name="Manager IDOR",
+        role="manager",
+        azure_id="manager-azure-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+# ── owned requisition + offer + changelog ────────────────────────────────────
+
+
+@pytest.fixture()
+def owned_requisition(db_session: Session, sales_owner: User) -> Requisition:
+    req = Requisition(
+        name="Owned Req IDOR",
+        status="open",
+        created_by=sales_owner.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(req)
+    db_session.commit()
+    db_session.refresh(req)
+    return req
+
+
+@pytest.fixture()
+def owned_offer(
+    db_session: Session,
+    owned_requisition: Requisition,
+    sales_owner: User,
+) -> Offer:
+    offer = Offer(
+        requisition_id=owned_requisition.id,
+        vendor_name="Secret Vendor Inc",
+        mpn="ABC-123",
+        qty_available=100,
+        unit_price=Decimal("1.2345"),
+        entered_by_id=sales_owner.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(offer)
+    db_session.commit()
+    db_session.refresh(offer)
+    return offer
+
+
+@pytest.fixture()
+def owned_changelog(db_session: Session, owned_offer: Offer, sales_owner: User) -> ChangeLog:
+    row = ChangeLog(
+        entity_type="offer",
+        entity_id=owned_offer.id,
+        field_name="unit_price",
+        old_value="2.0000",
+        new_value="1.2345",
+        user_id=sales_owner.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(row)
+    db_session.commit()
+    db_session.refresh(row)
+    return row
+
+
+# ── F1: get_changelog ────────────────────────────────────────────────────────
+
+
+class TestChangelogIDOR:
+    """GET /api/changelog/offer/{id} must gate on require_requisition_access."""
+
+    def test_unrelated_sales_gets_404(
+        self,
+        db_session: Session,
+        sales_stranger: User,
+        owned_offer: Offer,
+        owned_changelog: ChangeLog,
+    ):
+        client = _client_for(db_session, sales_stranger)
+        try:
+            resp = client.get(f"/api/changelog/offer/{owned_offer.id}")
+        finally:
+            _teardown_client(client)
+        assert resp.status_code == 404
+
+    def test_owner_sales_gets_200(
+        self,
+        db_session: Session,
+        sales_owner: User,
+        owned_offer: Offer,
+        owned_changelog: ChangeLog,
+    ):
+        client = _client_for(db_session, sales_owner)
+        try:
+            resp = client.get(f"/api/changelog/offer/{owned_offer.id}")
+        finally:
+            _teardown_client(client)
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+
+# ── F2: list_offer_attachments ───────────────────────────────────────────────
+
+
+class TestOfferAttachmentsIDOR:
+    """GET /api/offers/{id}/attachments must gate on require_requisition_access."""
+
+    def test_unrelated_sales_gets_404(
+        self,
+        db_session: Session,
+        sales_stranger: User,
+        owned_offer: Offer,
+    ):
+        client = _client_for(db_session, sales_stranger)
+        try:
+            resp = client.get(f"/api/offers/{owned_offer.id}/attachments")
+        finally:
+            _teardown_client(client)
+        assert resp.status_code == 404
+
+    def test_owner_sales_gets_200(
+        self,
+        db_session: Session,
+        sales_owner: User,
+        owned_offer: Offer,
+    ):
+        client = _client_for(db_session, sales_owner)
+        try:
+            resp = client.get(f"/api/offers/{owned_offer.id}/attachments")
+        finally:
+            _teardown_client(client)
+        assert resp.status_code == 200
+        # The owner receives the (JSON) attachment list the stranger was denied.
+        assert isinstance(resp.json(), list)
+
+
+# ── F3: list_review_queue ────────────────────────────────────────────────────
+
+
+class TestReviewQueueIDOR:
+    """GET /api/offers/review-queue must be restricted to managers/admins."""
+
+    def test_non_manager_sales_gets_403(
+        self,
+        db_session: Session,
+        sales_stranger: User,
+    ):
+        client = _client_for(db_session, sales_stranger)
+        try:
+            resp = client.get("/api/offers/review-queue")
+        finally:
+            _teardown_client(client)
+        assert resp.status_code == 403
+
+    def test_manager_gets_200(
+        self,
+        db_session: Session,
+        manager: User,
+    ):
+        client = _client_for(db_session, manager)
+        try:
+            resp = client.get("/api/offers/review-queue")
+        finally:
+            _teardown_client(client)
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)

--- a/tests/test_offers_nightly.py
+++ b/tests/test_offers_nightly.py
@@ -108,14 +108,18 @@ class TestCreateOffer:
 
 
 class TestReviewQueue:
-    def test_list_review_queue_empty(self, client):
+    def test_list_review_queue_empty(self, client, db_session, test_user):
         """GET /api/offers/review-queue returns empty list when no T4 offers."""
+        test_user.role = "manager"  # review queue is manager/admin-only
+        db_session.commit()
         resp = client.get("/api/offers/review-queue")
         assert resp.status_code == 200
         assert resp.json() == []
 
     def test_list_review_queue_with_t4_offer(self, client, db_session, test_user):
         """GET /api/offers/review-queue returns T4 pending_review offers."""
+        test_user.role = "manager"  # review queue is manager/admin-only
+        db_session.commit()
         offer = _make_committed_offer(db_session, test_user.id, status="pending_review", evidence_tier="T4")
 
         resp = client.get("/api/offers/review-queue")
@@ -125,6 +129,8 @@ class TestReviewQueue:
 
     def test_list_review_queue_excludes_non_t4(self, client, db_session, test_user):
         """Review queue does not include active (non-T4) offers."""
+        test_user.role = "manager"  # review queue is manager/admin-only
+        db_session.commit()
         _make_committed_offer(db_session, test_user.id, status="active", evidence_tier="T5")
 
         resp = client.get("/api/offers/review-queue")

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -248,14 +248,14 @@ class TestCompanies:
         assert isinstance(data["items"], list)
         assert "total" in data
 
-    def test_list_companies_with_data(self, client, db_session, test_company):
-        resp = client.get("/api/companies")
+    def test_list_companies_with_data(self, admin_client, db_session, test_company):
+        resp = admin_client.get("/api/companies")
         assert resp.status_code == 200
         names = [c["name"] for c in resp.json()["items"]]
         assert "Acme Electronics" in names
 
-    def test_list_companies_search(self, client, db_session, test_company):
-        resp = client.get("/api/companies", params={"search": "Acme"})
+    def test_list_companies_search(self, admin_client, db_session, test_company):
+        resp = admin_client.get("/api/companies", params={"search": "Acme"})
         assert resp.status_code == 200
         names = [c["name"] for c in resp.json()["items"]]
         assert "Acme Electronics" in names
@@ -294,9 +294,9 @@ class TestCompanies:
 
 
 class TestCompanyDetail:
-    def test_get_company_basic(self, client, db_session, test_company, test_customer_site):
+    def test_get_company_basic(self, admin_client, db_session, test_company, test_customer_site):
         """GET /api/companies/{id} returns company with sites."""
-        resp = client.get(f"/api/companies/{test_company.id}")
+        resp = admin_client.get(f"/api/companies/{test_company.id}")
         assert resp.status_code == 200
         data = resp.json()
         assert data["id"] == test_company.id
@@ -314,7 +314,7 @@ class TestCompanyDetail:
         resp = client.get("/api/companies/999999")
         assert resp.status_code == 404
 
-    def test_get_company_sites_include_contacts(self, client, db_session, test_company, test_customer_site):
+    def test_get_company_sites_include_contacts(self, admin_client, db_session, test_company, test_customer_site):
         """Site contacts are nested under each site."""
         sc = SiteContact(
             customer_site_id=test_customer_site.id,
@@ -325,7 +325,7 @@ class TestCompanyDetail:
         db_session.add(sc)
         db_session.commit()
 
-        resp = client.get(f"/api/companies/{test_company.id}")
+        resp = admin_client.get(f"/api/companies/{test_company.id}")
         assert resp.status_code == 200
         data = resp.json()
         site = [s for s in data["sites"] if s["site_name"] == "Acme HQ"][0]
@@ -333,7 +333,7 @@ class TestCompanyDetail:
         contact_names = [c["full_name"] for c in site["contacts"]]
         assert "Bob Smith" in contact_names
 
-    def test_get_company_open_reqs_count(self, client, db_session, test_company, test_customer_site, test_user):
+    def test_get_company_open_reqs_count(self, admin_client, db_session, test_company, test_customer_site, test_user):
         """open_reqs count is aggregated per site."""
         req = Requisition(
             name="REQ-DETAIL-001",
@@ -345,20 +345,20 @@ class TestCompanyDetail:
         db_session.add(req)
         db_session.commit()
 
-        resp = client.get(f"/api/companies/{test_company.id}")
+        resp = admin_client.get(f"/api/companies/{test_company.id}")
         assert resp.status_code == 200
         data = resp.json()
         site = [s for s in data["sites"] if s["site_name"] == "Acme HQ"][0]
         assert site["open_reqs"] >= 1
 
-    def test_get_company_inactive_sites_excluded(self, client, db_session, test_company):
+    def test_get_company_inactive_sites_excluded(self, admin_client, db_session, test_company):
         """Inactive sites are filtered out of the response."""
         active = CustomerSite(company_id=test_company.id, site_name="Active Branch", is_active=True)
         inactive = CustomerSite(company_id=test_company.id, site_name="Closed Branch", is_active=False)
         db_session.add_all([active, inactive])
         db_session.commit()
 
-        resp = client.get(f"/api/companies/{test_company.id}")
+        resp = admin_client.get(f"/api/companies/{test_company.id}")
         assert resp.status_code == 200
         data = resp.json()
         site_names = [s["site_name"] for s in data["sites"]]
@@ -524,9 +524,9 @@ class TestQuotes:
 
 
 class TestCompaniesAdditional:
-    def test_list_companies_unassigned(self, client, db_session, test_company):
+    def test_list_companies_unassigned(self, admin_client, db_session, test_company):
         """Filter companies with no account_owner_id."""
-        resp = client.get("/api/companies", params={"unassigned": 1})
+        resp = admin_client.get("/api/companies", params={"unassigned": 1})
         assert resp.status_code == 200
         data = resp.json()["items"]
         # test_company has no account_owner_id, so it should appear
@@ -573,9 +573,9 @@ class TestCompaniesAdditional:
                 assert "sites" not in c
                 assert "site_count" in c
 
-    def test_list_companies_pagination(self, client, db_session, test_company):
+    def test_list_companies_pagination(self, admin_client, db_session, test_company):
         """Pagination params limit and offset work correctly."""
-        resp = client.get("/api/companies", params={"limit": 1, "offset": 0})
+        resp = admin_client.get("/api/companies", params={"limit": 1, "offset": 0})
         assert resp.status_code == 200
         data = resp.json()
         assert data["limit"] == 1
@@ -583,9 +583,9 @@ class TestCompaniesAdditional:
         assert data["total"] >= 1
         assert len(data["items"]) <= 1
 
-    def test_list_companies_response_shape(self, client, db_session, test_company):
+    def test_list_companies_response_shape(self, admin_client, db_session, test_company):
         """List response includes open_req_count and site_count, not sites."""
-        resp = client.get("/api/companies")
+        resp = admin_client.get("/api/companies")
         assert resp.status_code == 200
         data = resp.json()
         assert "items" in data
@@ -596,7 +596,7 @@ class TestCompaniesAdditional:
         assert "sites" not in item
 
     def test_list_companies_revenue_90d_with_won_quote(
-        self, client, db_session, test_company, test_customer_site, test_user
+        self, admin_client, db_session, test_company, test_customer_site, test_user
     ):
         """revenue_90d reflects sum of Quote.subtotal for won requisitions in last 90
         days."""
@@ -619,7 +619,7 @@ class TestCompaniesAdditional:
         db_session.add(q)
         db_session.commit()
 
-        resp = client.get("/api/companies")
+        resp = admin_client.get("/api/companies")
         assert resp.status_code == 200
         items = resp.json()["items"]
         match = [i for i in items if i["id"] == test_company.id]
@@ -627,7 +627,7 @@ class TestCompaniesAdditional:
         assert match[0]["revenue_90d"] == 5000.0
 
     def test_list_companies_revenue_90d_uses_status_enum(
-        self, client, db_session, test_company, test_customer_site, test_user
+        self, admin_client, db_session, test_company, test_customer_site, test_user
     ):
         """revenue_90d filter must use the RequisitionStatus.WON StrEnum constant, not a
         raw 'won' string.
@@ -654,15 +654,15 @@ class TestCompaniesAdditional:
         db_session.add(q)
         db_session.commit()
 
-        resp = client.get("/api/companies")
+        resp = admin_client.get("/api/companies")
         assert resp.status_code == 200
         match = [i for i in resp.json()["items"] if i["id"] == test_company.id]
         assert len(match) == 1
         assert match[0]["revenue_90d"] == 4200.0
 
-    def test_list_companies_revenue_90d_zero_when_no_won(self, client, db_session, test_company):
+    def test_list_companies_revenue_90d_zero_when_no_won(self, admin_client, db_session, test_company):
         """Companies with no won quotes should have revenue_90d=0."""
-        resp = client.get("/api/companies")
+        resp = admin_client.get("/api/companies")
         assert resp.status_code == 200
         items = resp.json()["items"]
         match = [i for i in items if i["id"] == test_company.id]
@@ -670,7 +670,7 @@ class TestCompaniesAdditional:
         assert match[0]["revenue_90d"] == 0
 
     def test_list_companies_revenue_90d_excludes_old(
-        self, client, db_session, test_company, test_customer_site, test_user
+        self, admin_client, db_session, test_company, test_customer_site, test_user
     ):
         """Quotes older than 90 days should not count toward revenue_90d."""
         req = Requisition(
@@ -692,7 +692,7 @@ class TestCompaniesAdditional:
         db_session.add(q)
         db_session.commit()
 
-        resp = client.get("/api/companies")
+        resp = admin_client.get("/api/companies")
         assert resp.status_code == 200
         items = resp.json()["items"]
         match = [i for i in items if i["id"] == test_company.id]
@@ -2460,27 +2460,27 @@ class TestHistoricalOffersSubstitutes:
 
 
 class TestCompanyTags:
-    def test_list_companies_includes_tags(self, client, db_session, test_company):
+    def test_list_companies_includes_tags(self, admin_client, db_session, test_company):
         """brand_tags and commodity_tags are returned in list response."""
         test_company.brand_tags = ["IBM", "HP"]
         test_company.commodity_tags = ["Server"]
         db_session.commit()
 
-        resp = client.get("/api/companies")
+        resp = admin_client.get("/api/companies")
         assert resp.status_code == 200
         data = resp.json()["items"]
         comp = [c for c in data if c["name"] == "Acme Electronics"][0]
         assert comp["brand_tags"] == ["IBM", "HP"]
         assert comp["commodity_tags"] == ["Server"]
 
-    def test_list_companies_tag_filter(self, client, db_session, test_company):
+    def test_list_companies_tag_filter(self, admin_client, db_session, test_company):
         """Tag query param filters companies by brand/commodity tags."""
         test_company.brand_tags = ["IBM", "HP"]
         test_company.commodity_tags = ["Server"]
         db_session.commit()
 
         # Should match
-        resp = client.get("/api/companies", params={"tag": "IBM"})
+        resp = admin_client.get("/api/companies", params={"tag": "IBM"})
         assert resp.status_code == 200
         names = [c["name"] for c in resp.json()["items"]]
         assert "Acme Electronics" in names
@@ -2494,12 +2494,12 @@ class TestCompanyTags:
         assert resp.status_code == 200
         assert resp.json()["items"] == []
 
-    def test_list_companies_tag_filter_commodity(self, client, db_session, test_company):
+    def test_list_companies_tag_filter_commodity(self, admin_client, db_session, test_company):
         """Tag filter matches commodity_tags too."""
         test_company.commodity_tags = ["Networking"]
         db_session.commit()
 
-        resp = client.get("/api/companies", params={"tag": "network"})
+        resp = admin_client.get("/api/companies", params={"tag": "network"})
         assert resp.status_code == 200
         names = [c["name"] for c in resp.json()["items"]]
         assert "Acme Electronics" in names

--- a/tests/test_site_read_idor.py
+++ b/tests/test_site_read_idor.py
@@ -1,0 +1,175 @@
+"""tests/test_site_read_idor.py - Cross-tenant IDOR regression guard for site READ endpoints.
+
+site_contacts_list (GET .../sites/{id}/contacts) and site_edit_form
+(GET .../sites/{id}/edit-form) both returned company/site data (contact PII,
+site commercial terms, internal user roster) gated on require_user only. An
+unrelated buyer who owns nothing must get 404 (existence hidden); the account
+owner must still get 200.
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, test_user, db_session), app.dependencies
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.auth import User
+from app.models.crm import Company, CustomerSite, SiteContact
+
+# -- shared fixtures ----------------------------------------------------------
+
+
+@pytest.fixture()
+def owned_company(db_session: Session, test_user: User) -> Company:
+    """A company owned by test_user (account_owner_id set)."""
+    co = Company(
+        name="Owned Corp ReadIDOR",
+        is_active=True,
+        account_owner_id=test_user.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+@pytest.fixture()
+def owned_site(db_session: Session, owned_company: Company) -> CustomerSite:
+    """A site under owned_company with commercial terms populated."""
+    site = CustomerSite(
+        company_id=owned_company.id,
+        site_name="Owner HQ",
+        is_active=True,
+        payment_terms="NET30",
+        shipping_terms="FOB",
+        notes="internal pricing note",
+    )
+    db_session.add(site)
+    db_session.commit()
+    db_session.refresh(site)
+    return site
+
+
+@pytest.fixture()
+def owned_contact(db_session: Session, owned_site: CustomerSite) -> SiteContact:
+    """A contact under owned_site (the PII that must not leak)."""
+    contact = SiteContact(
+        customer_site_id=owned_site.id,
+        full_name="Alice Owner",
+        first_name="Alice",
+        last_name="Owner",
+        email="alice@owned-corp.com",
+        phone="+1-555-0100",
+    )
+    db_session.add(contact)
+    db_session.commit()
+    db_session.refresh(contact)
+    return contact
+
+
+@pytest.fixture()
+def unrelated_client(db_session: Session) -> TestClient:
+    """TestClient authenticated as a buyer who owns NO companies/sites."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    stranger = User(
+        email="stranger_read_idor@example.com",
+        name="Stranger Read IDOR",
+        role="buyer",
+        azure_id="stranger-azure-read-idor",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(stranger)
+    db_session.commit()
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: stranger
+    app.dependency_overrides[require_admin] = lambda: stranger
+    app.dependency_overrides[require_buyer] = lambda: stranger
+    app.dependency_overrides[require_fresh_token] = lambda: "mock-token"
+
+    with TestClient(app) as c:
+        yield c
+
+    for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
+        app.dependency_overrides.pop(dep, None)
+
+
+# -- site_contacts_list -------------------------------------------------------
+
+
+class TestSiteContactsListIDOR:
+    """GET .../sites/{id}/contacts must gate on can_manage_account (404 for
+    strangers)."""
+
+    def test_unrelated_rep_gets_404(
+        self,
+        unrelated_client: TestClient,
+        owned_company: Company,
+        owned_site: CustomerSite,
+        owned_contact: SiteContact,
+    ):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/sites/{owned_site.id}/contacts",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+        assert "alice@owned-corp.com" not in resp.text
+
+    def test_owner_gets_200(
+        self,
+        client: TestClient,
+        owned_company: Company,
+        owned_site: CustomerSite,
+        owned_contact: SiteContact,
+    ):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/sites/{owned_site.id}/contacts",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner sees the contact roster the stranger was denied.
+        assert "alice@owned-corp.com" in resp.text
+
+
+# -- site_edit_form -----------------------------------------------------------
+
+
+class TestSiteEditFormIDOR:
+    """GET .../sites/{id}/edit-form must gate on can_manage_account (404 for
+    strangers)."""
+
+    def test_unrelated_rep_gets_404(
+        self,
+        unrelated_client: TestClient,
+        owned_company: Company,
+        owned_site: CustomerSite,
+    ):
+        resp = unrelated_client.get(
+            f"/v2/partials/customers/{owned_company.id}/sites/{owned_site.id}/edit-form",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404
+        assert "internal pricing note" not in resp.text
+
+    def test_owner_gets_200(
+        self,
+        client: TestClient,
+        owned_company: Company,
+        owned_site: CustomerSite,
+    ):
+        resp = client.get(
+            f"/v2/partials/customers/{owned_company.id}/sites/{owned_site.id}/edit-form",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The owner's edit form actually renders (site-name field present).
+        assert "site_name" in resp.text

--- a/tests/test_sprint4_company_crud.py
+++ b/tests/test_sprint4_company_crud.py
@@ -68,7 +68,9 @@ class TestCreateCompany:
 
 
 class TestEditCompany:
-    def test_edit_form_renders(self, client: TestClient, test_company: Company):
+    def test_edit_form_renders(self, client: TestClient, test_company: Company, test_user: User, db_session: Session):
+        test_company.account_owner_id = test_user.id  # owner passes can_manage_account gate
+        db_session.commit()
         resp = client.get(
             f"/v2/partials/customers/{test_company.id}/edit-form",
             headers={"HX-Request": "true"},
@@ -132,12 +134,19 @@ class TestEditSite:
         assert resp.status_code == 404
 
     def test_edit_form_targets_tab_panel_not_shell(
-        self, client: TestClient, test_company: Company, test_customer_site: CustomerSite
+        self,
+        client: TestClient,
+        test_company: Company,
+        test_customer_site: CustomerSite,
+        test_user: User,
+        db_session: Session,
     ):
         """F1: the site-edit modal must swap the Sites tab panel (#company-tab-content),
         NOT #main-content. The edit handler returns the sites_tab fragment (same as a
         Sites-tab click); targeting #main-content replaced the whole page/workspace shell
         with a bare sites list, wiping the header, tabs, and account list."""
+        test_company.account_owner_id = test_user.id  # owner passes can_manage_account gate
+        db_session.commit()
         resp = client.get(
             f"/v2/partials/customers/{test_company.id}/sites/{test_customer_site.id}/edit-form",
             headers={"HX-Request": "true"},


### PR DESCRIPTION
## What
A whole-CRM-module security sweep found **23 GET/read endpoints returning scoped data (contact/company/site PII, company financials) with only `require_user`** — while their mutating peers gated. This closes all of them, adds a matching IDOR test per endpoint, and updates the pre-existing tests whose setups predated the gates.

### The critical one
`GET /api/companies/{id}` and the `GET /api/companies` list handed back a company's full record — `tax_id`, `credit_terms`, revenue, notes — to any authenticated user, plus every site/contact's PII. Now:
- `GET /api/companies/{id}` → 404 via `can_manage_account` (out-of-scope indistinguishable from missing).
- `GET /api/companies` list filters on `company_visibility_predicate` for non-managers, and threads `user` into the cached `_fetch` so `@cached_endpoint` folds `user.id` into the key (no cross-rep cache bleed).

### The rest (all gate to 404/403/286 for out-of-scope; managers/admins bypass)
- **crm/offers.py** — `get_changelog` + `list_offer_attachments` require `require_requisition_access`; `list_review_queue` is `is_manager_or_admin`-only.
- **crm/enrichment.py** — `enrich_vendor_card` + `get_suggested_contacts` require `require_buyer`.
- **htmx company/site/contact read partials** — `company_edit_form`, `company_field_edit_form`/`_display`, `company_dup_suggestion`, `company_name_suggestion`, `site_contacts_list`, `site_edit_form`, `contacts_tab_add_form`, `contact_field_edit_form`/`_display`, `contact_notes_modal`, `contact_history_modal`, `contact_files_modal`, `company_segment_tags_partial` gate on `can_manage_account` → 404. The `suggested-contacts` trigger gates before spending paid credits; its **poller** returns an empty `286` to stop polling rather than leak existence.

## Tests
- **7 new IDOR test modules** (`test_company_api_idor`, `test_offers_idor`, `test_enrichment_authz`, `test_contacts_tab_idor`, `test_company_core_idor`, `test_site_read_idor`, `test_company_segment_tags_idor`) — stranger gets 404/403/286, owner gets 200 with **content assertions** (owner receives the exact data the stranger was denied).
- **30 pre-existing tests** updated where their setups predated the gates: own the company for single-record tests, use the existing `admin_client` for data-shape list tests, use a manager for the now-manager-only review queue.
- Full suite green: **23,526 passed, 0 failed**. `pre-commit` (ruff, mypy, docformatter, assertion-theater) clean.

`docs/APP_MAP_INTERACTIONS.md` updated with the Wave 1 hardening note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)