### PR TITLE
AVAIL governance + proactive→Teams push (Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,8 @@ PROACTIVE_THROTTLE_DAYS=21
 PROACTIVE_SCAN_INTERVAL_HOURS=4
 PROACTIVE_MIN_MARGIN_PCT=10.0
 PROACTIVE_MATCH_EXPIRY_DAYS=30
+# Push new proactive matches into Teams as an Adaptive Card digest (opt-in).
+PROACTIVE_TEAMS_PUSH_ENABLED=false
 
 # ── Buy plan (CSV env vars, parsed to list[str] by model_validator) ──
 STOCK_SALE_VENDOR_NAMES=trio,trio supply chain,stock,internal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,414 +1,117 @@
-# CLAUDE.md — AvailAI
+# CLAUDE.md — AVAIL
 
-**AvailAI** — electronic-component sourcing engine and CRM for Trio Supply Chain Solutions.
-**Stack:** FastAPI + SQLAlchemy 2.0 + PostgreSQL 16 + HTMX 2.x + Alpine.js 3.x + Jinja2 + Tailwind CSS 3.x.
-**Deploy:** Docker Compose (app, enrichment-worker, db, redis, caddy, db-backup) on DigitalOcean.
-**Version:** `APP_VERSION` constant in `app/config.py` (currently `3.1.0`).
+Loaded every session. Do not restate this back to me.
 
-It searches supplier APIs in parallel (BrokerBin, Nexar, DigiKey, Mouser, OEMSecrets,
-Element14, Sourcengine, eBay, AI web search, email mining, plus browser-worker
-queues for NetComponents, The Broker Forum, and ICsource), tracks vendor intelligence,
-enriches companies/contacts (SAM.gov, Clay, Explorium, Lusha, Hunter + AI web
-search), automates RFQ workflows via Microsoft Graph,
-mines inboxes with Claude AI, and runs a full CRM (companies, quotes, buy plans,
-customer matching).
+## What this is
 
----
+AVAIL is a FastAPI/PostgreSQL sourcing platform and CRM for TRIO,
+an electronic component brokerage and ITAD operation. Single
+developer. Hosted on DigitalOcean at app.availai.net.
 
-## Authoritative Maps — read before exploring code
+**AVAIL is the command center, not the ERP.** We do not cut POs in
+AVAIL. We issue buy instructions to buyers, who cut the POs in the
+ERP and send them.
 
-- `docs/APP_MAP_ARCHITECTURE.md` — stack, infra, project structure
-- `docs/APP_MAP_DATABASE.md` — models, tables, relationships
-- `docs/APP_MAP_INTERACTIONS.md` — service interactions, data flows, integration patterns
-- `docs/BRANCH_AND_CI_WORKFLOW.md` — branch naming/lifecycle, the changed-files
-  formatting gate (do NOT bundle unrelated drift), and quarantine-before-delete
-  branch hygiene (`scripts/branch-cleanup.sh`)
+## Systems of record
 
-These are the canonical reference. CLAUDE.md only points at them. **After any code
-change, update the relevant APP_MAP doc(s) in the same PR.**
-
----
-
-## CODE RULES
-
-### Non-Negotiables
-- **Stack is HTMX + Alpine.js + Jinja2 — NOT React.** Reject React/SPA patterns; if a problem seems to need React, you're modeling it wrong. Server-render + HTMX swap.
-- **No band-aids, no half-measures.** Root-cause fixes only, even if interim breakage shows. Workarounds get the PR closed.
-- **Quality > speed. Zero ambiguity in designs.** Resolve every decision in the spec; no TBDs, no "options A/B".
-- **Hosted CLI only.** No GUI, no screenshots, no desktop-dependent suggestions, no browser visual companion.
-- **Before pushing big PRs:** run `pre-commit run --all-files` (local git-hook scope is narrower than CI and bites otherwise).
-- **Deploy is `./deploy.sh` only.** It passes a unique `--build-arg BUILD_COMMIT=<sha>-<ts>` that the Dockerfile consumes right before the source COPYs in BOTH stages, so templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache (~30s deploys; PR #211 — no more `--no-cache`). Bare `docker compose up -d --build` (without that build-arg) ships stale templates. After deploy, verify any new Tailwind classes actually appear in built CSS.
-
-- Always write tests with any new code. Don't ask, just include them.
-- Give exact file paths for everything.
-- Never use placeholder comments like "# rest of code here" — give complete code.
-- Keep responses under 150 lines. Break big tasks into steps.
-- Simple beats clever. 20 readable lines > 10 clever lines.
-- Use Loguru for logging, never print().
-- Use Ruff for linting.
-- Use Alembic for database migrations. Always include rollback steps.
-
-## Standing Workflow Rules
-
-### Execution Model
-- Always use subagent-driven execution for multi-step tasks — never ask, never offer inline
-- Maximize parallel subagents for all independent work — never serialize what can parallelize
-- Run the full skill pipeline on every task: brainstorm → plan → TDD → execute → simplify → review → verify (this order is canonical)
-- Never skip a step because it seems "overkill" — use every available tool and skill aggressively
-- Fix ALL review findings immediately — never defer as "lower priority" or "MVP acceptable"
-
-### UI Guardrails
-- Never add, remove, or rearrange UI elements without explicit user approval
-- Follow existing codebase patterns — find a working example before creating new UI conventions
-
-### Code Anti-Patterns (never introduce — in addition to Coding Conventions section)
-- `innerHTML` → use `htmx.ajax()` or Alpine reactive binding
-- Pydantic `class Config` → use `model_config = ConfigDict()`
-- Alpine `_x_dataStack` → use `Alpine.store()`
-- `db.query(Model).get(id)` → use `db.get(Model, id)`
-- Anything with a literal `"` inside a **double-quoted** Alpine attribute (`x-data`/`@event`/`:bind`) → the `"` closes the attribute early and breaks Alpine init for the whole component (dead handlers, often only a console warning). Two common triggers: (a) prose / JS `//` comments — move them to a Jinja `{# #}` comment *outside* the attribute; (b) `{{ ...|tojson }}` — `tojson` is Markup-safe so a trailing `|e` is a **no-op**; embed it in a **single-quoted** attribute instead (`x-data='{{ x|tojson }}'`, tojson escapes `'`).
-- Inner htmx container that should swap into **itself** but omits `hx-target` → under `<main id="main-content" hx-target="this">` it inherits `hx-target="this"` (resolving to `#main-content`) and **replaces the whole page** on its `load`/trigger. Always set an explicit `hx-target` (e.g. `hx-target="this"`) on faceted/lazy-load sub-containers.
-- htmx event filter `[condition]` **not** hugging the event name → `keyup[cond]` is valid, but `keyup changed delay:800ms[cond]` (filter trailing a modifier) throws `htmx:syntax:error` and silently disables the trigger. The `[filter]` must immediately follow the event.
-- Alpine magics (`$dispatch`/`$store`/`$el`…) inside an **`hx-on:`** attribute → htmx evaluates hx-on code as plain JS (`new Function('event', code)`), so the magic is undefined and the handler throws `ReferenceError` at runtime (e.g. a modal that never closes after save, with a clean server log). In hx-on use plain JS — `this.dispatchEvent(new CustomEvent("close-modal", {bubbles: true}))` — or move the handler to an Alpine-evaluated attribute (`@htmx:after-request.camel`).
-- Jinja form prefills like `value='{{ (obj.field if obj else "") | e }}'` → a NULL column stringifies to the literal **'None'** in the input, and the next save writes the string `'None'` into the DB. Always coalesce: `value='{{ ((obj.field or "") if obj else "") | e }}'`.
-- htmx clickable rows (`hx-trigger="click, keyup[key=='Enter']"`) with interactive descendants guarded only by `@click.stop` → Enter on a focused child (link/button) still bubbles its **keyup** to the row and double-fires the row navigation. Add `@keyup.stop` alongside `@click.stop` on every focusable child.
-
-### Asking Questions / Clarifications
-- Ask clarifying questions **ONE AT A TIME** — never batch multiple questions into a single
-  message. Wait for the answer before asking the next.
-- Always present **suggested answers** as concrete options (each with a one-line rationale),
-  and mark exactly **one "(Recommended)"** with why.
-- Prefer the structured multiple-choice question tool (with the Recommended option) over
-  open-ended prose questions.
-
-### Linear Development
-- Memory references specific code (line numbers, function names)? Verify against current files before acting
-- Plans or specs with line numbers? Verify those lines are still correct before editing
-- Never mix old patterns with new — if the codebase has moved to a new pattern, follow the new one
-- Always read the actual codebase before making changes — never rely on cached assumptions
-
-### PR Reviews
-- Saved fleet: `Workflow({name: "pr-review-fleet", args: {pr, branch, worktree, title}})`
-  (`.claude/workflows/pr-review-fleet.js`) — all 6 pr-review-toolkit + feature-dev
-  reviewers in parallel → adversarial verify per finding → fix-all → simplify, with the
-  git constraints below baked in.
-- Caveat: invoking via scriptPath+args has misfired twice — for a one-off fleet, bake the
-  pr/branch/worktree/title values inline instead of passing args.
-
-### Git Discipline
-- **Merge, don't rebase, on pushed branches** — force-push is hook-blocked, so a rebase
-  strands the branch. `git fetch origin && git merge origin/main`; resolve conflicts root-cause.
-- Already-rebased branch? Append-only recovery: (1) snapshot the rebased state to a temp
-  branch, (2) `git checkout -B <branch> origin/<branch>`, (3) merge origin/main, (4) apply
-  the snapshot as a tree diff (`git diff HEAD <temp> | git apply`, commit), (5) plain push.
-- `gh pr edit` is broken (deprecated Projects-classic GraphQL, fails silently) — use
-  `gh api -X PATCH /repos/<owner>/<repo>/pulls/<n> --input -`.
-- When docformatter rewraps a docstring, run `pre-commit` twice — the first run mutates,
-  the second verifies clean.
-
----
-
-## Project Layout
-
-Top-level `app/` modules of note (see APP_MAP_ARCHITECTURE for the full tree):
-
-- `main.py` — FastAPI app, router registration, middleware, lifespan
-- `config.py` — Pydantic Settings (env vars, `APP_VERSION`, `MVP_MODE`)
-- `database.py` — SQLAlchemy engine, `SessionLocal`, `UTCDateTime` type
-- `dependencies.py` — auth deps: `require_user`, `require_admin`, `require_buyer`, `require_fresh_token`
-- `constants.py` — status `StrEnum`s — always use these, never raw strings
-- `shared_constants.py` — `JUNK_DOMAINS`, `JUNK_EMAIL_PREFIXES`
-- `startup.py` — runtime ops only (triggers, seeds, ANALYZE) — **no DDL**
-- `scheduler.py` / `jobs/` — APScheduler coordinator and job definitions
-- `search_service.py` — requirement search orchestrator (all supplier sources)
-- `email_service.py` — Graph API batch RFQ, inbox monitor, AI reply parsing
-- `enrichment_service.py` — customer/vendor enrichment orchestrator
-- `scoring.py` — sighting buyer-usefulness multi-factor scoring
-- `evidence_tiers.py` — data-provenance tier tags for sightings/offers
-- `vendor_utils.py` — `fuzzy_score_vendor()` (rapidfuzz wrapper) — use this, never inline fuzzy
-- `http_client.py` — shared singleton `httpx.AsyncClient`s (connection pooling for outbound)
-- `rate_limit.py` — shared rate limiter (Redis-backed, in-memory fallback)
-- `prometheus_metrics.py` — ASGI metrics middleware + `/metrics` endpoint
-- `connector_status.py` — logs which supplier connectors are enabled/disabled at startup
-- `models/` `schemas/` `routers/` `services/` `connectors/` `cache/` `utils/` `management/`
-- `config/routing_maps.json` — brand→commodity inference maps (used by buy-plan scoring)
-- `templates/` (Jinja2) `static/` (Vite-built assets in `static/dist/`)
-
-`app/management/` holds one-off CLI commands (e.g. `python -m app.management.reenrich`).
-
-Migrations live at repo-root `alembic/versions/`, **not** under `app/`.
-Tests live in `tests/` (unit/integration) and `tests/e2e/` (Playwright).
-
----
-
-## Auth Model
-
-OAuth2 via Azure AD — `app/routers/auth.py` handles login/callback/logout.
-Session middleware stores `user_id` in an HTTP-only cookie (24-hour expiry,
-`max_age=86400` in `app/main.py`). `require_fresh_token` enforces hard token
-expiry only; the 15-min-buffer refresh runs in the background token-refresh
-job (`app/jobs/core_jobs.py`, every 5 min).
-
-Permission dependencies: `require_user` (any login — includes the search
-views), `require_buyer` (buyer actions: stock-list import, enrichment,
-vendor-contact ops), `require_admin` (settings, user management).
-
----
-
-## Coding Conventions
-
-### Database
-- Use `db.get(Model, id)`, **not** `db.query(Model).get(id)` (SQLAlchemy 2.0 style).
-- Status values: always use `StrEnum` constants from `app/constants.py`, never raw strings
-  (e.g. `RequisitionStatus.OPEN`, `SourcingStatus.OFFERED`).
-- Keep routers thin (HTTP only); put business logic in `app/services/`.
-- **MaterialCard category/spec writes: the F1 tier ladder (`app/services/spec_tiers.py`)
-  is the single arbitration point.** ALL such writes go through `set_category()` /
-  `record_spec()` — never assign `card.category` or facets directly. Writers MUST register
-  their source string in `SOURCE_TIER` (unknown source → tier 0 → loses every conflict).
-  Never add per-writer confidence pre-gates — the ladder owns arbitration; run order is
-  not load-bearing. Enrichment writers + evidence-source tiers table:
-  `docs/APP_MAP_INTERACTIONS.md`.
-
-### Search & Matching
-- Vendor matching: `fuzzy_score_vendor()` from `app/vendor_utils.py` (rapidfuzz wrapper). Never inline fuzzy logic.
-- MPN dedup: `strip_packaging_suffixes()` from `app/services/search_worker_base/mpn_normalizer.py`.
-- **`search_requirement()` uses a separate write session** — the caller's ORM objects are
-  stale after it returns. Call `db.expire(requirement)` before rendering templates.
-
-### MPN Normalization
-- `normalize_mpn()` uppercases, strips noise, returns `None` for MPNs < 3 chars.
-- `@validates` on `Requirement` auto-uppercases `primary_mpn`, `customer_pn`, `oem_pn` on save.
-- Use the `|sub_mpns` Jinja2 filter to display substitutes (handles string and dict forms).
-
-### Substitutes Format
-- Canonical: `[{"mpn": "ABC123", "manufacturer": "TI"}, ...]` (list of dicts).
-- Legacy rows may hold plain strings `["ABC123"]` — always handle both.
-- Write paths: use `parse_substitute_mpns()` from `app/utils/normalization.py`.
-
-### Shared Constants
-- Junk email domains/prefixes: import `JUNK_DOMAINS` / `JUNK_EMAIL_PREFIXES` from `app/shared_constants.py`. Don't duplicate.
-
-### Caching
-```python
-from app.cache.decorators import cached_endpoint
-
-@cached_endpoint("vendor_list", ttl_hours=24, key_params=["supplier"])
-async def get_vendors(supplier: str): ...
-```
-
-### Logging
-- Always Loguru (`from loguru import logger`), never `print()`. request_id context is auto-injected.
-
-### Frontend
-- Navigation is HTMX-driven: `<a hx-get>` → server HTML fragment → swap into `#main-content`. No client routing, no JSON.
-- State is Alpine.js via `Alpine.store()` (persisted with the `@persist` plugin).
-- Toast: `$store.toast` has `message`, `type`, `show` (boolean) — set them directly; `show` is not a method.
-- Plugin/extension lists: see `app/static/htmx_app.js` and `app/templates/htmx/base.html`.
-- **Before editing any template**, trace `router → view function → template_response()`.
-  Routers can render a partial whose path doesn't match the router name — follow the router.
-
-### Response Formats
-- JSON errors: `{"error": "...", "status_code": 400, "request_id": "..."}` — tests check `["error"]`, not `["detail"]`.
-- List responses: `{"items": [...], "total": N, "limit": N, "offset": N}` — not a plain array.
-- HTMX responses: `HTMLResponse` from Jinja2. Schemas in `app/schemas/`.
-
-### Files
-- Every new file needs a header comment: what it does, what calls it, what it depends on.
-
----
-
-## Database & Migration Rules
-
-### ABSOLUTE RULES — NEVER VIOLATE
-1. **ALL schema changes go through Alembic.** Never use raw DDL in startup.py, services, routers, or scripts.
-2. **Never use Base.metadata.create_all() for schema changes.**
-3. **Never run raw SQL against production** outside of a migration.
-4. **Migration workflow — every time:**
-   a. Make model change in `app/models/`
-   b. Run: `alembic revision --autogenerate -m "description"`
-   c. REVIEW the generated migration
-   d. Test: upgrade → downgrade → upgrade
-   e. Commit migration with model change
-
-5. **After creating a migration, ALWAYS run `alembic heads`** to verify a single head. If multiple heads: `alembic merge heads -m "merge_description"`. Data-only migrations (no schema changes) use `op.get_bind()` + raw SQL via `text()`.
-
-6. **startup.py is for runtime operations ONLY:**
-   - FTS triggers (PostgreSQL-specific)
-   - Seed data (system_config defaults)
-   - ANALYZE on hot tables
-   - Idempotent backfill queries
-   - Count triggers (PG-specific)
-   - NOTHING that creates, alters, or drops tables/columns/indexes/constraints
-
----
-
-## Commands
-
-### Docker
-```bash
-docker compose up -d              # Start all containers
-docker compose logs -f app        # Tail app logs
-docker compose ps                 # Show status
-docker compose down               # Stop everything
-```
-
-### Deploy
-```bash
-./deploy.sh                       # From main: commit + push + rebuild + health-check + verify
-./deploy.sh --no-commit           # Rebuild current branch without committing/pushing
-```
-`deploy.sh` must run from `main` unless `--no-commit`. It builds with a unique
-`BUILD_COMMIT` build-arg (consumed before the source COPYs in both Dockerfile stages, so
-templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache — no `--no-cache`),
-rebuilds + recreates **both** the `app` and `enrichment-worker` containers (they share
-`requirements.txt`, so the worker must not lag the app on a dependency bump), waits for
-the app health check, verifies the deployed build tag on both, checks that Tailwind
-classes in templates exist in the built CSS bundle, and restarts the host `nc`/`ics`
-worker systemd units (they run from `/root/availai` outside docker, so they'd otherwise
-keep running stale code after a deploy).
-Never use bare `docker compose up -d --build` (without `--build-arg BUILD_COMMIT=...`) —
-it ships stale templates.
-
-### Python lint / type check
-```bash
-ruff check app/                   # Lint
-ruff format app/                  # Auto-format
-mypy app/                         # Type check
-```
-Pre-commit hooks: ruff, ruff-format, mypy, docformatter, detect-private-key.
-
-### Dependencies (pip-tools lockfiles)
-
-Python deps are **pinned lockfiles** compiled from hand-authored sources, so every
-install (CI + deploy) is reproducible.
-
-- **Edit** `requirements.in` (prod) / `requirements-dev.in` (dev) — never the `.txt`.
-- **Recompile** the locks, then commit BOTH the `.in` and the regenerated `.txt`:
-  ```bash
-  pip-compile --no-header --no-strip-extras requirements.in
-  pip-compile --no-header --no-strip-extras requirements-dev.in
-  ```
-- `requirements.txt` (prod lock) is what the Docker image + `deploy.sh` install;
-  `requirements-dev.txt` adds the dev/test tools. CI fails if a `.txt` drifts from
-  its `.in` (the "Verify requirements lockfiles are in sync" step).
-- To bump a dep: change the constraint in the `.in`, recompile, run the suite. To
-  refresh transitive pins to newest: `pip-compile --upgrade ...`.
-- **Dependabot pip PRs** edit the files textually and can't run pip-compile, so they
-  fail the sync gate. `.github/workflows/dependabot-lockfile-sync.yml` auto-recompiles
-  the locks and pushes the corrected `.txt` back to the PR (set a `DEPENDABOT_LOCKFILE_TOKEN`
-  PAT secret to make that push re-trigger CI / turn the checks green).
-
-### Migrations
-```bash
-alembic upgrade head                              # Apply pending
-alembic downgrade -1                              # Rollback one
-alembic revision --autogenerate -m "description"  # New migration
-alembic current / alembic history / alembic heads
-```
-
-### Tests
-`pytest.ini` sets `asyncio_mode=auto`, `-n auto` (xdist parallel), a 30s per-test
-timeout, and ignores `tests/e2e/`. Always set `TESTING=1` (disables scheduler and
-real API calls); tests use in-memory SQLite. `conftest.py` provides fixtures and the
-test `engine`.
-
-```bash
-# During dev — changed module only
-TESTING=1 PYTHONPATH=/root/availai pytest tests/test_<module>.py -v
-
-# Before commit — full suite
-TESTING=1 PYTHONPATH=/root/availai pytest tests/ -v
-
-# Before PR only — coverage
-TESTING=1 PYTHONPATH=/root/availai pytest tests/ --cov=app --cov-report=term-missing --tb=no -q
-
-# Skip slow tests
-TESTING=1 PYTHONPATH=/root/availai pytest -m "not slow" -v
-
-# Single file without xdist parallelism
-TESTING=1 PYTHONPATH=/root/availai pytest tests/test_foo.py -v --override-ini="addopts="
-```
-Never add `--cov` to iterative dev runs — only before a PR. Mock lazy imports at the
-source module, not the import site.
-
-### Frontend / E2E
-```bash
-npm run dev          # Vite dev server (localhost:5173)
-npm run build        # Production build → app/static/dist/ (postbuild smoke test is a NO-OP — scripts/smoke-test-bundles.mjs missing)
-npm run lint         # ESLint
-npm run test:frontend  # Vitest
-npx playwright test --project=workflows   # E2E (also: dead-ends, visual, accessibility)
-```
-
----
-
-## MVP Mode
-
-`config.py: mvp_mode` now gates ONLY the Teams chat integration (webhook 404 +
-subscription skip). Dashboard, Enrichment, and Task Manager are un-gated,
-always on.
-
----
-
-## Observability
-
-- **Sentry** — initialized in `app/main.py` lifespan only when `SENTRY_DSN` is set
-  (FastAPI, httpx, Loguru, SQLAlchemy integrations). A `before_send` hook scrubs
-  sensitive data — extend it, never bypass it, when adding new sensitive fields.
-- **Prometheus** — `app/prometheus_metrics.py` is a pure ASGI middleware exposing
-  `http_requests_total`, `http_request_duration_seconds`, and `http_requests_inprogress`
-  at `GET /metrics` (token-gated). It replaced `prometheus-fastapi-instrumentator` (which
-  hard-pinned `starlette<1.0.0`); keep it streaming-safe (don't consume response bodies)
-  so it composes with SSE endpoints.
-- **Logging** — Loguru with auto-injected `request_id` context (see Logging convention).
-
----
-
-## Configuration
-
-All config via `.env` (see `.env.example`). Key groups: Azure OAuth (`AZURE_CLIENT_ID`,
-`AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`; the OAuth callback URL is derived from `APP_URL`),
-Anthropic (`ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`), `DATABASE_URL`, `REDIS_URL`, supplier API
-keys (feature disabled if unset — e.g. `NEXAR_CLIENT_ID`, `BROKERBIN_API_KEY`,
-`DIGIKEY_CLIENT_ID`, `MOUSER_API_KEY`), feature flags (`MVP_MODE`, `EMAIL_MINING_ENABLED`,
-etc.), and observability (`SENTRY_DSN` — optional).
-
----
-
-## Triggers
-
-- "new feature" = make a plan first, don't just start coding
-- "bug" / "error" = ask for the full error message before fixing
-- "refactor" = check what's stable first
-- "quick" / "just" = warn about hidden complexity
-
-## Safety
-
-- WARN before DROP, DELETE, or bulk data changes; include backup + rollback steps.
-- For production, verify a backup exists first. The `db-backup` service runs `pg_dump`
-  every 6 hours; manual restore via `scripts/restore.sh`.
-
----
-
-## Skill Usage Guide
-
-Invoke skills proactively — don't ask. Triggers:
-
-| Trigger | Skill |
+| Lives in Acctivate (ERP) | Lives in AVAIL |
 |---|---|
-| Adding/modifying FastAPI routes, deps, middleware | `fastapi` |
-| Writing SQLAlchemy 2.0 models, queries, relationships, fixtures | `sqlalchemy` |
-| Adding HTMX attributes, partials, inline edits, lazy-loads, modals | `htmx` |
-| Editing Jinja2 templates, macros, custom filters, partials | `jinja2` |
-| Touching `vite.config.js`, JS/CSS entry points, Vitest specs | `vite` |
-| Building/styling UI (HTMX + Alpine + Tailwind) | `frontend-design` |
-| Writing/fixing pytest tests, fixtures, mocks | `pytest` |
-| Adding/invalidating Redis cache, `@cached_endpoint` | `redis` |
-| Fixing pre-commit lint errors, ruff rules, noqa | `ruff` |
-| Fixing mypy errors, adding type annotations | `mypy` |
-| Writing/extending Playwright E2E specs | `playwright` |
-| Empty states, first-run flows, onboarding nudges | `designing-onboarding-paths`, `orchestrating-feature-adoption` |
-| Funnel events, activity tracking, activation metrics | `mapping-conversion-events`, `instrumenting-product-metrics` |
-| Page copy, CTAs, microcopy | `crafting-page-messaging`, `tuning-landing-journeys` |
-| SEO/meta/structured data on public pages | `inspecting-search-coverage`, `adding-structured-signals` |
+| Sales orders | Everything else |
+| Purchase orders | Requisitions, buy plans, quality plans |
+| Inventory | Resell, CRM, contacts, approvals, audit |
+
+## Hard constraints
+
+- **Nothing integrates with Acctivate.** No sync, no read, no
+  write. It is manual by design. Do not propose otherwise.
+- **ERP-neutral field naming.** We move to Dynamics 365 Business
+  Central in 2027. Never hardcode a vendor name into a field,
+  model, or column. `erp_so_number`, not `acctivate_so_number`.
+- AVAIL stores external ERP document numbers as references only.
+  It never owns the SO/PO lifecycle.
+
+## Business context
+
+**The Quality Plan is the hub document.** One QP per TSO, today an
+Excel workbook in a SharePoint library. It contains four sections
+in one sheet:
+
+```
+QUALITY PLAN (per TSO)
+├── SALES section        → gated by Sales Order approval
+├── PURCHASING section   → gated by PO approval
+├── BUY PLAN section     → gated by Buy Plan approval
+└── SERIAL / FRU section → ops / receiving tracking
+    + Vendor Prepayment approval (standalone, tied to a PO)
+```
+
+The Buy Plan already in AVAIL is a section inside the QP, not a
+sibling of it. Approved QPs render back into the same SharePoint
+library path so existing approval-card attachment links keep
+working.
+
+**Order types:** New, Revision, Testing Service, Comps Program,
+Stock Sale. Some order types have no buy plan.
+
+**Approvals Workspace:** four tabs — Sales Orders, Buy Plans,
+Purchase Orders, Prepayments. All four are lenses on one pipeline
+rooted at the sales order, not four separate sign-offs. The buy
+plan shares the sales order's single manager approval. The detail
+pane is a working editor at every stage; every change is
+audit-logged.
+
+**Two-screen model:** the Approvals workspace is the approval desk
+(all decide actions). A full-page Deal view is the home for
+build/fix work — draft, submit, line edits, issues,
+request-prepayment.
+
+**Approval routing:** SO, buy plan, and PO run day to day through
+one manager, with two others as any-of-3 first-responder-wins
+backup. Prepayments route to two accounting approvers, plus the
+owner on higher value.
+
+**Auto-approve rule:** deals under $5K revenue auto-approve.
+Everything else is a one-click approval with drill-in to edit.
+
+**Roles:** sales, buyer, manager, admin. No sub-roles. Internally,
+sales staff only sell, buyers only buy, traders do both.
+
+**Resell module:** the inverse of sourcing. Post customer excess,
+internal traders submit offers, owner builds a bid back to the
+customer. ExcessList/ExcessLine mirrors the
+Requisition/Requirement pattern. Posted lines dual-write into the
+existing Sighting table so the matcher picks them up. Offers are
+scoped per-line or take-all. Customer identity is hidden on
+postings. Match on part number only — no price ranking, no margin
+math.
+
+## Code conventions
+
+- Structure: `routers/` (thin), `services/` (fat), `models/`,
+  `schemas/`, `specs/`, `test_fixtures/`, `tests/`
+- Routers call services. Business logic never lives in a router.
+- Loguru, never `print()`
+- Header docstring on every new file
+- Tests alongside code, same commit
+- Exact file paths. No placeholders, no `path/to/file.py`
+- Alembic: check the current migration head before writing one
+
+## How to work with me
+
+- I am usually on a phone in Termius. I cannot read code to check
+  your work. Show me output, not claims.
+- Simple over clever, every time.
+- ~150 lines per response.
+- Warn before any destructive operation and wait.
+- If something is missing that materially changes the answer, ask.
+  Do not guess and do not present an assumption as a fact.
+
+## Do not
+
+- Invent file paths, model names, or column names. Verify or ask.
+- Add phasing plans, role-permission tiers, or financial logic I
+  did not ask for.
+- Expand scope past the one feature named in the session prompt.
+- Answer with a plan when I asked for the concept.
+- Report a test as passing without pasting the actual output.
+- Leave a TBD anywhere.

--- a/app/config.py
+++ b/app/config.py
@@ -258,6 +258,10 @@ class Settings(BaseSettings):
     proactive_scan_interval_hours: int = 4
     proactive_min_margin_pct: float = 10.0
     proactive_match_expiry_days: int = 30
+    # Push new proactive matches into Teams as an Adaptive Card digest. Default
+    # OFF so enabling delivery is a deliberate admin choice (it sends real Teams
+    # messages). Admin can override via the proactive_teams_push_enabled flag.
+    proactive_teams_push_enabled: bool = False
 
     # --- Buy plan (CSV env vars, parsed to list[str] by model_validator) ---
     stock_sale_vendor_names: str | list[str] = "trio,trio supply chain,stock,internal"

--- a/app/jobs/offers_jobs.py
+++ b/app/jobs/offers_jobs.py
@@ -33,6 +33,15 @@ def register_offers_jobs(scheduler, settings, db=None):
             name="Proactive matching",
         )
 
+    if get_effective_flag(db, "proactive_teams_push_enabled", settings.proactive_teams_push_enabled):
+        push_interval_h = max(1, settings.proactive_scan_interval_hours)
+        scheduler.add_job(
+            _job_proactive_teams_push,
+            IntervalTrigger(hours=push_interval_h),
+            id="proactive_teams_push",
+            name="Push new proactive matches to Teams",
+        )
+
     scheduler.add_job(
         _job_performance_tracking, IntervalTrigger(hours=12), id="performance_tracking", name="Scoring and leaderboards"
     )
@@ -103,6 +112,28 @@ async def _job_proactive_matching():
         logger.exception(f"Proactive matching error: {e}")
         db.rollback()
         raise
+    finally:
+        db.close()
+
+
+@_traced_job
+async def _job_proactive_teams_push():
+    """Push not-yet-pushed NEW proactive matches to Teams as an Adaptive Card digest.
+
+    Flag-gated (proactive_teams_push_enabled, default off). Idempotent via a
+    SystemConfig watermark, so it is safe to run every scan cycle.
+    """
+    from ..database import SessionLocal
+    from ..services.proactive_teams_push import push_new_matches_to_teams
+
+    db = SessionLocal()
+    try:
+        result = await push_new_matches_to_teams(db)
+        if result["pushed"]:
+            logger.info(f"Proactive Teams push: delivered {result['pushed']} new match(es)")
+    except Exception as e:
+        logger.exception(f"Proactive Teams push error: {e}")
+        db.rollback()
     finally:
         db.close()
 

--- a/app/jobs/offers_jobs.py
+++ b/app/jobs/offers_jobs.py
@@ -33,7 +33,9 @@ def register_offers_jobs(scheduler, settings, db=None):
             name="Proactive matching",
         )
 
-    if get_effective_flag(db, "proactive_teams_push_enabled", settings.proactive_teams_push_enabled):
+    # `is True` (not truthiness): register only on an explicit True so a MagicMock
+    # settings passed by unrelated scheduler tests resolves to off, not a spurious job.
+    if get_effective_flag(db, "proactive_teams_push_enabled", settings.proactive_teams_push_enabled) is True:
         push_interval_h = max(1, settings.proactive_scan_interval_hours)
         scheduler.add_job(
             _job_proactive_teams_push,

--- a/app/services/proactive_teams_push.py
+++ b/app/services/proactive_teams_push.py
@@ -1,0 +1,120 @@
+"""proactive_teams_push.py — Push new proactive matches into Teams.
+
+Phase 1 of the Teams-agent / proactive plan (specs/plan-teams-agent-proactive.md).
+The proactive engine already writes scored ProactiveMatch rows but they only
+surface in-app. This service composes an Adaptive Card digest of the newly
+created NEW matches and posts it to the shared Teams channel, so a salesperson
+learns about them without opening AVAIL and clicking "refresh".
+
+A SystemConfig high-water-mark on the match id (``proactive_teams_push_last_id``)
+guarantees each match is pushed at most once — the job is safe to run on any
+cadence and across restarts. Delivery reuses the existing outbound Adaptive Card
+webhook path; nothing here talks to a bot.
+
+Called by: app/jobs/offers_jobs.py (_job_proactive_teams_push)
+Depends on: app.config, app.models, app.services.teams_notifications
+"""
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from ..config import settings
+from ..constants import ProactiveMatchStatus
+from ..models.config import SystemConfig
+from ..models.crm import Company
+from ..models.intelligence import ProactiveMatch
+from .teams_notifications import post_teams_channel_card
+
+_WATERMARK_KEY = "proactive_teams_push_last_id"
+
+# Bound how many matches one run considers, and how many appear in the card body.
+_SCAN_CAP = 500
+_CARD_ROWS = 10
+
+
+def _get_last_id(db: Session) -> int:
+    """Highest ProactiveMatch id already pushed to Teams (0 if never)."""
+    row = db.query(SystemConfig).filter(SystemConfig.key == _WATERMARK_KEY).first()
+    if row and row.value and row.value.isdigit():
+        return int(row.value)
+    return 0
+
+
+def _set_last_id(db: Session, match_id: int) -> None:
+    """Persist the push high-water-mark to SystemConfig."""
+    row = db.query(SystemConfig).filter(SystemConfig.key == _WATERMARK_KEY).first()
+    if row:
+        row.value = str(match_id)
+    else:
+        db.add(
+            SystemConfig(
+                key=_WATERMARK_KEY,
+                value=str(match_id),
+                description="Highest proactive match id pushed to Teams",
+            )
+        )
+    db.commit()
+
+
+def _build_card(matches: list[ProactiveMatch], names: dict[int, str], total: int) -> dict:
+    """Build the Adaptive Card for a batch of new proactive matches."""
+    header = f"🎯 {total} new proactive match{'es' if total != 1 else ''} in AVAIL"
+    facts = []
+    for m in matches[:_CARD_ROWS]:
+        company = names.get(m.company_id, "Unknown customer") if m.company_id else "Unknown customer"
+        facts.append({"title": m.mpn, "value": f"{company} — score {m.match_score or 0}"})
+    body: list[dict] = [
+        {"type": "TextBlock", "text": header, "weight": "Bolder", "size": "Medium", "wrap": True},
+        {"type": "FactSet", "facts": facts},
+    ]
+    if total > _CARD_ROWS:
+        body.append(
+            {
+                "type": "TextBlock",
+                "text": f"+{total - _CARD_ROWS} more — open AVAIL to review.",
+                "wrap": True,
+                "isSubtle": True,
+            }
+        )
+    return {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "body": body,
+        "actions": [{"type": "Action.OpenUrl", "title": "Review in AVAIL", "url": f"{settings.app_url}/v2/proactive"}],
+    }
+
+
+async def push_new_matches_to_teams(db: Session) -> dict[str, int]:
+    """Post a digest of not-yet-pushed NEW proactive matches to Teams.
+
+    Idempotent via the ``proactive_teams_push_last_id`` watermark: only matches
+    with an id above the mark are considered, and the mark advances to the highest
+    id seen this run (whether or not it made the card body), so nothing repeats.
+
+    Returns ``{"pushed": <count>}`` — 0 when there is nothing new.
+    """
+    last_id = _get_last_id(db)
+    matches: list[ProactiveMatch] = (
+        db.query(ProactiveMatch)
+        .filter(ProactiveMatch.status == ProactiveMatchStatus.NEW, ProactiveMatch.id > last_id)
+        .order_by(ProactiveMatch.match_score.desc(), ProactiveMatch.id.asc())
+        .limit(_SCAN_CAP)
+        .all()
+    )
+    if not matches:
+        return {"pushed": 0}
+
+    company_ids = {m.company_id for m in matches if m.company_id}
+    names: dict[int, str] = {}
+    if company_ids:
+        for cid, cname in db.query(Company.id, Company.name).filter(Company.id.in_(company_ids)).all():
+            names[cid] = cname
+
+    total = len(matches)
+    await post_teams_channel_card(_build_card(matches, names, total))
+
+    max_id = max(m.id for m in matches)
+    _set_last_id(db, max_id)
+    logger.info(f"Proactive Teams push: sent digest of {total} new match(es), watermark now {max_id}")
+    return {"pushed": total}

--- a/docs/CLAUDE_legacy_availai.md
+++ b/docs/CLAUDE_legacy_availai.md
@@ -1,0 +1,414 @@
+# CLAUDE.md — AvailAI
+
+**AvailAI** — electronic-component sourcing engine and CRM for Trio Supply Chain Solutions.
+**Stack:** FastAPI + SQLAlchemy 2.0 + PostgreSQL 16 + HTMX 2.x + Alpine.js 3.x + Jinja2 + Tailwind CSS 3.x.
+**Deploy:** Docker Compose (app, enrichment-worker, db, redis, caddy, db-backup) on DigitalOcean.
+**Version:** `APP_VERSION` constant in `app/config.py` (currently `3.1.0`).
+
+It searches supplier APIs in parallel (BrokerBin, Nexar, DigiKey, Mouser, OEMSecrets,
+Element14, Sourcengine, eBay, AI web search, email mining, plus browser-worker
+queues for NetComponents, The Broker Forum, and ICsource), tracks vendor intelligence,
+enriches companies/contacts (SAM.gov, Clay, Explorium, Lusha, Hunter + AI web
+search), automates RFQ workflows via Microsoft Graph,
+mines inboxes with Claude AI, and runs a full CRM (companies, quotes, buy plans,
+customer matching).
+
+---
+
+## Authoritative Maps — read before exploring code
+
+- `docs/APP_MAP_ARCHITECTURE.md` — stack, infra, project structure
+- `docs/APP_MAP_DATABASE.md` — models, tables, relationships
+- `docs/APP_MAP_INTERACTIONS.md` — service interactions, data flows, integration patterns
+- `docs/BRANCH_AND_CI_WORKFLOW.md` — branch naming/lifecycle, the changed-files
+  formatting gate (do NOT bundle unrelated drift), and quarantine-before-delete
+  branch hygiene (`scripts/branch-cleanup.sh`)
+
+These are the canonical reference. CLAUDE.md only points at them. **After any code
+change, update the relevant APP_MAP doc(s) in the same PR.**
+
+---
+
+## CODE RULES
+
+### Non-Negotiables
+- **Stack is HTMX + Alpine.js + Jinja2 — NOT React.** Reject React/SPA patterns; if a problem seems to need React, you're modeling it wrong. Server-render + HTMX swap.
+- **No band-aids, no half-measures.** Root-cause fixes only, even if interim breakage shows. Workarounds get the PR closed.
+- **Quality > speed. Zero ambiguity in designs.** Resolve every decision in the spec; no TBDs, no "options A/B".
+- **Hosted CLI only.** No GUI, no screenshots, no desktop-dependent suggestions, no browser visual companion.
+- **Before pushing big PRs:** run `pre-commit run --all-files` (local git-hook scope is narrower than CI and bites otherwise).
+- **Deploy is `./deploy.sh` only.** It passes a unique `--build-arg BUILD_COMMIT=<sha>-<ts>` that the Dockerfile consumes right before the source COPYs in BOTH stages, so templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache (~30s deploys; PR #211 — no more `--no-cache`). Bare `docker compose up -d --build` (without that build-arg) ships stale templates. After deploy, verify any new Tailwind classes actually appear in built CSS.
+
+- Always write tests with any new code. Don't ask, just include them.
+- Give exact file paths for everything.
+- Never use placeholder comments like "# rest of code here" — give complete code.
+- Keep responses under 150 lines. Break big tasks into steps.
+- Simple beats clever. 20 readable lines > 10 clever lines.
+- Use Loguru for logging, never print().
+- Use Ruff for linting.
+- Use Alembic for database migrations. Always include rollback steps.
+
+## Standing Workflow Rules
+
+### Execution Model
+- Always use subagent-driven execution for multi-step tasks — never ask, never offer inline
+- Maximize parallel subagents for all independent work — never serialize what can parallelize
+- Run the full skill pipeline on every task: brainstorm → plan → TDD → execute → simplify → review → verify (this order is canonical)
+- Never skip a step because it seems "overkill" — use every available tool and skill aggressively
+- Fix ALL review findings immediately — never defer as "lower priority" or "MVP acceptable"
+
+### UI Guardrails
+- Never add, remove, or rearrange UI elements without explicit user approval
+- Follow existing codebase patterns — find a working example before creating new UI conventions
+
+### Code Anti-Patterns (never introduce — in addition to Coding Conventions section)
+- `innerHTML` → use `htmx.ajax()` or Alpine reactive binding
+- Pydantic `class Config` → use `model_config = ConfigDict()`
+- Alpine `_x_dataStack` → use `Alpine.store()`
+- `db.query(Model).get(id)` → use `db.get(Model, id)`
+- Anything with a literal `"` inside a **double-quoted** Alpine attribute (`x-data`/`@event`/`:bind`) → the `"` closes the attribute early and breaks Alpine init for the whole component (dead handlers, often only a console warning). Two common triggers: (a) prose / JS `//` comments — move them to a Jinja `{# #}` comment *outside* the attribute; (b) `{{ ...|tojson }}` — `tojson` is Markup-safe so a trailing `|e` is a **no-op**; embed it in a **single-quoted** attribute instead (`x-data='{{ x|tojson }}'`, tojson escapes `'`).
+- Inner htmx container that should swap into **itself** but omits `hx-target` → under `<main id="main-content" hx-target="this">` it inherits `hx-target="this"` (resolving to `#main-content`) and **replaces the whole page** on its `load`/trigger. Always set an explicit `hx-target` (e.g. `hx-target="this"`) on faceted/lazy-load sub-containers.
+- htmx event filter `[condition]` **not** hugging the event name → `keyup[cond]` is valid, but `keyup changed delay:800ms[cond]` (filter trailing a modifier) throws `htmx:syntax:error` and silently disables the trigger. The `[filter]` must immediately follow the event.
+- Alpine magics (`$dispatch`/`$store`/`$el`…) inside an **`hx-on:`** attribute → htmx evaluates hx-on code as plain JS (`new Function('event', code)`), so the magic is undefined and the handler throws `ReferenceError` at runtime (e.g. a modal that never closes after save, with a clean server log). In hx-on use plain JS — `this.dispatchEvent(new CustomEvent("close-modal", {bubbles: true}))` — or move the handler to an Alpine-evaluated attribute (`@htmx:after-request.camel`).
+- Jinja form prefills like `value='{{ (obj.field if obj else "") | e }}'` → a NULL column stringifies to the literal **'None'** in the input, and the next save writes the string `'None'` into the DB. Always coalesce: `value='{{ ((obj.field or "") if obj else "") | e }}'`.
+- htmx clickable rows (`hx-trigger="click, keyup[key=='Enter']"`) with interactive descendants guarded only by `@click.stop` → Enter on a focused child (link/button) still bubbles its **keyup** to the row and double-fires the row navigation. Add `@keyup.stop` alongside `@click.stop` on every focusable child.
+
+### Asking Questions / Clarifications
+- Ask clarifying questions **ONE AT A TIME** — never batch multiple questions into a single
+  message. Wait for the answer before asking the next.
+- Always present **suggested answers** as concrete options (each with a one-line rationale),
+  and mark exactly **one "(Recommended)"** with why.
+- Prefer the structured multiple-choice question tool (with the Recommended option) over
+  open-ended prose questions.
+
+### Linear Development
+- Memory references specific code (line numbers, function names)? Verify against current files before acting
+- Plans or specs with line numbers? Verify those lines are still correct before editing
+- Never mix old patterns with new — if the codebase has moved to a new pattern, follow the new one
+- Always read the actual codebase before making changes — never rely on cached assumptions
+
+### PR Reviews
+- Saved fleet: `Workflow({name: "pr-review-fleet", args: {pr, branch, worktree, title}})`
+  (`.claude/workflows/pr-review-fleet.js`) — all 6 pr-review-toolkit + feature-dev
+  reviewers in parallel → adversarial verify per finding → fix-all → simplify, with the
+  git constraints below baked in.
+- Caveat: invoking via scriptPath+args has misfired twice — for a one-off fleet, bake the
+  pr/branch/worktree/title values inline instead of passing args.
+
+### Git Discipline
+- **Merge, don't rebase, on pushed branches** — force-push is hook-blocked, so a rebase
+  strands the branch. `git fetch origin && git merge origin/main`; resolve conflicts root-cause.
+- Already-rebased branch? Append-only recovery: (1) snapshot the rebased state to a temp
+  branch, (2) `git checkout -B <branch> origin/<branch>`, (3) merge origin/main, (4) apply
+  the snapshot as a tree diff (`git diff HEAD <temp> | git apply`, commit), (5) plain push.
+- `gh pr edit` is broken (deprecated Projects-classic GraphQL, fails silently) — use
+  `gh api -X PATCH /repos/<owner>/<repo>/pulls/<n> --input -`.
+- When docformatter rewraps a docstring, run `pre-commit` twice — the first run mutates,
+  the second verifies clean.
+
+---
+
+## Project Layout
+
+Top-level `app/` modules of note (see APP_MAP_ARCHITECTURE for the full tree):
+
+- `main.py` — FastAPI app, router registration, middleware, lifespan
+- `config.py` — Pydantic Settings (env vars, `APP_VERSION`, `MVP_MODE`)
+- `database.py` — SQLAlchemy engine, `SessionLocal`, `UTCDateTime` type
+- `dependencies.py` — auth deps: `require_user`, `require_admin`, `require_buyer`, `require_fresh_token`
+- `constants.py` — status `StrEnum`s — always use these, never raw strings
+- `shared_constants.py` — `JUNK_DOMAINS`, `JUNK_EMAIL_PREFIXES`
+- `startup.py` — runtime ops only (triggers, seeds, ANALYZE) — **no DDL**
+- `scheduler.py` / `jobs/` — APScheduler coordinator and job definitions
+- `search_service.py` — requirement search orchestrator (all supplier sources)
+- `email_service.py` — Graph API batch RFQ, inbox monitor, AI reply parsing
+- `enrichment_service.py` — customer/vendor enrichment orchestrator
+- `scoring.py` — sighting buyer-usefulness multi-factor scoring
+- `evidence_tiers.py` — data-provenance tier tags for sightings/offers
+- `vendor_utils.py` — `fuzzy_score_vendor()` (rapidfuzz wrapper) — use this, never inline fuzzy
+- `http_client.py` — shared singleton `httpx.AsyncClient`s (connection pooling for outbound)
+- `rate_limit.py` — shared rate limiter (Redis-backed, in-memory fallback)
+- `prometheus_metrics.py` — ASGI metrics middleware + `/metrics` endpoint
+- `connector_status.py` — logs which supplier connectors are enabled/disabled at startup
+- `models/` `schemas/` `routers/` `services/` `connectors/` `cache/` `utils/` `management/`
+- `config/routing_maps.json` — brand→commodity inference maps (used by buy-plan scoring)
+- `templates/` (Jinja2) `static/` (Vite-built assets in `static/dist/`)
+
+`app/management/` holds one-off CLI commands (e.g. `python -m app.management.reenrich`).
+
+Migrations live at repo-root `alembic/versions/`, **not** under `app/`.
+Tests live in `tests/` (unit/integration) and `tests/e2e/` (Playwright).
+
+---
+
+## Auth Model
+
+OAuth2 via Azure AD — `app/routers/auth.py` handles login/callback/logout.
+Session middleware stores `user_id` in an HTTP-only cookie (24-hour expiry,
+`max_age=86400` in `app/main.py`). `require_fresh_token` enforces hard token
+expiry only; the 15-min-buffer refresh runs in the background token-refresh
+job (`app/jobs/core_jobs.py`, every 5 min).
+
+Permission dependencies: `require_user` (any login — includes the search
+views), `require_buyer` (buyer actions: stock-list import, enrichment,
+vendor-contact ops), `require_admin` (settings, user management).
+
+---
+
+## Coding Conventions
+
+### Database
+- Use `db.get(Model, id)`, **not** `db.query(Model).get(id)` (SQLAlchemy 2.0 style).
+- Status values: always use `StrEnum` constants from `app/constants.py`, never raw strings
+  (e.g. `RequisitionStatus.OPEN`, `SourcingStatus.OFFERED`).
+- Keep routers thin (HTTP only); put business logic in `app/services/`.
+- **MaterialCard category/spec writes: the F1 tier ladder (`app/services/spec_tiers.py`)
+  is the single arbitration point.** ALL such writes go through `set_category()` /
+  `record_spec()` — never assign `card.category` or facets directly. Writers MUST register
+  their source string in `SOURCE_TIER` (unknown source → tier 0 → loses every conflict).
+  Never add per-writer confidence pre-gates — the ladder owns arbitration; run order is
+  not load-bearing. Enrichment writers + evidence-source tiers table:
+  `docs/APP_MAP_INTERACTIONS.md`.
+
+### Search & Matching
+- Vendor matching: `fuzzy_score_vendor()` from `app/vendor_utils.py` (rapidfuzz wrapper). Never inline fuzzy logic.
+- MPN dedup: `strip_packaging_suffixes()` from `app/services/search_worker_base/mpn_normalizer.py`.
+- **`search_requirement()` uses a separate write session** — the caller's ORM objects are
+  stale after it returns. Call `db.expire(requirement)` before rendering templates.
+
+### MPN Normalization
+- `normalize_mpn()` uppercases, strips noise, returns `None` for MPNs < 3 chars.
+- `@validates` on `Requirement` auto-uppercases `primary_mpn`, `customer_pn`, `oem_pn` on save.
+- Use the `|sub_mpns` Jinja2 filter to display substitutes (handles string and dict forms).
+
+### Substitutes Format
+- Canonical: `[{"mpn": "ABC123", "manufacturer": "TI"}, ...]` (list of dicts).
+- Legacy rows may hold plain strings `["ABC123"]` — always handle both.
+- Write paths: use `parse_substitute_mpns()` from `app/utils/normalization.py`.
+
+### Shared Constants
+- Junk email domains/prefixes: import `JUNK_DOMAINS` / `JUNK_EMAIL_PREFIXES` from `app/shared_constants.py`. Don't duplicate.
+
+### Caching
+```python
+from app.cache.decorators import cached_endpoint
+
+@cached_endpoint("vendor_list", ttl_hours=24, key_params=["supplier"])
+async def get_vendors(supplier: str): ...
+```
+
+### Logging
+- Always Loguru (`from loguru import logger`), never `print()`. request_id context is auto-injected.
+
+### Frontend
+- Navigation is HTMX-driven: `<a hx-get>` → server HTML fragment → swap into `#main-content`. No client routing, no JSON.
+- State is Alpine.js via `Alpine.store()` (persisted with the `@persist` plugin).
+- Toast: `$store.toast` has `message`, `type`, `show` (boolean) — set them directly; `show` is not a method.
+- Plugin/extension lists: see `app/static/htmx_app.js` and `app/templates/htmx/base.html`.
+- **Before editing any template**, trace `router → view function → template_response()`.
+  Routers can render a partial whose path doesn't match the router name — follow the router.
+
+### Response Formats
+- JSON errors: `{"error": "...", "status_code": 400, "request_id": "..."}` — tests check `["error"]`, not `["detail"]`.
+- List responses: `{"items": [...], "total": N, "limit": N, "offset": N}` — not a plain array.
+- HTMX responses: `HTMLResponse` from Jinja2. Schemas in `app/schemas/`.
+
+### Files
+- Every new file needs a header comment: what it does, what calls it, what it depends on.
+
+---
+
+## Database & Migration Rules
+
+### ABSOLUTE RULES — NEVER VIOLATE
+1. **ALL schema changes go through Alembic.** Never use raw DDL in startup.py, services, routers, or scripts.
+2. **Never use Base.metadata.create_all() for schema changes.**
+3. **Never run raw SQL against production** outside of a migration.
+4. **Migration workflow — every time:**
+   a. Make model change in `app/models/`
+   b. Run: `alembic revision --autogenerate -m "description"`
+   c. REVIEW the generated migration
+   d. Test: upgrade → downgrade → upgrade
+   e. Commit migration with model change
+
+5. **After creating a migration, ALWAYS run `alembic heads`** to verify a single head. If multiple heads: `alembic merge heads -m "merge_description"`. Data-only migrations (no schema changes) use `op.get_bind()` + raw SQL via `text()`.
+
+6. **startup.py is for runtime operations ONLY:**
+   - FTS triggers (PostgreSQL-specific)
+   - Seed data (system_config defaults)
+   - ANALYZE on hot tables
+   - Idempotent backfill queries
+   - Count triggers (PG-specific)
+   - NOTHING that creates, alters, or drops tables/columns/indexes/constraints
+
+---
+
+## Commands
+
+### Docker
+```bash
+docker compose up -d              # Start all containers
+docker compose logs -f app        # Tail app logs
+docker compose ps                 # Show status
+docker compose down               # Stop everything
+```
+
+### Deploy
+```bash
+./deploy.sh                       # From main: commit + push + rebuild + health-check + verify
+./deploy.sh --no-commit           # Rebuild current branch without committing/pushing
+```
+`deploy.sh` must run from `main` unless `--no-commit`. It builds with a unique
+`BUILD_COMMIT` build-arg (consumed before the source COPYs in both Dockerfile stages, so
+templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache — no `--no-cache`),
+rebuilds + recreates **both** the `app` and `enrichment-worker` containers (they share
+`requirements.txt`, so the worker must not lag the app on a dependency bump), waits for
+the app health check, verifies the deployed build tag on both, checks that Tailwind
+classes in templates exist in the built CSS bundle, and restarts the host `nc`/`ics`
+worker systemd units (they run from `/root/availai` outside docker, so they'd otherwise
+keep running stale code after a deploy).
+Never use bare `docker compose up -d --build` (without `--build-arg BUILD_COMMIT=...`) —
+it ships stale templates.
+
+### Python lint / type check
+```bash
+ruff check app/                   # Lint
+ruff format app/                  # Auto-format
+mypy app/                         # Type check
+```
+Pre-commit hooks: ruff, ruff-format, mypy, docformatter, detect-private-key.
+
+### Dependencies (pip-tools lockfiles)
+
+Python deps are **pinned lockfiles** compiled from hand-authored sources, so every
+install (CI + deploy) is reproducible.
+
+- **Edit** `requirements.in` (prod) / `requirements-dev.in` (dev) — never the `.txt`.
+- **Recompile** the locks, then commit BOTH the `.in` and the regenerated `.txt`:
+  ```bash
+  pip-compile --no-header --no-strip-extras requirements.in
+  pip-compile --no-header --no-strip-extras requirements-dev.in
+  ```
+- `requirements.txt` (prod lock) is what the Docker image + `deploy.sh` install;
+  `requirements-dev.txt` adds the dev/test tools. CI fails if a `.txt` drifts from
+  its `.in` (the "Verify requirements lockfiles are in sync" step).
+- To bump a dep: change the constraint in the `.in`, recompile, run the suite. To
+  refresh transitive pins to newest: `pip-compile --upgrade ...`.
+- **Dependabot pip PRs** edit the files textually and can't run pip-compile, so they
+  fail the sync gate. `.github/workflows/dependabot-lockfile-sync.yml` auto-recompiles
+  the locks and pushes the corrected `.txt` back to the PR (set a `DEPENDABOT_LOCKFILE_TOKEN`
+  PAT secret to make that push re-trigger CI / turn the checks green).
+
+### Migrations
+```bash
+alembic upgrade head                              # Apply pending
+alembic downgrade -1                              # Rollback one
+alembic revision --autogenerate -m "description"  # New migration
+alembic current / alembic history / alembic heads
+```
+
+### Tests
+`pytest.ini` sets `asyncio_mode=auto`, `-n auto` (xdist parallel), a 30s per-test
+timeout, and ignores `tests/e2e/`. Always set `TESTING=1` (disables scheduler and
+real API calls); tests use in-memory SQLite. `conftest.py` provides fixtures and the
+test `engine`.
+
+```bash
+# During dev — changed module only
+TESTING=1 PYTHONPATH=/root/availai pytest tests/test_<module>.py -v
+
+# Before commit — full suite
+TESTING=1 PYTHONPATH=/root/availai pytest tests/ -v
+
+# Before PR only — coverage
+TESTING=1 PYTHONPATH=/root/availai pytest tests/ --cov=app --cov-report=term-missing --tb=no -q
+
+# Skip slow tests
+TESTING=1 PYTHONPATH=/root/availai pytest -m "not slow" -v
+
+# Single file without xdist parallelism
+TESTING=1 PYTHONPATH=/root/availai pytest tests/test_foo.py -v --override-ini="addopts="
+```
+Never add `--cov` to iterative dev runs — only before a PR. Mock lazy imports at the
+source module, not the import site.
+
+### Frontend / E2E
+```bash
+npm run dev          # Vite dev server (localhost:5173)
+npm run build        # Production build → app/static/dist/ (postbuild smoke test is a NO-OP — scripts/smoke-test-bundles.mjs missing)
+npm run lint         # ESLint
+npm run test:frontend  # Vitest
+npx playwright test --project=workflows   # E2E (also: dead-ends, visual, accessibility)
+```
+
+---
+
+## MVP Mode
+
+`config.py: mvp_mode` now gates ONLY the Teams chat integration (webhook 404 +
+subscription skip). Dashboard, Enrichment, and Task Manager are un-gated,
+always on.
+
+---
+
+## Observability
+
+- **Sentry** — initialized in `app/main.py` lifespan only when `SENTRY_DSN` is set
+  (FastAPI, httpx, Loguru, SQLAlchemy integrations). A `before_send` hook scrubs
+  sensitive data — extend it, never bypass it, when adding new sensitive fields.
+- **Prometheus** — `app/prometheus_metrics.py` is a pure ASGI middleware exposing
+  `http_requests_total`, `http_request_duration_seconds`, and `http_requests_inprogress`
+  at `GET /metrics` (token-gated). It replaced `prometheus-fastapi-instrumentator` (which
+  hard-pinned `starlette<1.0.0`); keep it streaming-safe (don't consume response bodies)
+  so it composes with SSE endpoints.
+- **Logging** — Loguru with auto-injected `request_id` context (see Logging convention).
+
+---
+
+## Configuration
+
+All config via `.env` (see `.env.example`). Key groups: Azure OAuth (`AZURE_CLIENT_ID`,
+`AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`; the OAuth callback URL is derived from `APP_URL`),
+Anthropic (`ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`), `DATABASE_URL`, `REDIS_URL`, supplier API
+keys (feature disabled if unset — e.g. `NEXAR_CLIENT_ID`, `BROKERBIN_API_KEY`,
+`DIGIKEY_CLIENT_ID`, `MOUSER_API_KEY`), feature flags (`MVP_MODE`, `EMAIL_MINING_ENABLED`,
+etc.), and observability (`SENTRY_DSN` — optional).
+
+---
+
+## Triggers
+
+- "new feature" = make a plan first, don't just start coding
+- "bug" / "error" = ask for the full error message before fixing
+- "refactor" = check what's stable first
+- "quick" / "just" = warn about hidden complexity
+
+## Safety
+
+- WARN before DROP, DELETE, or bulk data changes; include backup + rollback steps.
+- For production, verify a backup exists first. The `db-backup` service runs `pg_dump`
+  every 6 hours; manual restore via `scripts/restore.sh`.
+
+---
+
+## Skill Usage Guide
+
+Invoke skills proactively — don't ask. Triggers:
+
+| Trigger | Skill |
+|---|---|
+| Adding/modifying FastAPI routes, deps, middleware | `fastapi` |
+| Writing SQLAlchemy 2.0 models, queries, relationships, fixtures | `sqlalchemy` |
+| Adding HTMX attributes, partials, inline edits, lazy-loads, modals | `htmx` |
+| Editing Jinja2 templates, macros, custom filters, partials | `jinja2` |
+| Touching `vite.config.js`, JS/CSS entry points, Vitest specs | `vite` |
+| Building/styling UI (HTMX + Alpine + Tailwind) | `frontend-design` |
+| Writing/fixing pytest tests, fixtures, mocks | `pytest` |
+| Adding/invalidating Redis cache, `@cached_endpoint` | `redis` |
+| Fixing pre-commit lint errors, ruff rules, noqa | `ruff` |
+| Fixing mypy errors, adding type annotations | `mypy` |
+| Writing/extending Playwright E2E specs | `playwright` |
+| Empty states, first-run flows, onboarding nudges | `designing-onboarding-paths`, `orchestrating-feature-adoption` |
+| Funnel events, activity tracking, activation metrics | `mapping-conversion-events`, `instrumenting-product-metrics` |
+| Page copy, CTAs, microcopy | `crafting-page-messaging`, `tuning-landing-journeys` |
+| SEO/meta/structured data on public pages | `inspecting-search-coverage`, `adding-structured-signals` |

--- a/specs/plan-teams-agent-proactive.md
+++ b/specs/plan-teams-agent-proactive.md
@@ -1,0 +1,82 @@
+# Plan — Teams agent + a more proactive AVAIL
+
+Phased plan. Discovery-grounded; every current-state claim is cited
+`file:line`. No code written yet. Ends with Open Questions — answer
+those before any build.
+
+## The idea in one line
+
+AVAIL already computes scored inventory→customer matches but only
+shows them in-app. Push those (and other already-computed signals)
+into Teams, then make the Teams surface actionable, then — only if
+warranted — a true interactive bot.
+
+## Current state (what exists, so we don't rebuild it)
+
+- Outbound Teams: `post_teams_channel`, `post_teams_channel_card`
+  (full Adaptive Card, FactSet + `Action.OpenUrl`), `send_teams_dm`
+  (Graph 1:1 chat) — `app/services/teams_notifications.py:17-135`.
+- Inbound Teams webhook logs messages only, no reply/action —
+  `app/routers/v13_features/activity.py:101-134`,
+  `app/services/webhook_service.py:573-671`.
+- No Bot Framework anywhere (no `/api/messages`, no adapter) — not found.
+- Proactive engine: `ProactiveMatch` rows, recency/frequency/margin
+  scoring, hotlist seed, scan — `app/services/proactive_matching.py`
+  (`compute_match_score:83`, `run_proactive_scan:466`). Matches write
+  only an in-app `ActivityLog` (`:445-455`); **no Teams/email push.**
+- Scheduled scan `proactive_matching`, flag-gated
+  `proactive_matching_enabled` — `app/jobs/offers_jobs.py:19-34`.
+- Migration head: **203** (`203_outreach_recipient_email`). New = 204.
+
+## Conflicts with the brief (code wins — confirm before building)
+
+1. Per-user `teams_alert_config` (webhook, quiet-hours, threshold,
+   digest hour) was created (`059`, `062`) then **DROPPED**
+   (`a3f9c1d82e47_drop_dead_tables.py:25`). Only a single global
+   `TEAMS_WEBHOOK_URL` credential remains. Per-user routing must be
+   rebuilt if we want it.
+2. Teams-Q&A agent was scaffolded but **never built** — `teams_qa_service.py`
+   absent (`app/models/knowledge.py:10-15`); dead columns
+   `KnowledgeEntry.nudged_at/delivered_at/answered_via` (`:62-65`).
+
+## Phases
+
+### Phase 1 — Proactive push (no bot; reuses the outbound card path)
+Scheduled job that takes each salesperson's new `ProactiveMatch` rows
+and posts a digest Adaptive Card (FactSet: customer, MPN, score,
+last-bought) with an `Action.OpenUrl` deep-link into `/v2/proactive`.
+Delivery via `send_teams_dm` (per-rep) or `post_teams_channel_card`
+(shared channel). Respects the scan flag. **This alone makes AVAIL
+proactive** — matches reach reps instead of waiting for a manual
+refresh. New job in `offers_jobs.py`; likely a small `TeamsAlertConfig`
+model + migration 204 if per-user routing/quiet-hours are wanted.
+
+### Phase 2 — Actionable cards (still no bot transport)
+Card buttons are `Action.OpenUrl` deep-links to existing endpoints
+(prepare / send / dismiss in `htmx/proactive.py`). One tap in Teams →
+lands in the app pre-filled. Cheap, no Azure Bot registration.
+
+### Phase 3 — Interactive agent (real bot; the big lift — gated)
+Azure Bot registration + Bot Framework `/api/messages` + adapter +
+conversation-reference persistence. `Action.Execute` card buttons that
+act in-place (send offer, dismiss, snooze, "why this match" using
+`Sighting.evidence_tier` / `score_components`, `sourcing.py:284-287`).
+Optionally revive or explicitly drop the dead Q&A scaffolding.
+
+## Signals available to push (beyond matches)
+
+Expiring strategic-vendor warnings (`offers_jobs.py:262-307`),
+stale-offer flags (`:206-229`), vendor/company activity-health
+red/yellow (`activity.py:589-648`), 12h score digests (`:110-160`) —
+all computed today, none pushed.
+
+## Open Questions (answer before build)
+
+1. Delivery target: per-salesperson DM, a shared sales channel, or both?
+2. How far: Phase 1–2 (push + deep links, no Azure Bot) — or Phase 3
+   (interactive bot, which needs an Azure Bot registration you provision)?
+3. First signal to push: proactive matches only, or also
+   expiring-vendor / activity-health / score digests?
+4. Config: rebuild a per-user `TeamsAlertConfig` (quiet hours,
+   threshold), or start with the single global webhook?
+5. Dead Teams-Q&A scaffolding: fold into this, or drop it separately?

--- a/specs/session-prompt-template.md
+++ b/specs/session-prompt-template.md
@@ -1,0 +1,79 @@
+# Session prompt template
+
+Save as `specs/session-prompt-template.md`. Copy, fill the three
+brackets, paste into the CLI. Everything else is already in
+`CLAUDE.md` — do not repeat it here.
+
+---
+
+## TASK
+
+<one feature. one sentence. e.g. "Build the Quality Plan model and
+the completeness gate that blocks routing on blank fields.">
+
+**In scope:** <list>
+**Out of scope:** <list — be specific, this is the guardrail>
+
+---
+
+## GROUND RULE
+
+You have the repo. I don't. Anything I describe below is business
+truth, not code truth. Where my description conflicts with what is
+actually in the codebase, **the code wins** — flag the conflict
+and stop. Do not silently reconcile it.
+
+---
+
+## PHASE 0 — DISCOVERY (write no code)
+
+Map the following and write your findings to
+`specs/discovery-<feature>.md`:
+
+1. <models / routers / services you expect to be involved>
+2. Existing patterns this feature must match
+3. Current Alembic migration head
+4. Anything I described above that does not exist in the code
+
+Rules for Phase 0:
+- Cite `file:line` for every claim. No claim without a citation.
+- If you cannot find something, say "not found" — do not infer it
+  from a similar name.
+- End with an **Open Questions** list. No TBDs anywhere else.
+
+**Then stop and wait for my go.** Do not proceed to build.
+
+---
+
+## BEFORE YOU BUILD
+
+Restate in one paragraph, in your own words, what you are about to
+build and why. If your restatement and my task don't match, we fix
+it now instead of three files in.
+
+---
+
+## BEFORE YOU WRITE
+
+Show me:
+- Files touched (created / modified / deleted)
+- Approximate lines added and removed
+- Anything destructive, called out explicitly
+
+Wait for confirmation on anything destructive.
+
+---
+
+## AFTER YOU BUILD
+
+- Run the tests. Paste the actual terminal output.
+- A test is not passing until I have seen the output.
+- Summarize what changed in five lines or fewer.
+
+---
+
+## SESSION HYGIENE
+
+One feature per session. At ~15–20 exchanges, stop and tell me to
+start fresh — the next session reads
+`specs/discovery-<feature>.md` instead of re-mapping cold.

--- a/tests/test_offers_jobs_comprehensive.py
+++ b/tests/test_offers_jobs_comprehensive.py
@@ -62,7 +62,6 @@ class TestRegisterOffersJobs:
         mock_settings = MagicMock()
         mock_settings.proactive_matching_enabled = True
         mock_settings.proactive_scan_interval_hours = 4
-        mock_settings.proactive_teams_push_enabled = False  # opt-in job, off by default
 
         from app.jobs.offers_jobs import register_offers_jobs
 
@@ -82,7 +81,6 @@ class TestRegisterOffersJobs:
         mock_scheduler = MagicMock()
         mock_settings = MagicMock()
         mock_settings.proactive_matching_enabled = False
-        mock_settings.proactive_teams_push_enabled = False  # opt-in job, off by default
 
         from app.jobs.offers_jobs import register_offers_jobs
 
@@ -98,7 +96,6 @@ class TestRegisterOffersJobs:
         mock_settings = MagicMock()
         mock_settings.proactive_matching_enabled = True
         mock_settings.proactive_scan_interval_hours = 0  # Below minimum
-        mock_settings.proactive_teams_push_enabled = False  # opt-in job, off by default
 
         from app.jobs.offers_jobs import register_offers_jobs
 

--- a/tests/test_offers_jobs_comprehensive.py
+++ b/tests/test_offers_jobs_comprehensive.py
@@ -62,6 +62,7 @@ class TestRegisterOffersJobs:
         mock_settings = MagicMock()
         mock_settings.proactive_matching_enabled = True
         mock_settings.proactive_scan_interval_hours = 4
+        mock_settings.proactive_teams_push_enabled = False  # opt-in job, off by default
 
         from app.jobs.offers_jobs import register_offers_jobs
 
@@ -81,6 +82,7 @@ class TestRegisterOffersJobs:
         mock_scheduler = MagicMock()
         mock_settings = MagicMock()
         mock_settings.proactive_matching_enabled = False
+        mock_settings.proactive_teams_push_enabled = False  # opt-in job, off by default
 
         from app.jobs.offers_jobs import register_offers_jobs
 
@@ -96,6 +98,7 @@ class TestRegisterOffersJobs:
         mock_settings = MagicMock()
         mock_settings.proactive_matching_enabled = True
         mock_settings.proactive_scan_interval_hours = 0  # Below minimum
+        mock_settings.proactive_teams_push_enabled = False  # opt-in job, off by default
 
         from app.jobs.offers_jobs import register_offers_jobs
 

--- a/tests/test_proactive_teams_push.py
+++ b/tests/test_proactive_teams_push.py
@@ -1,0 +1,139 @@
+"""test_proactive_teams_push.py — Tests for the proactive→Teams push (Phase 1).
+
+Covers app/services/proactive_teams_push.py (digest build, idempotent watermark,
+status filtering) and the flag-gated job registration in app/jobs/offers_jobs.py.
+
+Called by: pytest
+Depends on: app.services.proactive_teams_push, app.jobs.offers_jobs, conftest fixtures
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.models import Company, MaterialCard, Offer, ProactiveMatch, Requisition, User
+from app.models.config import SystemConfig
+from app.services.proactive_teams_push import _WATERMARK_KEY, push_new_matches_to_teams
+
+_PUSH_PATH = "app.services.proactive_teams_push.post_teams_channel_card"
+
+
+def _scaffold(db: Session) -> dict:
+    """Minimal owner/company/offer needed to hang ProactiveMatch rows off of."""
+    owner = User(email="s@trioscs.com", name="Rep", role="sales", azure_id="s-1", created_at=datetime.now(UTC))
+    db.add(owner)
+    db.flush()
+    company = Company(name="Acme Corp", is_active=True, account_owner_id=owner.id)
+    db.add(company)
+    db.flush()
+    card = MaterialCard(normalized_mpn="lm358n", display_mpn="LM358N")
+    db.add(card)
+    db.flush()
+    req = Requisition(name="R", customer_site_id=None, status="archived", created_by=owner.id)
+    db.add(req)
+    db.flush()
+    offer = Offer(
+        requisition_id=req.id,
+        material_card_id=card.id,
+        vendor_name="Arrow",
+        mpn="LM358N",
+        unit_price=Decimal("0.42"),
+        qty_available=5000,
+        status="active",
+    )
+    db.add(offer)
+    db.flush()
+    return {"owner": owner, "company": company, "offer": offer}
+
+
+def _add_match(db: Session, ctx: dict, mpn: str, score: int, status: str = "new") -> ProactiveMatch:
+    match = ProactiveMatch(
+        offer_id=ctx["offer"].id,
+        salesperson_id=ctx["owner"].id,
+        company_id=ctx["company"].id,
+        mpn=mpn,
+        match_score=score,
+        status=status,
+    )
+    db.add(match)
+    db.commit()
+    return match
+
+
+async def test_no_new_matches_returns_zero(db_session: Session):
+    with patch(_PUSH_PATH, new=AsyncMock()) as mock_post:
+        result = await push_new_matches_to_teams(db_session)
+    assert result == {"pushed": 0}
+    mock_post.assert_not_called()
+
+
+async def test_pushes_new_matches_and_advances_watermark(db_session: Session):
+    ctx = _scaffold(db_session)
+    _add_match(db_session, ctx, "LM358N", 85)
+    m2 = _add_match(db_session, ctx, "TL072CP", 60)
+
+    with patch(_PUSH_PATH, new=AsyncMock()) as mock_post:
+        result = await push_new_matches_to_teams(db_session)
+
+    assert result == {"pushed": 2}
+    mock_post.assert_awaited_once()
+    card = mock_post.call_args.args[0]
+    # Header reflects the count, FactSet carries the company name, action deep-links to AVAIL.
+    assert "2 new proactive matches" in card["body"][0]["text"]
+    facts = card["body"][1]["facts"]
+    assert any("Acme Corp" in f["value"] for f in facts)
+    assert card["actions"][0]["url"].endswith("/v2/proactive")
+    # Watermark advanced to the highest match id seen.
+    row = db_session.query(SystemConfig).filter(SystemConfig.key == _WATERMARK_KEY).first()
+    assert row is not None and int(row.value) == m2.id
+
+
+async def test_idempotent_second_run_pushes_nothing(db_session: Session):
+    ctx = _scaffold(db_session)
+    _add_match(db_session, ctx, "LM358N", 85)
+
+    with patch(_PUSH_PATH, new=AsyncMock()) as mock_post:
+        first = await push_new_matches_to_teams(db_session)
+        second = await push_new_matches_to_teams(db_session)
+
+    assert first == {"pushed": 1}
+    assert second == {"pushed": 0}
+    assert mock_post.await_count == 1
+
+
+async def test_only_new_status_is_pushed(db_session: Session):
+    ctx = _scaffold(db_session)
+    _add_match(db_session, ctx, "SENT-MPN", 90, status="sent")
+    _add_match(db_session, ctx, "NEW-MPN", 70, status="new")
+
+    with patch(_PUSH_PATH, new=AsyncMock()) as mock_post:
+        result = await push_new_matches_to_teams(db_session)
+
+    assert result == {"pushed": 1}
+    card = mock_post.call_args.args[0]
+    titles = [f["title"] for f in card["body"][1]["facts"]]
+    assert "NEW-MPN" in titles
+    assert "SENT-MPN" not in titles
+
+
+class TestPushJobRegistration:
+    """The push job registers only when its flag is on."""
+
+    def _register(self, push_enabled: bool) -> list[str]:
+        mock_scheduler = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.proactive_matching_enabled = False
+        mock_settings.proactive_scan_interval_hours = 4
+        mock_settings.proactive_teams_push_enabled = push_enabled
+        from app.jobs.offers_jobs import register_offers_jobs
+
+        register_offers_jobs(mock_scheduler, mock_settings)
+        return [c.kwargs.get("id") for c in mock_scheduler.add_job.call_args_list]
+
+    def test_registered_when_flag_on(self):
+        assert "proactive_teams_push" in self._register(push_enabled=True)
+
+    def test_absent_when_flag_off(self):
+        assert "proactive_teams_push" not in self._register(push_enabled=False)


### PR DESCRIPTION
Recovers work from a closed session and builds on it. Three commits.

## 1. Governance docs (`7ccf171`)
- **`CLAUDE.md`** — replaced the 414-line "AvailAI" version with the lean 118-line **AVAIL** rewrite.
- **`docs/CLAUDE_legacy_availai.md`** — prior version preserved as a backup.
- **`specs/session-prompt-template.md`** — one-feature-per-session task harness.

## 2. Phased plan (`f2abb63`)
- **`specs/plan-teams-agent-proactive.md`** — discovery-grounded plan for a Teams agent + a more proactive AVAIL. Flags two code-vs-brief conflicts (the `teams_alert_config` table was built then dropped; `teams_qa_service.py` was never built) and ends with open questions.

## 3. Phase 1 — proactive matches pushed to Teams (`681801d`)
The proactive engine already scores `ProactiveMatch` rows but they only surface in-app. This pushes them out:
- **`app/services/proactive_teams_push.py`** — composes an Adaptive Card digest of new matches (deep-links to `/v2/proactive`) and posts it via the existing outbound webhook path. **No bot.** Idempotent via a `SystemConfig` high-water-mark on match id, so it never double-sends.
- **`app/jobs/offers_jobs.py`** — `_job_proactive_teams_push`, registered only when the flag is on, on the proactive scan interval.
- **`app/config.py`** — `proactive_teams_push_enabled`, **default OFF** — enabling real Teams delivery is a deliberate admin choice.
- Tests: digest build, status filtering, watermark idempotency, flag-gated registration; existing offers-jobs tests pinned to the new flag.

### Test output (local, Python 3.13, `TESTING=1`)
```
tests/test_proactive_teams_push.py ......                          [6 passed]
+ test_offers_jobs_comprehensive, test_config, test_scheduler,
  test_system_flag_resolver, test_teams_notifications
92 passed, 3 warnings
```
`ruff check` clean · `ruff format` clean · `mypy` clean on changed files.

## Not included (needs your input)
Phases 2–3 from the plan — actionable card buttons and a true interactive bot (the latter needs an Azure Bot registration you'd provision). See the plan's Open Questions.