### PR TITLE
fix(scripts): branch-cleanup no longer emits a phantom "origin/origin" remote

### DIFF
--- a/scripts/branch-cleanup.sh
+++ b/scripts/branch-cleanup.sh
@@ -50,8 +50,10 @@ done
 
 if [ "$REMOTE" = 1 ]; then
   echo "== stale remote branches (merged or archived; never open PRs) =="
-  for r in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ \
-              | sed 's#^origin/##' | grep -vxF 'HEAD' | grep -vxF 'main'); do
+  # Use %(refname), not %(refname:short): git shortens refs/remotes/origin/HEAD to
+  # bare "origin", which survives the HEAD filter and yields a phantom "origin/origin".
+  for r in $(git for-each-ref --format='%(refname)' refs/remotes/origin/ \
+              | sed 's#^refs/remotes/origin/##' | grep -vxF 'HEAD' | grep -vxF 'main'); do
     protected "$r" && { echo "skip (open PR): origin/$r"; continue; }
     merged=$(git merge-base --is-ancestor "origin/$r" origin/main 2>/dev/null && echo yes || echo no)
     archived=$(git rev-parse -q --verify "refs/tags/archive/$r" >/dev/null && echo yes || echo no)


### PR DESCRIPTION
## Problem

`scripts/branch-cleanup.sh --remote` printed a phantom entry on every run:

```
skip (unmerged, not archived): origin/origin
```

There is no `refs/remotes/origin/origin`. The entry comes from the remote enumeration:

```bash
git for-each-ref --format='%(refname:short)' refs/remotes/origin/ \
  | sed 's#^origin/##' | grep -vxF 'HEAD' | grep -vxF 'main'
```

git shortens `refs/remotes/origin/HEAD` to bare **`origin`** (not `origin/HEAD`), so the
`sed 's#^origin/##'` prefix-strip does not apply and `grep -vxF 'HEAD'` never matches it.
The HEAD symref therefore falls through into the remote-**deletion** loop as if it were a branch.

It was inert in practice — `git merge-base --is-ancestor origin/origin origin/main` errors on the
unknown revision (so `merged=no`) and no `refs/tags/archive/origin` exists (so `archived=no`), meaning
the branch was always skipped. But it was noisy on a safety-critical script and left a dormant
delete path keyed on a ref that is not a branch.

## Fix

Enumerate with the full `%(refname)` and strip the exact `refs/remotes/origin/` prefix. The HEAD
symref then reduces to `HEAD` and the existing filter catches it. One line, plus a comment so the
`:short` form does not get reintroduced as a "simplification".

## Verification

`--remote` dry run before / after, on the same repo state:

```
before:  skip (unmerged, not archived): origin/origin     <-- phantom
         skip (open PR): origin/claude/issues-remediation-plan-tdd147
         skip (open PR): origin/claude/resell-module-5f5wv7

after:   skip (open PR): origin/claude/issues-remediation-plan-tdd147
         skip (open PR): origin/claude/resell-module-5f5wv7
```

`bash -n` clean; `pre-commit run --files scripts/branch-cleanup.sh` passes.

Open-PR protection and the archive-before-delete quarantine guarantee are unchanged — this only
removes a non-branch from the loop.

## Context

Found while running the script for real: it archived and deleted the two stale nightly-coverage
branches (`archive/nightly-coverage-2026-07-03`, `archive/test/nightly-coverage-2026-07-05` pushed
first, both recoverable) and correctly protected #782 and #785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)