### PR TITLE
perf(crm): factor the anchored company dup-match into a testable utility + cover it

### DIFF
--- a/app/company_utils.py
+++ b/app/company_utils.py
@@ -200,6 +200,74 @@ def _find_company_dedup_candidates_rapidfuzz(db, threshold: int, limit: int) -> 
     return candidates
 
 
+def _dup_match_pg_query(db, company_id: int, norm: str, threshold: int):
+    """Build the anchored pg_trgm query (kept separate so tests can compile it with the
+    postgresql dialect — SQLite masks PG-invalid SQL).
+
+    `%` pre-filters via the GIN(normalized_name gin_trgm_ops) index (migration 120); the
+    explicit similarity() >= threshold/100 predicate enforces the caller's cutoff (same
+    pattern as services.vendor_duplicates._fuzzy_match_pg_trgm).
+    """
+    from sqlalchemy import func
+
+    from .models import Company
+
+    sim = func.similarity(Company.normalized_name, norm)
+    return (
+        db.query(Company.id, Company.name, sim.label("sim"))
+        .filter(
+            Company.is_active.is_(True),
+            Company.id != company_id,
+            Company.normalized_name.isnot(None),
+            Company.normalized_name != "",
+            Company.normalized_name.op("%")(norm),
+            sim >= (threshold / 100.0),
+        )
+        .order_by(sim.desc(), Company.id.asc())
+    )
+
+
+def find_company_dup_match(db, company_id: int, normalized_name: str | None, threshold: int = 85) -> dict | None:
+    """Top near-duplicate partner for ONE company — anchored, never the global pair
+    scan.
+
+    Returns {"id", "name", "score"} for the best-scoring active partner at or above
+    `threshold`, or None. Unlike find_company_dedup_candidates (global all-pairs, used by
+    data-ops and the auto-dedup job), this is a single-anchor lookup: one GIN index probe
+    on PostgreSQL, one O(n) fuzzy_dedup_scan anchor pass on SQLite/fallback — and it can
+    never lose a real match to the global scan's top-`limit` truncation.
+
+    Called by: routers.htmx.companies.core.company_dup_suggestion (per-render banner).
+    """
+    if not normalized_name:
+        return None
+
+    if db.bind is not None and db.bind.dialect.name == "postgresql":
+        row = _dup_match_pg_query(db, company_id, normalized_name, threshold).first()
+        if row is None:
+            return None
+        return {"id": row.id, "name": row.name, "score": round(row.sim * 100)}
+
+    from .models import Company
+    from .vendor_utils import fuzzy_dedup_scan
+
+    rows = (
+        db.query(Company.id, Company.name, Company.normalized_name)
+        .filter(
+            Company.is_active.is_(True),
+            Company.id != company_id,
+            Company.normalized_name.isnot(None),
+            Company.normalized_name != "",
+        )
+        .all()
+    )
+    scanned = fuzzy_dedup_scan(rows, lambda r: r.normalized_name, threshold=threshold, anchor_key=normalized_name)
+    if not scanned:
+        return None
+    best_row, _, best_score = max(scanned, key=lambda t: (t[2], -t[0].id))  # tie -> lowest id
+    return {"id": best_row.id, "name": best_row.name, "score": round(best_score)}
+
+
 def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> list[dict]:
     """Find potential duplicate companies using fuzzy name matching.
 

--- a/app/routers/htmx/companies/core.py
+++ b/app/routers/htmx/companies/core.py
@@ -34,7 +34,7 @@ from sqlalchemy.orm import Session
 import app.routers.htmx.companies as _pkg
 
 from ....cache.decorators import invalidate_prefix
-from ....company_utils import find_company_dedup_candidates, suggest_clean_company_name
+from ....company_utils import find_company_dup_match, suggest_clean_company_name
 from ....constants import UserRole
 from ....database import get_db
 from ....dependencies import can_manage_account, can_manage_account_team, is_manager_or_admin, require_user
@@ -813,42 +813,14 @@ async def company_dup_suggestion(
     if not can_manage_account(user, company, db):
         raise HTTPException(404, "Company not found")
 
-    # Only THIS company's single best near-dup is needed, so key the lookup on its own
-    # normalized_name instead of generating the global dedup candidate set. On Postgres
-    # that is one trgm-index probe (% operator over ix_companies_normalized_name_trgm),
-    # not a whole-table self-join + aggregate join. SQLite (tests) has no pg_trgm, so it
-    # keeps the original rapidfuzz scan; its tables are tiny and behavior is unchanged.
+    # Anchored lookup for THIS company only (one trgm-index probe on PG, one O(n) fuzzy
+    # anchor pass on SQLite) — never the global all-pairs scan, whose top-50 truncation
+    # could silently hide a real near-dup. Inactive accounts get no banner (the lookup
+    # filters partners to active companies; the anchor must be active too).
     match = None
-    norm = company.normalized_name
     try:
-        if db.bind is not None and db.bind.dialect.name == "postgresql":
-            if company.is_active and norm:
-                sim = sqlfunc.similarity(Company.normalized_name, norm)
-                row = (
-                    db.query(Company.id, Company.name, sim.label("sim"))
-                    .filter(
-                        Company.id != company_id,
-                        Company.is_active.is_(True),
-                        Company.normalized_name.isnot(None),
-                        Company.normalized_name != "",
-                        Company.normalized_name.op("%")(norm),
-                        sim >= (85 / 100.0),
-                    )
-                    .order_by(sim.desc())
-                    .first()
-                )
-                if row is not None:
-                    match = {"id": row.id, "name": row.name, "score": int(round(row.sim * 100))}
-        else:
-            candidates = find_company_dedup_candidates(db, threshold=85, limit=50)
-            for pair in candidates:
-                a, b = pair["company_a"], pair["company_b"]
-                if a["id"] == company_id:
-                    match = {"id": b["id"], "name": b["name"], "score": pair["score"]}
-                    break
-                if b["id"] == company_id:
-                    match = {"id": a["id"], "name": a["name"], "score": pair["score"]}
-                    break
+        if company.is_active:
+            match = find_company_dup_match(db, company.id, company.normalized_name, threshold=85)
     except Exception as e:  # pragma: no cover - defensive, mirrors data-ops scan guard
         logger.warning("dup-suggestion scan failed for company {}: {}", company_id, e)
         return HTMLResponse("")

--- a/tests/test_company_utils.py
+++ b/tests/test_company_utils.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from app.company_utils import find_company_dedup_candidates, normalize_company_name
+from app.company_utils import find_company_dedup_candidates, find_company_dup_match, normalize_company_name
 from app.models import Company, CustomerSite
 
 
@@ -188,3 +188,61 @@ def test_find_company_dedup_candidates_pg_empty_pairs():
     result = _find_company_dedup_candidates_pg(mock_db, 85, 50)
 
     assert result == []
+
+
+# ── find_company_dup_match (anchored single-company lookup) ──────────────────
+
+
+class TestFindCompanyDupMatch:
+    def _make_company(self, db, name, is_active=True):
+        c = Company(name=name, is_active=is_active, created_at=datetime.now(UTC))
+        db.add(c)
+        db.flush()
+        return c
+
+    def test_returns_best_match_above_threshold(self, db_session):
+        target = self._make_company(db_session, "Arrow Electronics")
+        partner = self._make_company(db_session, "Arrow Electronic")
+        self._make_company(db_session, "Zeta Industries")
+        db_session.commit()
+
+        match = find_company_dup_match(db_session, target.id, target.normalized_name, threshold=80)
+        assert match is not None
+        assert match["id"] == partner.id
+        assert match["name"] == "Arrow Electronic"
+        assert match["score"] >= 80
+
+    def test_excludes_self(self, db_session):
+        only = self._make_company(db_session, "Solo Industries")
+        db_session.commit()
+        assert find_company_dup_match(db_session, only.id, only.normalized_name) is None
+
+    def test_excludes_inactive(self, db_session):
+        target = self._make_company(db_session, "Arrow Electronics")
+        self._make_company(db_session, "Arrow Electronic", is_active=False)
+        db_session.commit()
+        assert find_company_dup_match(db_session, target.id, target.normalized_name, threshold=80) is None
+
+    def test_none_below_threshold(self, db_session):
+        target = self._make_company(db_session, "Acme Corporation")
+        self._make_company(db_session, "Zeta Industries")
+        db_session.commit()
+        assert find_company_dup_match(db_session, target.id, target.normalized_name, threshold=85) is None
+
+    def test_none_when_normalized_name_falsy(self, db_session):
+        assert find_company_dup_match(db_session, 123, "") is None
+        assert find_company_dup_match(db_session, 123, None) is None
+
+    def test_pg_query_shape_uses_trgm_operator(self, db_session):
+        """Compile the PG-path query with the postgresql dialect: the trgm `%`
+        operator (rendered `%%` under pyformat) + similarity() in both WHERE and
+        ORDER BY must appear — SQLite masks PG-invalid SQL, so pin the shape."""
+        from sqlalchemy.dialects import postgresql
+
+        from app.company_utils import _dup_match_pg_query
+
+        sql = str(_dup_match_pg_query(db_session, 1, "acme", 85).statement.compile(dialect=postgresql.dialect()))
+        assert "companies.normalized_name %% " in sql
+        assert "similarity(companies.normalized_name" in sql
+        assert "ORDER BY similarity(companies.normalized_name" in sql
+        assert "companies.is_active IS true" in sql or "companies.is_active IS 1" in sql

--- a/tests/test_crm_aiorg.py
+++ b/tests/test_crm_aiorg.py
@@ -224,6 +224,23 @@ class TestDupSuggestionRoute:
         resp = unauthenticated_client.get(f"/v2/partials/customers/{solo.id}/dup-suggestion")
         assert resp.status_code == 401
 
+    def test_banner_survives_many_earlier_dup_pairs(self, client: TestClient, db_session: Session, test_user: User):
+        """The banner must be ANCHORED on this company, not filtered out of the global
+        pair scan's top-50: with 51 decoy near-dup pairs at lower ids, the old org-wide
+        scan hit its 50-pair cap before ever comparing the target pair and silently
+        rendered no banner despite a real near-duplicate."""
+        for i in range(51):
+            _make_company(db_session, f"Decoy {i} Inc")
+            _make_company(db_session, f"Decoy {i} Incorporated")
+        keep = _make_company(db_session, "Acme Corp", sites=1)
+        _make_company(db_session, "Acme Corporation")
+        keep.account_owner_id = test_user.id  # owner passes can_manage_account gate
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{keep.id}/dup-suggestion", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Acme Corporation" in resp.text
+
 
 # ── name-suggestion chip (suggest-only) ────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Recovers **orphaned work** found uncommitted in the `crm-wave2b` worktree during a shipment/cleanup sweep — a refactor of the per-company dup-banner lookup that #777 shipped inline, plus the test coverage that inline version never got.

- Extract the anchored pg_trgm dup lookup from `company_dup_suggestion` (routers/htmx/companies/core.py) into `app/company_utils.py::find_company_dup_match` + `_dup_match_pg_query` (query kept separate so tests compile it with the **postgresql dialect** — SQLite masks PG-invalid SQL).
- Improvements over the shipped inline version:
  - deterministic tiebreak (`sim DESC, id ASC`) on equal-similarity partners
  - the SQLite/fallback path is now an **anchored O(n) `fuzzy_dedup_scan` pass** instead of the global all-pairs scan whose top-50 truncation could hide a real near-dup
  - preserves the inline version's anchor `is_active` guard (inactive accounts get no banner)
- Tests: +60 lines in `tests/test_company_utils.py` (PG-dialect SQL compile assertions + fallback behavior), +17 in `tests/test_crm_aiorg.py` (router-level banner coverage).

Rebased onto latest main; conflict with #777's inline implementation resolved by keeping the utility and folding in the inline version's guard.

## Test plan

- [x] 556 tests green across the 9 dup-path test files (`test_crm_perf_wave2b`, `test_company_utils`, `test_crm_aiorg`, `test_htmx_views`, `test_company_core_idor`, `test_auto_dedup_service`, `test_data_ops`, `test_services_coverage_2`, `test_vendor_utils`), run inside the worktree
- [x] `pre-commit run` clean on changed files (docformatter re-run to verify)
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiADLAQZoguPngnXNKHJ22