### PR TITLE
docs: retire stale "blocked on sign-off" header in approvals parity checklist

### DIFF
--- a/docs/APPROVALS_PARITY_CHECKLIST.md
+++ b/docs/APPROVALS_PARITY_CHECKLIST.md
@@ -5,8 +5,10 @@ Verifiable, surface-by-surface map of every capability of the retired Buy Plans 
 (`/v2/approvals`: Sales Orders · Buy Plans · Purchase Orders · Prepayments).
 Spec: `specs/approvals-workspace.md` §11.1 ("old Buy Plans hub retires after parity").
 
-**This PR is blocked on Mike's parity sign-off.** Prepare-only; do not merge before
-he approves. Legend: ☑ built and verified in the workspace · ☐ needs check / gap.
+**Merged 2026-07-18 (PR #759) with Mike's parity sign-off.** The organizational
+cutover is tracked separately in `docs/APPROVALS_WORKSPACE_PILOT.md` (Teams forms /
+QP workbooks stay authoritative until Mike declares cutover after the pilot).
+Legend: ☑ built and verified in the workspace · ☐ needs check / gap.
 One conscious gap remains: the org-wide `open_avg_margin` metric strip, dropped with
 rationale (see Margin metrics below). The deep-link preselection gap is closed —
 `/v2/buy-plans/{id}` now lands on its plan via `?select=`.


### PR DESCRIPTION
## What

`docs/APPROVALS_PARITY_CHECKLIST.md` still opened with "**This PR is blocked on Mike's parity sign-off.** Prepare-only; do not merge" — but that PR (#759) merged on 2026-07-18 with the sign-off. Anyone reading the checklist now would think the buy-plans-hub retirement is still gated.

This replaces the stale header with the actual state: merged with sign-off, and the remaining gate is the **organizational cutover** tracked in `docs/APPROVALS_WORKSPACE_PILOT.md` (Teams forms / QP workbooks stay authoritative until Mike declares cutover after the pilot).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rEjW6fapcrHEXhK6EUeHp

---
_Generated by [Claude Code](https://claude.ai/code/session_019rEjW6fapcrHEXhK6EUeHp)_