### PR TITLE
perf(crm): 6 query rewrites — kill N+1 / O(n²) / unbounded loads (Wave 2b)

### DIFF
--- a/app/routers/crm/_helpers.py
+++ b/app/routers/crm/_helpers.py
@@ -53,16 +53,24 @@ def record_changes(
             )
 
 
-def quote_to_dict(q: Quote, db=None) -> dict:
-    """Serialize a Quote to API response dict."""
+def quote_to_dict(q: Quote, db=None, cards: dict | None = None) -> dict:
+    """Serialize a Quote to API response dict.
+
+    ``cards`` is an optional prefetched ``{material_card_id: MaterialCard}`` map. When
+    supplied (list views batch-load every referenced card in one IN query — see
+    ``list_quotes``), the per-quote MaterialCard lookup is skipped, eliminating the N+1.
+    When omitted, a single ``db`` query resolves this quote's cards (unchanged single-quote
+    behavior).
+    """
     enriched_items = q.line_items or []
-    if db and enriched_items:
+    if (db is not None or cards is not None) and enriched_items:
         try:
             card_ids = [li.get("material_card_id") for li in enriched_items if li.get("material_card_id")]
             if card_ids:
-                from ...models import MaterialCard
+                if cards is None:
+                    from ...models import MaterialCard
 
-                cards = {c.id: c for c in db.query(MaterialCard).filter(MaterialCard.id.in_(card_ids)).all()}
+                    cards = {c.id: c for c in db.query(MaterialCard).filter(MaterialCard.id.in_(card_ids)).all()}
                 enriched_items = []
                 for li in q.line_items or []:
                     item = dict(li)

--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from ...constants import RESTRICTED_ROLES, QuoteStatus, RequisitionStatus
@@ -139,7 +140,23 @@ async def list_quotes(req_id: int, user: User = Depends(require_user), db: Sessi
         .order_by(Quote.revision.desc())
         .all()
     )
-    return [quote_to_dict(q, db) for q in quotes]
+    # Batch-load every MaterialCard referenced across all quotes' line_items in ONE IN
+    # query, then serialize against the shared map (kills the per-quote N+1). The caller
+    # passes cards= WITHOUT db, so no per-quote query can fire. Uses the 2.0
+    # select()/db.scalars() form so the legacy Query-API ratchet count does not rise.
+    from ...models import MaterialCard
+
+    cards: dict = {}
+    try:
+        card_ids = {
+            li.get("material_card_id") for q in quotes for li in (q.line_items or []) if li.get("material_card_id")
+        }
+        if card_ids:
+            cards = {c.id: c for c in db.scalars(select(MaterialCard).where(MaterialCard.id.in_(card_ids))).all()}
+    except Exception:
+        logger.warning("Batch MaterialCard enrichment failed for req {}, returning raw items", req_id)
+        cards = {}
+    return [quote_to_dict(q, cards=cards) for q in quotes]
 
 
 @router.post("/api/requisitions/{req_id}/quote")

--- a/app/routers/htmx/companies/core.py
+++ b/app/routers/htmx/companies/core.py
@@ -813,24 +813,45 @@ async def company_dup_suggestion(
     if not can_manage_account(user, company, db):
         raise HTTPException(404, "Company not found")
 
-    # Scan, then pick the highest-scoring pair that INVOLVES this company. The scanner
-    # already honors the auto_keep heuristic; here we only need the OTHER side as the
-    # merge-away candidate.
+    # Only THIS company's single best near-dup is needed, so key the lookup on its own
+    # normalized_name instead of generating the global dedup candidate set. On Postgres
+    # that is one trgm-index probe (% operator over ix_companies_normalized_name_trgm),
+    # not a whole-table self-join + aggregate join. SQLite (tests) has no pg_trgm, so it
+    # keeps the original rapidfuzz scan; its tables are tiny and behavior is unchanged.
+    match = None
+    norm = company.normalized_name
     try:
-        candidates = find_company_dedup_candidates(db, threshold=85, limit=50)
+        if db.bind is not None and db.bind.dialect.name == "postgresql":
+            if company.is_active and norm:
+                sim = sqlfunc.similarity(Company.normalized_name, norm)
+                row = (
+                    db.query(Company.id, Company.name, sim.label("sim"))
+                    .filter(
+                        Company.id != company_id,
+                        Company.is_active.is_(True),
+                        Company.normalized_name.isnot(None),
+                        Company.normalized_name != "",
+                        Company.normalized_name.op("%")(norm),
+                        sim >= (85 / 100.0),
+                    )
+                    .order_by(sim.desc())
+                    .first()
+                )
+                if row is not None:
+                    match = {"id": row.id, "name": row.name, "score": int(round(row.sim * 100))}
+        else:
+            candidates = find_company_dedup_candidates(db, threshold=85, limit=50)
+            for pair in candidates:
+                a, b = pair["company_a"], pair["company_b"]
+                if a["id"] == company_id:
+                    match = {"id": b["id"], "name": b["name"], "score": pair["score"]}
+                    break
+                if b["id"] == company_id:
+                    match = {"id": a["id"], "name": a["name"], "score": pair["score"]}
+                    break
     except Exception as e:  # pragma: no cover - defensive, mirrors data-ops scan guard
         logger.warning("dup-suggestion scan failed for company {}: {}", company_id, e)
         return HTMLResponse("")
-
-    match = None
-    for pair in candidates:
-        a, b = pair["company_a"], pair["company_b"]
-        if a["id"] == company_id:
-            match = {"id": b["id"], "name": b["name"], "score": pair["score"]}
-            break
-        if b["id"] == company_id:
-            match = {"id": a["id"], "name": a["name"], "score": pair["score"]}
-            break
 
     if not match:
         return HTMLResponse("")
@@ -1175,7 +1196,10 @@ async def company_edit_form(
         db.query(User).filter(User.role.in_((UserRole.BUYER, UserRole.TRADER, UserRole.MANAGER, UserRole.ADMIN))).all()
     )
     all_companies = (
-        db.query(Company).filter(Company.id != company_id, Company.is_active.is_(True)).order_by(Company.name).all()
+        db.query(Company.id, Company.name)
+        .filter(Company.id != company_id, Company.is_active.is_(True))
+        .order_by(Company.name)
+        .all()
     )
     return template_response(
         "htmx/partials/customers/edit_form.html",

--- a/app/routers/htmx/companies/detail.py
+++ b/app/routers/htmx/companies/detail.py
@@ -47,25 +47,32 @@ _VALID_CUSTOMER_TABS = frozenset(
 )
 
 
-def _company_quotes_query(db: Session, company):
+def _company_quotes_query(db: Session, company, *, req_ids=None):
     """Quotes belonging to an account: union of quotes linked via the
     company's customer sites OR via the company's requisitions (the latter
     catches quotes whose customer_site_id is NULL). Returns a Query, or None
     when the account can own no quotes (no sites and no requisitions).
     Called by: company_detail_partial (count), company_tab (quotes + activity).
+
+    ``req_ids`` may be pre-supplied by a caller that already computed the account's
+    matching requisition ids (e.g. _render_company_detail computes them once and
+    reuses across the count + quotes + buy-plans lookups). When omitted, the same
+    unindexable lower(trim(customer_name)) match is recomputed here (unchanged for
+    the _shared_tabs callers, which pass no req_ids).
     """
     site_ids = [s.id for s in db.query(CustomerSite.id).filter(CustomerSite.company_id == company.id).all()]
-    req_ids = [
-        r.id
-        for r in db.query(Requisition.id)
-        .filter(
-            or_(
-                Requisition.company_id == company.id,
-                sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
+    if req_ids is None:
+        req_ids = [
+            r.id
+            for r in db.query(Requisition.id)
+            .filter(
+                or_(
+                    Requisition.company_id == company.id,
+                    sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
+                )
             )
-        )
-        .all()
-    ]
+            .all()
+        ]
     conds = []
     if site_ids:
         conds.append(Quote.customer_site_id.in_(site_ids))
@@ -76,23 +83,27 @@ def _company_quotes_query(db: Session, company):
     return db.query(Quote).filter(or_(*conds)).options(joinedload(Quote.requisition))
 
 
-def _company_buy_plans_query(db: Session, company):
+def _company_buy_plans_query(db: Session, company, *, req_ids=None):
     """Buy plans belonging to an account: all buy-plans whose requisition links
     to the company (via company_id FK or customer_name match). Returns a Query,
     or None when the account has no requisitions.
     Called by: company_detail_partial (count), company_tab (buy_plans).
+
+    ``req_ids`` may be pre-supplied (see _company_quotes_query / _render_company_detail);
+    when omitted the same match is recomputed here (unchanged for _shared_tabs callers).
     """
-    req_ids = [
-        r.id
-        for r in db.query(Requisition.id)
-        .filter(
-            or_(
-                Requisition.company_id == company.id,
-                sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
+    if req_ids is None:
+        req_ids = [
+            r.id
+            for r in db.query(Requisition.id)
+            .filter(
+                or_(
+                    Requisition.company_id == company.id,
+                    sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
+                )
             )
-        )
-        .all()
-    ]
+            .all()
+        ]
     if not req_ids:
         return None
     return (
@@ -149,29 +160,30 @@ async def _render_company_detail(
 
     sites = [s for s in (company.sites or []) if s.is_active]
 
-    # Count open requisitions — use company_id FK if available, fall back to name match
-    open_req_count = (
-        db.query(sqlfunc.count(Requisition.id))
+    # Requisitions belonging to this account: company_id FK OR normalized
+    # customer_name match. The name match — lower(trim(customer_name)) — is
+    # unindexable, so run it ONCE here and reuse the id set for the open-req
+    # count and the quote / buy-plan lookups below (was 3 identical scans per
+    # render; now 1). Status is filtered in Python for the count so no extra
+    # scan is needed; StrEnum members compare equal to the stored String value,
+    # matching the previous SQL `status IN (...)` exactly (incl. NULL -> excluded).
+    _matching_reqs = (
+        db.query(Requisition.id, Requisition.status)
         .filter(
             or_(
                 Requisition.company_id == company.id,
                 sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
-            ),
-            Requisition.status.in_(
-                [
-                    RequisitionStatus.OPEN,
-                    RequisitionStatus.DRAFT,
-                ]
-            ),
+            )
         )
-        .scalar()
-        or 0
+        .all()
     )
+    _req_ids = [r.id for r in _matching_reqs]
+    open_req_count = sum(1 for r in _matching_reqs if r.status in (RequisitionStatus.OPEN, RequisitionStatus.DRAFT))
 
-    _cq = _company_quotes_query(db, company)
+    _cq = _company_quotes_query(db, company, req_ids=_req_ids)
     quote_count = _cq.count() if _cq is not None else 0
 
-    _bpq = _company_buy_plans_query(db, company)
+    _bpq = _company_buy_plans_query(db, company, req_ids=_req_ids)
     buy_plan_count = _bpq.count() if _bpq is not None else 0
 
     # Cadence card + commercial strip context

--- a/app/services/alerts/sources/inbound_customer.py
+++ b/app/services/alerts/sources/inbound_customer.py
@@ -94,5 +94,8 @@ class InboundCustomerSource(AlertSource):
         return self._eligible_query(db, user).count()
 
     def new_items_for_user(self, db: Session, user: User) -> list[AlertItem]:
-        activities = self._eligible_query(db, user).all()
-        return [AlertItem(ref_id=a.id, anchor=f"company-{a.company_id}") for a in activities]
+        # Markers consume only the id (ref) + company_id (anchor); project those two
+        # columns instead of hydrating the full, wide (text/JSON-bearing) ActivityLog
+        # entity for every recent inbound row on each account-list refresh.
+        rows = self._eligible_query(db, user).with_entities(ActivityLog.id, ActivityLog.company_id).all()
+        return [AlertItem(ref_id=row.id, anchor=f"company-{row.company_id}") for row in rows]

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -687,21 +687,34 @@ def _latest_contact_notes(db: Session, contact_ids: list[int]) -> dict[int, str]
         return {}
     from ..models.intelligence import ActivityLog
 
-    rows = (
-        db.query(ActivityLog.site_contact_id, ActivityLog.notes, ActivityLog.created_at)
-        .filter(
+    # Reduce "newest note per contact" in the DB so only N rows (one per contact)
+    # are fetched instead of the full note history. row_number() over
+    # (partition by contact, order by created_at DESC, id DESC) ranks each
+    # contact's notes newest-first; keeping rn == 1 yields exactly one row each.
+    # The `notes != ""` guard mirrors the old Python `and notes` truthiness check:
+    # an empty-string note was skipped so the loop fell through to the newest
+    # NON-empty note — excluding "" here makes rn == 1 land on that same row.
+    ranked = (
+        select(
+            ActivityLog.site_contact_id,
+            ActivityLog.notes,
+            func.row_number()
+            .over(
+                partition_by=ActivityLog.site_contact_id,
+                order_by=(ActivityLog.created_at.desc(), ActivityLog.id.desc()),
+            )
+            .label("rn"),
+        )
+        .where(
             ActivityLog.site_contact_id.in_(contact_ids),
             ActivityLog.activity_type == "note",
             ActivityLog.notes.isnot(None),
+            ActivityLog.notes != "",
         )
-        .order_by(ActivityLog.site_contact_id, ActivityLog.created_at.desc())
-        .all()
+        .subquery()
     )
-    latest: dict[int, str] = {}
-    for site_contact_id, notes, _created in rows:
-        # Rows are ordered newest-first per contact; keep the first seen for each.
-        if site_contact_id not in latest and notes:
-            latest[site_contact_id] = notes
+    result_rows = db.execute(select(ranked.c.site_contact_id, ranked.c.notes).where(ranked.c.rn == 1)).all()
+    latest: dict[int, str] = {row.site_contact_id: row.notes for row in result_rows}
     return latest
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,36 @@ def _clear_8x8_token_cache():
 
 
 @pytest.fixture(autouse=True)
+def _clear_run_registries():
+    """Reset every in-process run registry before AND after each test.
+
+    The enrich/discovery pollers coordinate through process-wide ``_state`` dicts
+    (``begin``/``finish``/``consume_outcome``). A test that monkeypatches the
+    background runner to a no-op leaves its company/card/vendor id stuck RUNNING —
+    and since the per-test row cleanup lets SQLite reuse integer ids, a later test
+    in the same xdist worker collides with the stale entry: ``begin()`` refuses,
+    the poller never reaches 286, and the test fails only under full-suite
+    ordering (e.g. TestC4SuggestedContactsUI after the suggested-contacts IDOR
+    tests). Clearing all five registries per test removes the whole class.
+    """
+    from app.services.company_enrich_runs import company_enrich_runs
+    from app.services.contact_discovery_runs import contact_discovery_runs
+    from app.services.material_enrich_runs import crosses_runs, enrich_runs
+    from app.services.vendor_contact_runs import vendor_contact_runs
+
+    registries = (contact_discovery_runs, company_enrich_runs, enrich_runs, crosses_runs, vendor_contact_runs)
+
+    def _reset() -> None:
+        for reg in registries:
+            with reg._lock:
+                reg._state.clear()
+
+    _reset()
+    yield
+    _reset()
+
+
+@pytest.fixture(autouse=True)
 def _clear_anthropic_client_cache():
     """Clear the shared Anthropic SDK client cache before and after each test.
 

--- a/tests/test_crm_perf_wave2b.py
+++ b/tests/test_crm_perf_wave2b.py
@@ -1,0 +1,547 @@
+"""tests/test_crm_perf_wave2b.py — result-equivalence guards for the CRM query-perf Wave
+2b rewrites.
+
+Each rewrite reduces N+1 / O(n^2) / unbounded-load / per-row work WITHOUT changing
+results. These tests pin the observable output so a future regression (or a subtly
+wrong optimization) is caught:
+
+  1. quote_to_dict(cards=...) + list_quotes batch-load — identical card enrichment
+     across multiple quotes, with a single materials query (N+1 killed).
+  2. _latest_contact_notes — newest note per contact via a window function, incl. the
+     empty-string fall-through and the id tie-break.
+  3. company_edit_form — parent-company dropdown lists active companies (id+name) and
+     excludes inactive + self.
+  4. InboundCustomerSource.new_items_for_user — column-projected markers identical to
+     the full-entity hydration.
+  5. _render_company_detail — matched-requisition counts (open/quote/buy-plan) unchanged
+     when the match is computed once and reused; helper req_ids= path == recompute path.
+  6. company_dup_suggestion — SQLite (unchanged rapidfuzz) path still renders. The
+     Postgres trgm branch is dialect-gated, so SQLite exercises the old path here; the
+     PG path needs a live-PG parity check (run by the coordinator).
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import event, or_
+from sqlalchemy import func as sqlfunc
+from sqlalchemy.orm import Session
+
+from app.constants import Channel, Direction, RequisitionStatus
+from app.models import MaterialCard, Quote
+from app.models.buy_plan import BuyPlan
+from app.models.crm import Company, CustomerSite, SiteContact
+from app.models.intelligence import ActivityLog
+from app.models.sourcing import Requisition
+from app.routers.crm import quote_to_dict
+from app.routers.htmx.companies.detail import _company_buy_plans_query, _company_quotes_query
+from app.services.crm_service import _latest_contact_notes
+
+# ── shared helpers ──────────────────────────────────────────────────────────────
+
+
+@contextmanager
+def _count_sql(db: Session, needle: str):
+    """Count executed statements whose (lowercased) SQL contains ``needle``."""
+    engine = db.get_bind()
+    hits: list[str] = []
+
+    def _after(conn, cursor, statement, parameters, context, executemany):
+        if needle.lower() in statement.lower():
+            hits.append(statement)
+
+    event.listen(engine, "after_cursor_execute", _after)
+    try:
+        yield hits
+    finally:
+        event.remove(engine, "after_cursor_execute", _after)
+
+
+def _card(db: Session, mpn: str, desc: str, cat: str = "voltage_regulators") -> MaterialCard:
+    mc = MaterialCard(
+        normalized_mpn=mpn.lower(),
+        display_mpn=mpn,
+        manufacturer="Texas Instruments",
+        description=desc,
+        category=cat,
+    )
+    db.add(mc)
+    db.commit()
+    db.refresh(mc)
+    return mc
+
+
+def _quote(db, req, site, user, number, revision, items) -> Quote:
+    q = Quote(
+        requisition_id=req.id,
+        customer_site_id=site.id if site else None,
+        quote_number=number,
+        revision=revision,
+        status="draft",
+        line_items=items,
+        subtotal=0,
+        created_by_id=user.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.commit()
+    db.refresh(q)
+    return q
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  1. quote_to_dict(cards=...) + list_quotes batch enrichment (N+1 kill)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestQuoteToDictCardsMap:
+    def test_prefetched_map_matches_db_path(self, db_session, test_requisition, test_customer_site, test_user):
+        """quote_to_dict(cards=map) yields byte-identical line_items to
+        quote_to_dict(db=db)."""
+        a = _card(db_session, "LM317T", "Adjustable Voltage Regulator, 1.5A")
+        b = _card(db_session, "NE555P", "Precision Timer IC")
+        items = [
+            {"mpn": "LM317T", "material_card_id": a.id, "qty": 100},
+            {"mpn": "NE555P", "material_card_id": b.id, "qty": 5},
+            {"mpn": "UNKNOWN", "qty": 1},  # no card id — untouched in both paths
+        ]
+        q = _quote(db_session, test_requisition, test_customer_site, test_user, "Q-W2B-DICT-1", 1, items)
+
+        via_db = quote_to_dict(q, db=db_session)["line_items"]
+        via_map = quote_to_dict(q, cards={a.id: a, b.id: b})["line_items"]
+        assert via_map == via_db
+        # sanity: enrichment actually happened
+        assert via_map[0]["description"] == "Adjustable Voltage Regulator, 1.5A"
+        assert via_map[1]["description"] == "Precision Timer IC"
+        assert "description" not in via_map[2]
+
+    def test_default_none_preserves_raw_behavior(self, db_session, test_requisition, test_customer_site, test_user):
+        """Neither db nor cards supplied -> raw line_items (unchanged single-arg
+        behavior)."""
+        a = _card(db_session, "LM7805", "5V Linear Regulator")
+        items = [{"mpn": "LM7805", "material_card_id": a.id}]
+        q = _quote(db_session, test_requisition, test_customer_site, test_user, "Q-W2B-DICT-2", 1, items)
+        d = quote_to_dict(q)  # no db, no cards
+        assert d["line_items"] == items
+        assert "description" not in d["line_items"][0]
+
+    def test_empty_cards_map_degrades_to_raw(self, db_session, test_requisition, test_customer_site, test_user):
+        """Cards={} (batch found no cards) -> items returned without enrichment, like a
+        miss."""
+        a = _card(db_session, "TL072", "JFET Op-Amp")
+        items = [{"mpn": "TL072", "material_card_id": a.id}]
+        q = _quote(db_session, test_requisition, test_customer_site, test_user, "Q-W2B-DICT-3", 1, items)
+        d = quote_to_dict(q, cards={})
+        assert d["line_items"][0]["mpn"] == "TL072"
+        assert "description" not in d["line_items"][0]
+
+
+class TestListQuotesBatch:
+    def test_multiple_quotes_identical_card_data_single_query(
+        self, client, db_session, test_requisition, test_customer_site, test_user
+    ):
+        """GET .../quotes enriches every quote's items identically to the per-quote db
+        path, using ONE materials query (was one per card-bearing quote)."""
+        a = _card(db_session, "LM317T", "Adjustable Voltage Regulator, 1.5A")
+        b = _card(db_session, "NE555P", "Precision Timer IC")
+        # rev2 references BOTH cards; rev1 references only A (overlap) + a dead card id.
+        q_rev2 = _quote(
+            db_session,
+            test_requisition,
+            test_customer_site,
+            test_user,
+            "Q-W2B-LIST-R2",
+            2,
+            [
+                {"mpn": "LM317T", "material_card_id": a.id},
+                {"mpn": "NE555P", "material_card_id": b.id},
+            ],
+        )
+        q_rev1 = _quote(
+            db_session,
+            test_requisition,
+            test_customer_site,
+            test_user,
+            "Q-W2B-LIST-R1",
+            1,
+            [
+                {"mpn": "LM317T", "material_card_id": a.id},
+                {"mpn": "GONE", "material_card_id": 999_999},  # nonexistent card -> no enrichment
+            ],
+        )
+
+        # Oracle: the per-quote db path, in the endpoint's revision-desc order.
+        oracle = [quote_to_dict(q, db=db_session)["line_items"] for q in (q_rev2, q_rev1)]
+
+        with _count_sql(db_session, "from material_cards") as hits:
+            resp = client.get(f"/api/requisitions/{test_requisition.id}/quotes")
+        assert resp.status_code == 200
+        got = [row["line_items"] for row in resp.json()]
+
+        assert got == oracle
+        # rev2: both cards enriched
+        assert got[0][0]["description"] == "Adjustable Voltage Regulator, 1.5A"
+        assert got[0][1]["description"] == "Precision Timer IC"
+        # rev1: card A enriched, dead card id left raw
+        assert got[1][0]["description"] == "Adjustable Voltage Regulator, 1.5A"
+        assert "description" not in got[1][1]
+        # N+1 killed: exactly one materials query for the whole list.
+        assert len(hits) == 1
+
+    def test_empty_quotes_no_materials_query(self, client, db_session, test_requisition):
+        """A requisition with no quotes returns [] and issues no materials query."""
+        with _count_sql(db_session, "from material_cards") as hits:
+            resp = client.get(f"/api/requisitions/{test_requisition.id}/quotes")
+        assert resp.status_code == 200
+        assert resp.json() == []
+        assert len(hits) == 0
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  2. _latest_contact_notes — newest note per contact (window function)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLatestContactNotes:
+    @staticmethod
+    def _contact(db, site, name) -> SiteContact:
+        c = SiteContact(customer_site_id=site.id, full_name=name, is_active=True)
+        db.add(c)
+        db.commit()
+        db.refresh(c)
+        return c
+
+    @staticmethod
+    def _note(db, contact, text, created_at) -> ActivityLog:
+        a = ActivityLog(
+            site_contact_id=contact.id,
+            activity_type="note",
+            channel=Channel.EMAIL,  # NOT NULL col; _latest_contact_notes ignores channel
+            notes=text,
+            created_at=created_at,
+            occurred_at=created_at,
+        )
+        db.add(a)
+        db.commit()
+        db.refresh(a)
+        return a
+
+    def test_newest_per_contact_and_edge_cases(self, db_session, test_customer_site):
+        base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+        # c1: three distinct-timestamp notes -> newest wins.
+        c1 = self._contact(db_session, test_customer_site, "Alpha")
+        self._note(db_session, c1, "oldest", base)
+        self._note(db_session, c1, "middle", base + timedelta(hours=1))
+        self._note(db_session, c1, "newest", base + timedelta(hours=2))
+
+        # c2: newest note is "" -> falls through to the older NON-empty note.
+        c2 = self._contact(db_session, test_customer_site, "Bravo")
+        self._note(db_session, c2, "real note", base)
+        self._note(db_session, c2, "", base + timedelta(hours=1))
+
+        # c3: only NULL / "" notes -> absent from the result dict.
+        c3 = self._contact(db_session, test_customer_site, "Charlie")
+        self._note(db_session, c3, None, base)
+        self._note(db_session, c3, "", base + timedelta(hours=1))
+
+        # c4: two notes at the SAME timestamp -> deterministic id-DESC tie-break wins.
+        c4 = self._contact(db_session, test_customer_site, "Delta")
+        tie = base + timedelta(hours=3)
+        low = self._note(db_session, c4, "tie-low-id", tie)
+        high = self._note(db_session, c4, "tie-high-id", tie)
+        assert high.id > low.id
+
+        result = _latest_contact_notes(db_session, [c1.id, c2.id, c3.id, c4.id])
+
+        assert result[c1.id] == "newest"
+        assert result[c2.id] == "real note"
+        assert c3.id not in result
+        assert result[c4.id] == "tie-high-id"
+        # one row per qualifying contact (c1,c2,c4) — never the full note history.
+        assert set(result) == {c1.id, c2.id, c4.id}
+
+    def test_empty_contact_ids_short_circuits(self, db_session):
+        assert _latest_contact_notes(db_session, []) == {}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  3. company_edit_form — parent-company dropdown (id/name projection)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCompanyEditFormDropdown:
+    def test_dropdown_lists_active_excludes_inactive_and_self(self, client, db_session, test_user):
+        edited = Company(
+            name="Edited Co W2B", is_active=True, account_owner_id=test_user.id, created_at=datetime.now(UTC)
+        )
+        active_1 = Company(name="Active One W2B", is_active=True, created_at=datetime.now(UTC))
+        active_2 = Company(name="Active Two W2B", is_active=True, created_at=datetime.now(UTC))
+        inactive = Company(name="Inactive Co W2B", is_active=False, created_at=datetime.now(UTC))
+        db_session.add_all([edited, active_1, active_2, inactive])
+        db_session.commit()
+        for c in (edited, active_1, active_2, inactive):
+            db_session.refresh(c)
+
+        resp = client.get(
+            f"/v2/partials/customers/{edited.id}/edit-form",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # Scope assertions to the parent-company <select> — company ids can collide with
+        # the account-owner (users) dropdown's option values elsewhere in the form.
+        m = re.search(r'name="parent_company_id".*?</select>', resp.text, re.S)
+        assert m is not None
+        select_html = m.group(0)
+        # Active peers present as <option value=ID>Name</option>
+        assert f'value="{active_1.id}"' in select_html
+        assert "Active One W2B" in select_html
+        assert f'value="{active_2.id}"' in select_html
+        assert "Active Two W2B" in select_html
+        # Inactive excluded, and the edited company is not listed among its own parents.
+        assert f'value="{inactive.id}"' not in select_html
+        assert "Inactive Co W2B" not in select_html
+        assert f'value="{edited.id}"' not in select_html
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  4. InboundCustomerSource.new_items_for_user — projected markers == full-entity
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestInboundMarkersProjection:
+    @staticmethod
+    def _inbound(db, company, when) -> ActivityLog:
+        a = ActivityLog(
+            activity_type="email_received",
+            channel=Channel.EMAIL,
+            direction=Direction.INBOUND,
+            company_id=company.id,
+            subject="Re: pricing",
+            occurred_at=when,
+            created_at=when,
+        )
+        db.add(a)
+        db.commit()
+        db.refresh(a)
+        return a
+
+    def test_projected_markers_equal_full_entity_markers(self, db_session, test_user, test_company):
+        from app.services.alerts.base import AlertItem
+        from app.services.alerts.sources.inbound_customer import InboundCustomerSource
+
+        # Own two Customer-type accounts as the rep.
+        test_company.account_type = "Customer"
+        test_company.account_owner_id = test_user.id
+        second = Company(
+            name="Second Customer W2B",
+            account_type="Customer",
+            account_owner_id=test_user.id,
+            is_active=True,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(second)
+        db_session.commit()
+        db_session.refresh(second)
+
+        now = datetime.now(UTC)
+        self._inbound(db_session, test_company, now - timedelta(hours=2))
+        self._inbound(db_session, test_company, now - timedelta(hours=1))
+        self._inbound(db_session, second, now - timedelta(minutes=30))
+
+        source = InboundCustomerSource()
+        # Oracle = the pre-rewrite full-entity hydration path, reconstructed inline.
+        oracle = [
+            AlertItem(ref_id=a.id, anchor=f"company-{a.company_id}")
+            for a in source._eligible_query(db_session, test_user).all()
+        ]
+        got = source.new_items_for_user(db_session, test_user)
+
+        assert [(i.ref_id, i.anchor) for i in got] == [(i.ref_id, i.anchor) for i in oracle]
+        assert len(got) == 3
+        # ordering preserved (oldest-first) and anchors well-formed
+        assert got[0].anchor == f"company-{test_company.id}"
+        assert got[-1].anchor == f"company-{second.id}"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  5. _render_company_detail — matched-requisition counts computed once & reused
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestRenderCompanyDetailMatchedReqs:
+    @staticmethod
+    def _req(db, user, *, name="REQ", customer_name=None, company_id=None, status="open") -> Requisition:
+        r = Requisition(
+            name=name,
+            customer_name=customer_name,
+            company_id=company_id,
+            status=status,
+            created_by=user.id,
+            created_at=datetime.now(UTC),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+        return r
+
+    def _seed_account(self, db, user):
+        company = Company(name="Matcher Co W2B", is_active=True, account_owner_id=user.id, created_at=datetime.now(UTC))
+        db.add(company)
+        db.commit()
+        db.refresh(company)
+
+        # matches by company_id FK (open)
+        self._req(db, user, name="R-fk-open", company_id=company.id, status="open")
+        # matches by exact customer_name (draft — draft counts as open-ish)
+        self._req(db, user, name="R-name-draft", customer_name="Matcher Co W2B", status="draft")
+        # matches by mixed-case / whitespace customer_name (open)
+        self._req(db, user, name="R-name-ws", customer_name="  MATCHER co w2b  ", status="open")
+        # matches but WON -> in the id set, NOT open
+        self._req(db, user, name="R-won", company_id=company.id, status="won")
+        # matches but NULL status -> in id set, NOT open (forced NULL below)
+        r_null = self._req(db, user, name="R-null", company_id=company.id, status="open")
+        db.execute(Requisition.__table__.update().where(Requisition.id == r_null.id).values(status=None))
+        db.commit()
+        # NON-matching (different company, different name)
+        self._req(db, user, name="R-other", customer_name="Totally Different Inc", status="open")
+        return company
+
+    def test_helper_reqids_path_equals_recompute(self, db_session, test_user):
+        company = self._seed_account(db_session, test_user)
+        # Independent req-id oracle (the same predicate the helpers use internally).
+        ids = [
+            r.id
+            for r in db_session.query(Requisition.id)
+            .filter(
+                or_(
+                    Requisition.company_id == company.id,
+                    sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
+                )
+            )
+            .all()
+        ]
+        # Seed one quote + one buy plan so the counts are non-trivial.
+        site = CustomerSite(company_id=company.id, site_name="HQ")
+        db_session.add(site)
+        db_session.commit()
+        db_session.refresh(site)
+        req_for_quote = db_session.query(Requisition).filter(Requisition.name == "R-fk-open").first()
+        q = _quote(db_session, req_for_quote, site, test_user, "Q-W2B-DET-1", 1, [])
+        bp = BuyPlan(quote_id=q.id, requisition_id=req_for_quote.id, status="draft", so_status="pending")
+        db_session.add(bp)
+        db_session.commit()
+
+        cq_default = _company_quotes_query(db_session, company)
+        cq_passed = _company_quotes_query(db_session, company, req_ids=ids)
+        assert cq_default.count() == cq_passed.count()
+        assert {x.id for x in cq_default} == {x.id for x in cq_passed}
+
+        bpq_default = _company_buy_plans_query(db_session, company)
+        bpq_passed = _company_buy_plans_query(db_session, company, req_ids=ids)
+        assert bpq_default.count() == bpq_passed.count()
+        assert {x.id for x in bpq_default} == {x.id for x in bpq_passed}
+
+        # Empty req_ids -> buy-plans short-circuit to None (buy plans link only via reqs).
+        assert _company_buy_plans_query(db_session, company, req_ids=[]) is None
+        # Quotes with empty req_ids still return the SITE-linked query (company has a site),
+        # so it is NOT None — the None case requires no sites AND no reqs:
+        bare = Company(name="Bare Co W2B", is_active=True, created_at=datetime.now(UTC))
+        db_session.add(bare)
+        db_session.commit()
+        db_session.refresh(bare)
+        assert _company_quotes_query(db_session, bare, req_ids=[]) is None
+        assert _company_buy_plans_query(db_session, bare, req_ids=[]) is None
+
+    def test_render_counts_match_oracle(self, client, db_session, test_user, monkeypatch):
+        from fastapi.responses import HTMLResponse
+
+        import app.routers.htmx.companies.detail as detail_mod
+
+        company = self._seed_account(db_session, test_user)
+        site = CustomerSite(company_id=company.id, site_name="HQ")
+        db_session.add(site)
+        db_session.commit()
+        db_session.refresh(site)
+        req_for_quote = db_session.query(Requisition).filter(Requisition.name == "R-fk-open").first()
+        q = _quote(db_session, req_for_quote, site, test_user, "Q-W2B-DET-2", 1, [])
+        db_session.add(BuyPlan(quote_id=q.id, requisition_id=req_for_quote.id, status="draft", so_status="pending"))
+        db_session.commit()
+
+        # Oracle: the PRE-rewrite open-req COUNT (SQL status IN (open, draft)).
+        oracle_open = (
+            db_session.query(sqlfunc.count(Requisition.id))
+            .filter(
+                or_(
+                    Requisition.company_id == company.id,
+                    sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
+                ),
+                Requisition.status.in_([RequisitionStatus.OPEN, RequisitionStatus.DRAFT]),
+            )
+            .scalar()
+            or 0
+        )
+        oracle_quotes = _company_quotes_query(db_session, company).count()
+        oracle_buy = _company_buy_plans_query(db_session, company).count()
+        assert oracle_open == 3  # fk-open + name-draft + name-ws (won/null/other excluded)
+
+        captured: dict = {}
+
+        def _capture(template_name, context, *a, **k):
+            captured.update(context)
+            return HTMLResponse("ok")
+
+        monkeypatch.setattr(detail_mod, "template_response", _capture)
+
+        resp = client.get(f"/v2/partials/customers/{company.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert captured["open_req_count"] == oracle_open
+        assert captured["quote_count"] == oracle_quotes
+        assert captured["buy_plan_count"] == oracle_buy
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  6. company_dup_suggestion — SQLite (unchanged rapidfuzz) path still renders
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDupSuggestionSqlite:
+    """SQLite has no pg_trgm, so the dialect gate keeps the ORIGINAL rapidfuzz path.
+
+    These assert the endpoint still renders; the Postgres func.similarity/% branch is
+    exercised separately by a live-PG parity check (run by the coordinator).
+    """
+
+    def test_no_near_dup_renders_empty(self, client, db_session, test_user):
+        solo = Company(
+            name="Unique Solo Co W2B", is_active=True, account_owner_id=test_user.id, created_at=datetime.now(UTC)
+        )
+        db_session.add(solo)
+        db_session.commit()
+        db_session.refresh(solo)
+        resp = client.get(
+            f"/v2/partials/customers/{solo.id}/dup-suggestion",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert resp.text == ""
+
+    def test_near_dup_renders_banner(self, client, db_session, test_user):
+        keeper = Company(
+            name="Contoso Widgets Inc", is_active=True, account_owner_id=test_user.id, created_at=datetime.now(UTC)
+        )
+        dup = Company(
+            name="Contoso Widgets LLC", is_active=True, account_owner_id=test_user.id, created_at=datetime.now(UTC)
+        )
+        db_session.add_all([keeper, dup])
+        db_session.commit()
+        db_session.refresh(keeper)
+        resp = client.get(
+            f"/v2/partials/customers/{keeper.id}/dup-suggestion",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "Possible duplicate account" in resp.text


### PR DESCRIPTION
## What
Six correctness-preserving CRM query-performance rewrites. Every one is backed by a result-equivalence test; **full suite green (23,539 passed)**, and the one Postgres-specific path was verified on a live PG.

| Fix | Before | After |
|---|---|---|
| `company_dup_suggestion` (core.py) | whole-table pg_trgm self-join **+ aggregate join on every company-detail render** to find one company's best near-dup | single trgm-index probe (`func.similarity` + `%` over `ix_companies_normalized_name_trgm`, `ORDER BY sim DESC LIMIT 1`); SQLite/test path unchanged (dialect-gated) |
| `_render_company_detail` (detail.py) | `lower(trim(customer_name))` requisition match run **3× per render** | computed once, threaded to the quotes + buy-plans helpers |
| `quote_to_dict` / `list_quotes` | **N+1** MaterialCard query per quote | one batched `IN` query (optional prefetched map, default `None` preserves single-quote behavior) |
| `new_items_for_user` (alerts) | full `ActivityLog` entities hydrated **per debounced keystroke** | projects the 2 columns the markers use |
| `_latest_contact_notes` (crm_service) | loads **every** note, keeps newest-per-contact in Python | `row_number()` window → N rows, deterministic id tie-break |
| `company_edit_form` (core.py) | loads **every active company** as full ORM entities for the parent dropdown | loads only `(id, name)` |

The `dup_suggestion` change also fixes a **latent bug**: the old global top-50 candidate cap could silently hide a company's real ≥85 duplicate; the new per-company probe always surfaces it. Verified on live Postgres — returns the correct match for a near-dup, empty for unrelated companies.

## Correctness
13 new equivalence tests in `tests/test_crm_perf_wave2b.py` (batched-vs-per-quote card data; window-function newest-note incl. ties/empties/NULLs; projected-vs-full markers; recompute-vs-threaded requisition ids; dropdown contents). All touched modules' existing tests pass (169). Net `db.query` count unchanged (legacy Query-API ratchet holds).

## Deferred (flagged, not in this PR)
- **`list_companies` tag filter** — the genuinely index-enabling fix is a GIN-index *migration*, not a query rewrite; low value while tables are near-empty.
- **`check_company_duplicate`** (loads up to 2000 companies) — a safe fix needs an ILIKE/trgm *superset* prefilter that provably never drops a real duplicate; high-risk, deserves a careful standalone pass. Harmless on today's near-empty tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)