### PR TITLE
fix(cache): mask the Redis AUTH password in the intel-cache connect log

### DIFF
--- a/app/cache/intel_cache.py
+++ b/app/cache/intel_cache.py
@@ -10,6 +10,7 @@ unavailable (e.g., during development without Docker).
 import os
 from datetime import UTC, datetime, timedelta
 from typing import cast
+from urllib.parse import urlsplit
 
 from loguru import logger
 from sqlalchemy import CursorResult, text
@@ -29,6 +30,22 @@ def _rkey(cache_key: str) -> str:
 def _ttl_seconds(ttl_days: float) -> int:
     """Convert a fractional-day TTL to whole seconds for Redis EXPIRE/SETEX."""
     return int(ttl_days * 86400)
+
+
+def _mask_url_password(url: str) -> str:
+    """Return *url* with any userinfo password replaced by ``***``.
+
+    The connect log goes to every loguru sink (stdout / docker logs), so the
+    AUTH password embedded in ``redis://:password@host`` must never be logged
+    verbatim. Host and port are kept byte-for-byte (netloc split at the last
+    ``@``) so the masked URL stays usable for diagnosing WHERE we connected.
+    """
+    parts = urlsplit(url)
+    if parts.password is None:
+        return url
+    userinfo, _, hostport = parts.netloc.rpartition("@")
+    user = userinfo.split(":", 1)[0]
+    return parts._replace(netloc=f"{user}:***@{hostport}").geturl()
 
 
 def _connect_intel_redis():
@@ -57,7 +74,7 @@ def _connect_intel_redis():
         retry_on_timeout=True,
     )
     client.ping()
-    logger.info("Redis cache connected: {}", settings.redis_url)
+    logger.info("Redis cache connected: {}", _mask_url_password(settings.redis_url))
     return client
 
 

--- a/tests/test_cache_intel.py
+++ b/tests/test_cache_intel.py
@@ -370,3 +370,50 @@ class TestIncrHashCount:
         mock_get_cached.return_value = None
         assert cache_mod.incr_hash_count("k", "x|y|corroboration", ttl_days=35.0) == 1
         mock_set_cached.assert_called_once_with("k", {"x|y|corroboration": 1}, ttl_days=35.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Connect-log credential masking (the log line must never leak the Redis
+# password embedded in settings.redis_url)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestConnectLogMasksPassword:
+    def test_mask_url_password_masks_password(self):
+        assert cache_mod._mask_url_password("redis://:s3cret@redis:6379/0") == "redis://:***@redis:6379/0"
+
+    def test_mask_url_password_keeps_username(self):
+        assert cache_mod._mask_url_password("redis://user:pw@host:6379/1") == "redis://user:***@host:6379/1"
+
+    def test_mask_url_password_without_credentials_is_unchanged(self):
+        assert cache_mod._mask_url_password("redis://redis:6379/0") == "redis://redis:6379/0"
+
+    def test_connect_log_never_contains_password(self, monkeypatch):
+        """The INFO line emitted on a successful connect masks the password.
+
+        Drives the REAL _connect_intel_redis (TESTING unset, redis.from_url stubbed) and
+        captures loguru output — the assertion is on what actually reaches the log
+        sinks, not on the helper in isolation.
+        """
+        import redis
+        from loguru import logger
+
+        from app.config import settings
+
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.setattr(settings, "cache_backend", "redis")
+        monkeypatch.setattr(settings, "redis_url", "redis://:supersecretpw@redis:6379/0")
+        fake_client = MagicMock()
+        monkeypatch.setattr(redis, "from_url", MagicMock(return_value=fake_client))
+
+        records: list[str] = []
+        sink_id = logger.add(lambda m: records.append(str(m)), level="INFO")
+        try:
+            client = cache_mod._connect_intel_redis()
+        finally:
+            logger.remove(sink_id)
+
+        assert client is fake_client
+        joined = "".join(records)
+        assert "supersecretpw" not in joined
+        assert "redis://:***@redis:6379/0" in joined


### PR DESCRIPTION
## What

The intel-cache connect log printed `settings.redis_url` verbatim — since the 07-28 Redis-auth rollout that means the live AUTH password lands in every loguru sink (stdout / docker logs) on each app boot, confirmed again in the post-#804 deploy's startup log.

New `_mask_url_password()` in `app/cache/intel_cache.py` replaces only the userinfo password (`redis://:***@redis:6379/0`); host and port are kept byte-for-byte (netloc split at the last `@`, IPv6-safe) so the line still says where we connected. URLs without credentials pass through unchanged. Sweep confirmed this is the only site logging a credential-bearing URL; the existing `_redact_secrets` / `_redact_api_keys` helpers are query-string-oriented and don't cover URL userinfo.

## Tests (TDD, red→green)

- 3 helper unit tests (password-only, user+password, no-credentials passthrough)
- 1 behavioral test driving the REAL `_connect_intel_redis` (TESTING unset, `redis.from_url` stubbed) asserting on captured loguru output: password absent, masked URL present
- Watched all 4 fail first (`AttributeError: no attribute '_mask_url_password'`), then: **32 passed** (full `tests/test_cache_intel.py`), pre-commit fully green (incl. mypy over 559 files)

No migration. No template/static changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)