### PR TITLE
fix(resell): expiry no longer strands partial awards; retry cannot double-send on Graph outage

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -447,6 +447,17 @@ async def send_batch_rfq(
     return results
 
 
+class SentMessageLookupError(RuntimeError):
+    """Sent-Items lookup FAILED (Graph API errors) — delivery state is UNKNOWN.
+
+    Raised by :func:`_find_sent_message` when the Sent-folder query itself errored (429 /
+    5xx / expired token) on an attempt and no match was found, so "the message is not
+    there" was never positively established. Callers implementing a double-send guard
+    MUST treat this as indeterminate and never resend on it; ``None`` remains the
+    positive "scanned the window cleanly, no match" answer that authorizes a resend.
+    """
+
+
 async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None:
     """Find the just-sent message in Sent Items to get its ID and conversationId.
 
@@ -459,6 +470,15 @@ async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None
 
     Retries with exponential backoff (1s, 2s, 4s) to handle Graph API propagation
     delays.
+
+    Three-state contract (deep-review #2, finding 2):
+      - **found** → the message dict (``id`` + ``conversationId``);
+      - **positively not found** → ``None`` — every attempt scanned the Sent window
+        cleanly and the recipient's message is not there (a resend-safe answer);
+      - **lookup failed** → raises :class:`SentMessageLookupError` — at least one attempt
+        hit a Graph API error and no match was found, so delivery state is UNKNOWN.
+        Double-send guards (e.g. ``retry_outreach_send``) must map this to their
+        no-resend branch, never to "not delivered".
     """
     wanted = (vendor_email or "").strip().lower()
     delays = [1, 2, 4]
@@ -488,23 +508,28 @@ async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None
         except Exception as e:
             api_error = True
             logger.warning(f"Sent message lookup attempt failed: {e}")
-    # Distinguish a transient API failure from a genuine no-match: the latter means the
-    # recipient never appeared in the $top window (likely pushed below it by a large
-    # batch fan-out), and the caller leaves the Contact's graph ids NULL.
+    # Distinguish a transient API failure from a genuine no-match: an API error means the
+    # lookup FAILED and delivery state is unknown → raise (three-state contract), so a
+    # double-send guard never mistakes an outage for "positively not delivered". A clean
+    # no-match means the recipient never appeared in the $top window (likely pushed below
+    # it by a large batch fan-out) → return None; the caller leaves graph ids NULL.
     if api_error:
         logger.warning(
-            "Sent-message lookup gave up for <{}> (subject '{}') after API errors on all retries",
+            "Sent-message lookup FAILED for <{}> (subject '{}') — Graph API errors during retries; "
+            "delivery state unknown (raising, not a positive no-match)",
             wanted,
             subject,
         )
-    else:
-        logger.warning(
-            "Sent-message lookup found no match for <{}> (subject '{}') within the top {} Sent items "
-            "— recipient may have been pushed below the window by a large batch",
-            wanted,
-            subject,
-            scanned,
+        raise SentMessageLookupError(
+            f"Sent-Items lookup for <{wanted}> (subject '{subject}') hit Graph API errors — delivery state unknown"
         )
+    logger.warning(
+        "Sent-message lookup found no match for <{}> (subject '{}') within the top {} Sent items "
+        "— recipient may have been pushed below the window by a large batch",
+        wanted,
+        subject,
+        scanned,
+    )
     return None
 
 

--- a/app/jobs/resell_jobs.py
+++ b/app/jobs/resell_jobs.py
@@ -4,7 +4,9 @@ Three nightly backstops for the Resell lifecycle:
   - M5 list-expiry: an ``open``/``collecting`` ExcessList whose ``close_at`` deadline has
     passed without being awarded or closed is flipped to ``expired`` and its Sighting
     live-mirror retired, so a lapsed posting stops advertising supply and drops out of the
-    offerable ("Open to Me") lens.
+    offerable ("Open to Me") lens. A partially-awarded list (any awarded line / won offer)
+    instead steps to the non-terminal ``bid_out`` — terminal ``expired`` would strand its
+    remaining live bids behind award's terminal-list guard (deep-review #2 finding #1).
   - Outreach send-durability sweep: an ExcessOutreach row stuck in ``sending`` past the
     staleness threshold (its background send job died mid-flight) is flipped to
     ``interrupted`` so it stops polling and becomes retryable — never resent here (the
@@ -50,10 +52,12 @@ def register_resell_jobs(scheduler, settings):
 
 @_traced_job
 async def _job_expire_resell_lists():
-    """Daily — flip unresolved excess lists past ``close_at`` to ``expired``.
+    """Daily — resolve unresolved excess lists past ``close_at``.
 
-    Delegates to ``excess_service.expire_overdue_lists`` (which also retires each expired
-    list's Sighting mirror). Idempotent — already-resolved lists are skipped.
+    Delegates to ``excess_service.expire_overdue_lists`` (which also retires each resolved
+    list's Sighting mirror): a list with no sale flips to terminal ``expired``; a
+    partially-awarded one steps to non-terminal ``bid_out`` so its remaining live bids
+    stay awardable. Idempotent — already-resolved lists are skipped.
     """
     from ..database import SessionLocal
     from ..services.excess_service import expire_overdue_lists
@@ -62,7 +66,7 @@ async def _job_expire_resell_lists():
     try:
         expired = expire_overdue_lists(db)
         if expired:
-            logger.info(f"Expired {expired} overdue excess list(s)")
+            logger.info(f"Resolved {expired} overdue excess list(s)")
     except sqlalchemy.exc.SQLAlchemyError as e:
         logger.error(f"Resell list expiry DB error: {e}")
         db.rollback()

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -1750,20 +1750,42 @@ def close_list_without_bid(db: Session, list_id: int, owner: User) -> ExcessList
 _UNRESOLVED_LIST_STATUSES = (ExcessListStatus.OPEN, ExcessListStatus.COLLECTING)
 
 
+def _list_is_partially_awarded(excess_list: ExcessList) -> bool:
+    """True when *excess_list* already SOLD something — any ``awarded`` line or ``won``
+    offer.
+
+    A partial award deliberately keeps the list ``collecting`` (``_apply_award_list_status``
+    only flips to ``awarded`` when EVERY line is decided), so such a list lands in the
+    nightly sweep's open/collecting net. Both markers are checked belt-and-braces: award
+    flips them together, but either alone is proof a sale exists that a terminal flip
+    would strand (deep-review #2, finding #1).
+    """
+    return any(it.status == ExcessLineItemStatus.AWARDED for it in excess_list.line_items) or any(
+        o.status == ExcessOfferStatus.WON for o in excess_list.offers
+    )
+
+
 def expire_overdue_lists(db: Session, *, now: datetime | None = None) -> int:
-    """Flip every unresolved list past its ``close_at`` to ``expired`` — the nightly
-    backstop.
+    """Resolve every unresolved list past its ``close_at`` — the nightly backstop.
 
     An ``open``/``collecting`` list whose ``close_at`` deadline has passed without being
-    awarded or closed is stale: it auto-expires so it stops advertising supply and drops
-    out of the offerable ("Open to Me") lens. For each expired list the Sighting mirror is
-    retired (``sync_list_mirror`` on the now-closed posting). Idempotent — a list already
-    ``expired``/``awarded``/``bid_out`` is skipped.
+    awarded or closed is stale: it auto-resolves so it stops advertising supply and drops
+    out of the offerable ("Open to Me") lens. For each resolved list the Sighting mirror
+    is retired (``sync_list_mirror`` on the now-closed posting). Idempotent — a list
+    already ``expired``/``awarded``/``bid_out`` is skipped.
+
+    A list with NO sale flips to terminal ``expired``. A PARTIALLY-AWARDED list (any
+    ``awarded`` line / ``won`` offer — a partial award deliberately stays ``collecting``)
+    instead steps to the NON-terminal ``bid_out``: ``expired`` would 409 every later
+    ``award_offer`` (the terminal-list guard), permanently stranding the still-live bids
+    on its remaining lines and mislabeling a list that actually sold parts as "expired"
+    (deep-review #2, finding #1). ``bid_out`` retires the mirror identically (both are in
+    the mirror's posting-closed set) while keeping the remaining offers awardable.
 
     Each list's flip + mirror-sync + commit is ISOLATED in its own try/except: one list
     whose mirror-sync raises is rolled back and skipped, and the batch continues expiring
     the others (a single bad list must never silently strand the whole nightly sweep).
-    Returns the count SUCCESSFULLY expired.
+    Returns the count SUCCESSFULLY resolved (expired + stepped to ``bid_out``).
     """
     from . import excess_mirror
 
@@ -1780,7 +1802,9 @@ def expire_overdue_lists(db: Session, *, now: datetime | None = None) -> int:
     expired_count = 0
     for excess_list in overdue:
         try:
-            excess_list.status = ExcessListStatus.EXPIRED
+            excess_list.status = (
+                ExcessListStatus.BID_OUT if _list_is_partially_awarded(excess_list) else ExcessListStatus.EXPIRED
+            )
             db.flush()
             excess_mirror.sync_list_mirror(db, excess_list)
             _safe_commit(db, entity="excess list expiry")
@@ -1791,7 +1815,11 @@ def expire_overdue_lists(db: Session, *, now: datetime | None = None) -> int:
                 excess_list.id,
             )
             db.rollback()
-    logger.info("Expired {} of {} overdue excess list(s) past close_at", expired_count, len(overdue))
+    logger.info(
+        "Resolved {} of {} overdue excess list(s) past close_at (partially-awarded → bid_out, rest → expired)",
+        expired_count,
+        len(overdue),
+    )
     return expired_count
 
 

--- a/app/services/quote_send.py
+++ b/app/services/quote_send.py
@@ -134,9 +134,16 @@ async def send_quote_email(
         if "error" in result:
             raise QuoteSendError(f"Failed to send quote email: {result.get('detail', '')}")
 
-        from ..email_service import _find_sent_message
+        from ..email_service import SentMessageLookupError, _find_sent_message
 
-        msg = await _find_sent_message(gc, subject, to_email)
+        try:
+            msg = await _find_sent_message(gc, subject, to_email)
+        except SentMessageLookupError:
+            # The quote email already went out (sendMail succeeded above) — a failed
+            # Sent-Items lookup must not fail the send. Graph ids stay NULL and reply
+            # matching degrades to the subject/email heuristics.
+            logger.warning("Quote sent-message lookup failed for <{}> — graph ids left NULL", to_email)
+            msg = None
         if msg:
             graph_message_id = msg["id"]
             graph_conversation_id = msg.get("conversationId")

--- a/app/services/resell_outreach_service.py
+++ b/app/services/resell_outreach_service.py
@@ -652,7 +652,12 @@ async def _finalize_outreach_send(
         if sent_ok and email:
             try:
                 sent_msg = await email_service._find_sent_message(gc, subject, email)
-            except Exception:  # lookup is best-effort — a failure must not lose the row
+            except Exception:
+                # Incl. SentMessageLookupError (the lookup's three-state "lookup failed").
+                # HERE the lookup is best-effort: the send itself already succeeded, so a
+                # failed id lookup must degrade (NULL ids + the note below), never lose
+                # the SENT row. Contrast retry_outreach_send, where the same raise is the
+                # UNKNOWN case that blocks a resend.
                 logger.warning("Outreach sent-message lookup failed for <{}>", email, exc_info=True)
                 sent_msg = None
             if isinstance(sent_msg, dict) and sent_msg:
@@ -885,9 +890,11 @@ async def retry_outreach_send(
     (``row.send_subject``, so a customized subject still matches its delivered message):
     a ``failed`` row may have actually DELIVERED (the failure was downstream of the send),
     so if the message is already there the row is reconciled to ``sent`` + its graph ids
-    stamped and NOTHING is resent. A lookup that RAISES is the UNKNOWN case (delivery
-    indeterminate) — the row is left ``interrupted`` and NOTHING is resent (never assume
-    not-sent). Only when the reconcile positively finds nothing is the row reset to
+    stamped and NOTHING is resent. A lookup that RAISES (``SentMessageLookupError`` —
+    the Sent-folder query itself hit Graph API errors, per the lookup's three-state
+    contract) is the UNKNOWN case (delivery indeterminate) — the row is left
+    ``interrupted`` and NOTHING is resent (never assume not-sent). Only when the
+    reconcile POSITIVELY finds nothing (a clean ``None``) is the row reset to
     ``sending`` (with a refreshed ``created_at`` so the stale sweeper cannot flip the
     in-flight retry) and re-sent via :func:`_finalize_outreach_send` (a one-buyer plan
     built from the row's ``parts_included`` snapshot, reusing the persisted subject/body).
@@ -935,8 +942,12 @@ async def retry_outreach_send(
             sent_msg = await email_service._find_sent_message(gc, guard_subject, email)
         except Exception:
             # A lookup FAILURE is the UNKNOWN case, never proof of not-sent — the original
-            # may have delivered while the Sent-folder query is transiently failing. Never
-            # assume not-sent: leave the row in the ambiguous ``interrupted`` state
+            # may have delivered while the Sent-folder query is transiently failing.
+            # _find_sent_message's three-state contract raises SentMessageLookupError on
+            # Graph API errors (429/5xx/expired token) precisely so this branch can tell
+            # an outage apart from its positive-None "scanned cleanly, not there"; the
+            # broad `except` also keeps any unexpected error on the safe no-resend side.
+            # Never assume not-sent: leave the row in the ambiguous ``interrupted`` state
             # (retryable, no false delivery claim) and do NOT resend, so a delivered offer
             # is never double-sent. The trader (or a later retry) can re-run once Graph recovers.
             logger.warning(

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1697,7 +1697,9 @@ else `CustomerSite.contact_email`), **hard-blocks DNC** (site-level or a matchin
 `_build_quote_email_html` (whose single home is now this module — re-exported from
 `crm/_helpers.py` for the preview route), POSTs `/me/sendMail`, then captures the sent
 message's Graph ids via `email_service._find_sent_message` into `quote.graph_message_id` /
-`graph_conversation_id` (NULL-safe). It then transitions the quote→SENT, advances the
+`graph_conversation_id` (NULL-safe; a raised `SentMessageLookupError` — the lookup's
+lookup-failed state — is swallowed here since the mail already went out: ids stay NULL,
+reply matching degrades). It then transitions the quote→SENT, advances the
 requisition→QUOTED (unless WON/LOST/ARCHIVED), writes an OUTBOUND email `ActivityLog` via
 `activity_service.log_email_activity`, and commits, returning a frozen `SendQuoteResult`.
 Under `TESTING=1` the Graph POST + Sent-Items lookup are skipped but the quote is still
@@ -2269,7 +2271,11 @@ when the LIST's status is posting-closed (`bid_out`/`awarded`/`closed`/`expired`
 collecting are unchanged (draft/open/collecting fall through to the per-line active check).
 The nightly `app/jobs/resell_jobs.py::_job_expire_resell_lists` (02:15) →
 `excess_service.expire_overdue_lists` flips past-`close_at` unresolved (open/collecting) lists
-to `expired` and retires their mirror; the left-list stage filter now offers the `closed` /
+to `expired` and retires their mirror; a PARTIALLY-AWARDED list (any `awarded` line / `won`
+offer — a partial award deliberately stays `collecting`) instead steps to the non-terminal
+`bid_out`, because terminal `expired` would 409 every later `award_offer` and strand the
+still-live bids on its remaining lines (deep-review #2 finding #1; mirror retired identically —
+both are posting-closed). The left-list stage filter now offers the `closed` /
 `expired` stages (the status badges already rendered them).
 
 **Phase 5 (posting window + scoring + mirror identity).** Four related fixes:
@@ -2549,8 +2555,12 @@ only for `SENT` buyers (gated at the call site). Every send persists its exact s
 campaign. A Retry action (`retry_outreach_send`, background) and a nightly stale-`sending` sweeper
 (`sweep_stale_sending_outreach`, flips aged `sending`→`interrupted`) close the durability gaps —
 retry re-runs `_find_sent_message` (matched on the PERSISTED subject) BEFORE resending so an
-already-delivered row is reconciled to `SENT`, never double-sent; a lookup that RAISES is the
-UNKNOWN case → the row is left `interrupted` and nothing is resent (never assume not-sent); the
+already-delivered row is reconciled to `SENT`, never double-sent. `_find_sent_message` has a
+THREE-STATE contract (deep-review #2 finding 2): found dict | positive not-found (`None` —
+every attempt scanned the Sent window cleanly) | lookup-failed (raises
+`email_service.SentMessageLookupError` on Graph API errors — 429/5xx/expired token). Retry maps
+lookup-failed to the UNKNOWN case → the row is left `interrupted` and nothing is resent (never
+assume not-sent); ONLY the positive not-found authorizes a resend; the
 resend refreshes `created_at` so the stale sweeper can't flip an in-flight retry. An inbound
 reply carrying a bid flips an `OPEN` list to `COLLECTING`
 (mirroring `submit_offer`), and `expire_overdue_lists` isolates each list's flip+mirror+commit so

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -29,6 +29,7 @@ import pytest
 from app.email_service import (
     NOISE_DOMAINS,
     NOISE_PREFIXES,
+    SentMessageLookupError,
     _apply_parsed_result,
     _build_html_body,
     _classify_response,
@@ -420,12 +421,31 @@ class TestFindSentMessage:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_exception_returns_none(self):
+    async def test_api_error_raises_lookup_error(self):
+        """Deep-review #2, finding 2 — three-state contract: a lookup whose attempts hit
+        Graph API errors must RAISE (delivery state unknown), never return None.
+
+        None is reserved for the POSITIVE 'scanned the window cleanly, message is not
+        there' answer that authorizes a caller's resend.
+        """
         gc = AsyncMock()
         gc.get_json.side_effect = Exception("Network error")
         with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(SentMessageLookupError):
+                await _find_sent_message(gc, "Subject", "sales@vendora.com")
+
+    @pytest.mark.asyncio
+    async def test_transient_error_then_found_returns_match(self):
+        """A transient error on an early attempt followed by a successful match still
+        returns the message dict — found always wins over lookup-failed."""
+        gc = AsyncMock()
+        gc.get_json.side_effect = [
+            Exception("transient 429"),
+            {"value": [_sent_item("msg-1", "conv-1", "Subject")]},
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await _find_sent_message(gc, "Subject", "sales@vendora.com")
-        assert result is None
+        assert result["id"] == "msg-1"
 
     @pytest.mark.asyncio
     async def test_subject_whitespace_matching(self):

--- a/tests/test_quote_send.py
+++ b/tests/test_quote_send.py
@@ -260,6 +260,33 @@ async def test_service_graph_ids_none_safe_when_no_message(db_session, test_requ
     assert quote.graph_conversation_id is None
 
 
+async def test_service_lookup_error_degrades_to_null_ids(db_session, test_requisition, test_customer_site, test_user):
+    """Deep-review #2, finding 2: _find_sent_message now RAISES SentMessageLookupError
+    on Graph API errors (three-state contract).
+
+    The quote email already went out by then, so the send must still complete — graph
+    ids stay NULL (reply matching degrades), quote still transitions to sent.
+    """
+    from app.email_service import SentMessageLookupError
+    from app.services.quote_send import send_quote_email
+
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-GLKF")
+
+    with (
+        patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock) as mock_post,
+        patch("app.email_service._find_sent_message", new_callable=AsyncMock) as mock_find,
+    ):
+        mock_post.return_value = {}
+        mock_find.side_effect = SentMessageLookupError("graph 503 during lookup")
+        result = await send_quote_email(db_session, quote, test_user, token="t", testing=False)
+
+    assert result.graph_message_id is None
+    db_session.refresh(quote)
+    assert quote.status == "sent"
+    assert quote.graph_message_id is None
+    assert quote.graph_conversation_id is None
+
+
 async def test_service_raises_on_graph_error(db_session, test_requisition, test_customer_site, test_user):
     """A Graph error response raises QuoteSendError and does NOT mark sent."""
     from app.services.quote_send import QuoteSendError, send_quote_email

--- a/tests/test_resell_list_lifecycle.py
+++ b/tests/test_resell_list_lifecycle.py
@@ -6,7 +6,9 @@ Covers the M5 rework of the ExcessList posting-window lifecycle:
     stops advertising its supply as live);
   • ``expire_overdue_lists`` flips past-``close_at`` unresolved (open/collecting) lists to
     ``expired`` + retires their mirror, skips current / already-resolved ones, and is
-    idempotent;
+    idempotent; a PARTIALLY-AWARDED list (any awarded line / won offer) instead steps to
+    the non-terminal ``bid_out`` so its remaining live bids stay awardable (finding #1,
+    deep-review #2);
   • the nightly ``_job_expire_resell_lists`` job delegates to that service;
   • ``register_resell_jobs`` registers the expiry job;
   • the list-view stage filter now offers the ``closed`` / ``expired`` stages.
@@ -19,15 +21,21 @@ Depends on: app.services.excess_service, app.services.excess_mirror, app.jobs.re
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from app.constants import ExcessListStatus
+from app.constants import (
+    ExcessLineItemStatus,
+    ExcessListStatus,
+    ExcessOfferStatus,
+    OfferLineMatchStatus,
+)
 from app.models import Company, User
-from app.models.excess import ExcessList
+from app.models.excess import ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine
 from app.models.sourcing import Sighting
 from app.services import excess_service
 from app.services.excess_mirror import publish_list
@@ -323,6 +331,92 @@ def test_expire_is_idempotent(db_session, owner, company):
     later = close + timedelta(hours=2)
     assert excess_service.expire_overdue_lists(db_session, now=later) == 1
     assert excess_service.expire_overdue_lists(db_session, now=later) == 0
+
+
+def _matched_open_offer(
+    db: Session, excess_list: ExcessList, submitter: User, line: ExcessLineItem, unit_price: Decimal
+) -> ExcessOffer:
+    """An OPEN per-line ExcessOffer carrying one MATCHED line — ready to be awarded."""
+    offer = ExcessOffer(
+        excess_list_id=excess_list.id,
+        submitted_by=submitter.id,
+        scope="per_line",
+        status=ExcessOfferStatus.OPEN,
+    )
+    db.add(offer)
+    db.flush()
+    db.add(
+        ExcessOfferLine(
+            offer_id=offer.id,
+            excess_line_item_id=line.id,
+            mpn_raw=line.part_number,
+            quantity=line.quantity,
+            unit_price=unit_price,
+            match_status=OfferLineMatchStatus.MATCHED,
+        )
+    )
+    db.flush()
+    return offer
+
+
+def test_expire_partially_awarded_list_steps_to_bid_out_not_expired(db_session, owner, other_user, company):
+    """Regression (deep-review #2, finding #1): the nightly sweep must NOT send a
+    partially-awarded list to terminal ``expired``.
+
+    A partial award deliberately keeps the list COLLECTING (offers are still being
+    collected on the rest), so it lands in the sweep's open/collecting net. Flipping it to
+    ``expired`` (terminal) would 409 every later ``award_offer``, stranding the still-live
+    bids on the remaining lines. Instead the sweep steps it to ``bid_out`` — window
+    closed, mirror retired like any closed posting, but the remaining bids stay awardable.
+    """
+    close = datetime.now(UTC) + timedelta(hours=1)
+    el = create_excess_list(db_session, title="Excess", company_id=company.id, owner_id=owner.id, close_at=close)
+    import_line_items(
+        db_session,
+        el.id,
+        [{"part_number": "LM358N", "quantity": "100"}, {"part_number": "NE555P", "quantity": "50"}],
+    )
+    publish_list(db_session, el.id, owner)  # → open, mirrored; close_at preserved
+    db_session.refresh(el)
+    line_a, line_b = sorted(el.line_items, key=lambda li: li.id)
+    winner = _matched_open_offer(db_session, el, other_user, line_a, Decimal("0.50"))
+    remaining = _matched_open_offer(db_session, el, other_user, line_b, Decimal("0.40"))
+    el.status = ExcessListStatus.COLLECTING  # what submit_offer stamps on the first inbound offer
+    db_session.commit()
+
+    excess_service.award_offer(db_session, winner.id, owner)  # partial → list stays collecting
+    db_session.refresh(el)
+    assert el.status == ExcessListStatus.COLLECTING
+
+    n = excess_service.expire_overdue_lists(db_session, now=close + timedelta(hours=2))
+
+    assert n == 1
+    db_session.refresh(el)
+    assert el.status == ExcessListStatus.BID_OUT  # non-terminal: window closed, sale preserved
+    assert _sightings(db_session, company.id) == []  # mirror retired like any closed window
+
+    # The still-live bid on the remaining line is resolvable — award works on bid_out.
+    awarded = excess_service.award_offer(db_session, remaining.id, owner)
+    assert awarded.status == ExcessOfferStatus.WON
+    db_session.refresh(line_b)
+    assert line_b.status == ExcessLineItemStatus.AWARDED
+
+
+def test_expire_unawarded_list_still_expires(db_session, owner, other_user, company):
+    """An overdue list holding only a still-OPEN (never awarded) offer expires as before
+    — the bid_out carve-out is strictly for lists that already SOLD something."""
+    close = datetime.now(UTC) + timedelta(hours=1)
+    el = create_excess_list(db_session, title="Excess", company_id=company.id, owner_id=owner.id, close_at=close)
+    import_line_items(db_session, el.id, [{"part_number": "LM358N", "quantity": "100"}])
+    publish_list(db_session, el.id, owner)
+    db_session.refresh(el)
+    _matched_open_offer(db_session, el, other_user, el.line_items[0], Decimal("0.30"))
+    el.status = ExcessListStatus.COLLECTING
+    db_session.commit()
+
+    assert excess_service.expire_overdue_lists(db_session, now=close + timedelta(hours=2)) == 1
+    db_session.refresh(el)
+    assert el.status == ExcessListStatus.EXPIRED
 
 
 # ── Nightly job + registration ───────────────────────────────────────

--- a/tests/test_resell_outreach_async.py
+++ b/tests/test_resell_outreach_async.py
@@ -1243,6 +1243,144 @@ class TestRetryOutreachSend:
         assert row.status == ExcessOutreachStatus.FAILED
         assert row.send_error == "no buyer email on file to retry"
 
+    # ── Deep-review #2, finding 2: the REAL _find_sent_message three-state contract ──
+    # The tests above mock _find_sent_message itself, so they cannot catch a contract
+    # regression in the real function (it used to swallow every Graph error and return
+    # None — indistinguishable from "positively not delivered" — making the UNKNOWN
+    # branch dead code and double-sending on a Graph outage). These three drive the REAL
+    # lookup through a mocked GraphClient.
+
+    @pytest.mark.asyncio
+    async def test_retry_real_lookup_api_error_leaves_interrupted_and_never_resends(
+        self,
+        db_session: Session,
+        posted_list: ExcessList,
+        trader: User,
+        buyer_card: VendorCard,
+    ):
+        """REGRESSION (deep-review #2, finding 2): a Graph 429/5xx/expired-token during
+        the reconcile lookup must surface as lookup-FAILED (raise), not as None — the
+        row stays ``interrupted`` and nothing is resent.
+
+        Before the fix the real _find_sent_message swallowed the errors and returned
+        None, so the retry resent a possibly-delivered offer to a real buyer.
+        """
+        row_id = _fail_row(db_session, posted_list, trader, buyer_card)
+        send_mock = AsyncMock(return_value=[{"vendor_email": "sales@asyncbuyer.com", "status": "sent"}])
+        gc = AsyncMock()
+        gc.get_json.side_effect = Exception("graph 503 — service unavailable")
+
+        with (
+            patch("app.email_service.send_batch_rfq", send_mock),
+            patch("app.utils.graph_client.GraphClient", return_value=gc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await svc.retry_outreach_send(
+                outreach_id=row_id,
+                owner_id=trader.id,
+                subject="Excess available",
+                body="surplus",
+                token="fake-token",
+                session_factory=lambda: db_session,
+            )
+
+        send_mock.assert_not_called()  # delivery unknown → NEVER resend
+        db_session.expire_all()
+        row = db_session.get(ExcessOutreach, row_id)
+        assert row.status == ExcessOutreachStatus.INTERRUPTED
+        assert row.sent_at is None
+        assert row.send_error and "double-send" in row.send_error
+
+    @pytest.mark.asyncio
+    async def test_retry_real_lookup_positive_not_found_resends(
+        self,
+        db_session: Session,
+        posted_list: ExcessList,
+        line_item: ExcessLineItem,
+        trader: User,
+        buyer_card: VendorCard,
+    ):
+        """A POSITIVE not-found (every reconcile attempt scanned the Sent window
+        cleanly, no match) is the only answer that authorizes a resend — the real lookup
+        returns None and the retry resends exactly once."""
+        row_id = _fail_row(db_session, posted_list, trader, buyer_card)
+        send_mock = AsyncMock(return_value=[{"vendor_email": "sales@asyncbuyer.com", "status": "sent"}])
+        resent = {
+            "id": "resent-real-1",
+            "conversationId": "conv-resent-real-1",
+            "subject": "Excess available",
+            "toRecipients": [{"emailAddress": {"address": "sales@asyncbuyer.com"}}],
+        }
+        gc = AsyncMock()
+        # Guard lookup: 3 clean empty scans → positive not-found; post-send stamp
+        # lookup inside _finalize_outreach_send then finds the resent message.
+        gc.get_json.side_effect = [{"value": []}, {"value": []}, {"value": []}, {"value": [resent]}]
+
+        with (
+            patch("app.email_service.send_batch_rfq", send_mock),
+            patch("app.utils.graph_client.GraphClient", return_value=gc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await svc.retry_outreach_send(
+                outreach_id=row_id,
+                owner_id=trader.id,
+                subject="Excess available",
+                body="surplus",
+                token="fake-token",
+                session_factory=lambda: db_session,
+            )
+
+        assert send_mock.await_count == 1  # resent exactly once
+        db_session.expire_all()
+        row = db_session.get(ExcessOutreach, row_id)
+        assert row.status == ExcessOutreachStatus.SENT
+        assert row.graph_message_id == "resent-real-1"
+        assert row.send_error is None
+
+    @pytest.mark.asyncio
+    async def test_retry_real_lookup_found_reconciles_to_sent_without_resend(
+        self,
+        db_session: Session,
+        posted_list: ExcessList,
+        line_item: ExcessLineItem,
+        trader: User,
+        buyer_card: VendorCard,
+    ):
+        """The real lookup finding the delivered message (exact subject + recipient)
+        reconciles the row to SENT + stamps the found ids and never resends."""
+        row_id = _fail_row(db_session, posted_list, trader, buyer_card)
+        send_mock = AsyncMock()
+        delivered = {
+            "id": "already-real-1",
+            "conversationId": "conv-already-real-1",
+            "subject": "Excess available",
+            "toRecipients": [{"emailAddress": {"address": "sales@asyncbuyer.com"}}],
+        }
+        gc = AsyncMock()
+        gc.get_json.return_value = {"value": [delivered]}
+
+        with (
+            patch("app.email_service.send_batch_rfq", send_mock),
+            patch("app.utils.graph_client.GraphClient", return_value=gc),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await svc.retry_outreach_send(
+                outreach_id=row_id,
+                owner_id=trader.id,
+                subject="Excess available",
+                body="surplus",
+                token="fake-token",
+                session_factory=lambda: db_session,
+            )
+
+        send_mock.assert_not_called()  # already delivered → no double-send
+        db_session.expire_all()
+        row = db_session.get(ExcessOutreach, row_id)
+        assert row.status == ExcessOutreachStatus.SENT
+        assert row.graph_message_id == "already-real-1"
+        assert row.graph_conversation_id == "conv-already-real-1"
+        assert row.send_error is None
+
 
 # ── Router: the submit returns immediately with ``sending`` rows ─────
 


### PR DESCRIPTION
The P1 pair (findings 1–2) from `docs/superpowers/plans/2026-07-22-resell-deep-review-2.md` — the plan's designated immediate follow-up to #785. Both fixes TDD'd and adversarially verified (APPROVE on both).

## Finding 1 [P1] — nightly expiry stranded partially-awarded lists
`expire_overdue_lists` swept every open/collecting list past `close_at` into terminal EXPIRED, including lists deliberately kept COLLECTING by a partial award — so a list that actually SOLD parts displayed as "expired" and `award_offer` 409'd forever on its remaining live bids.
**Fix:** lists with any AWARDED line or WON offer now step to non-terminal **BID_OUT** (re-grounded: not in `_TERMINAL_LIST_STATUSES`, awardable, and already in the mirror's `_POSTING_CLOSED_STATUSES` so the Sighting mirror retires identically). Un-awarded overdue lists still expire. Regression tests prove the sweep → award-remaining-line round-trip now works.

## Finding 2 [P1] — retry double-send guard was dead code
`_find_sent_message` never raised (every attempt swallowed into `api_error=True` → `return None`), so `retry_outreach_send` could not distinguish a Graph 429/5xx during reconcile from "positively not delivered" — a transient outage triggered a real resend to a buyer.
**Fix:** three-state contract — found dict | positive not-found (`None` only after clean scans) | **`SentMessageLookupError`** (any API-errored attempt with no match; a found match always wins). Lookup-failed now maps to the INTERRUPTED no-resend branch; resend only on positive not-found. All four callers audited: `send_batch_rfq` (gather already captures exceptions), `_finalize_outreach_send` (intentional best-effort degradation kept), `retry_outreach_send` (guard now live), `quote_send` (previously unwrapped — now degrades to NULL ids instead of failing an already-delivered quote send).

## Verification
- TDD: both regression sets red pre-fix, green post-fix.
- Full sweep of all 67 resell/outreach/excess/email test modules: **1548 passed, 0 failed**; `pre-commit run --all-files` clean; mypy clean on all changed app files.
- No migrations, no template/UI changes.

## Reviewer notes (minor, non-blocking, from the adversarial pass)
- The sweep remains an unlocked list-status writer (same class as plan findings 8/9/11 — deferred to theme A by the plan's own sequencing; this fix reduces damage on that race).
- BID_OUT-with-AWARDED-line now occurs more often, which is finding 12's precondition — don't deprioritize finding 12.
- One docstring still implies resolved lists drop out of the open lens; true only for the expired path (matches owner-driven `close_list` behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)