### PR TITLE
chore(hygiene): FK-cycle SAWarning, Sentry-under-TESTING, stale auto-approve docstring

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -59,6 +59,15 @@ def _scrub_nested_body(data, sensitive_vars: set[str]):
     return data
 
 
+def _sentry_enabled() -> bool:
+    """Sentry initializes only with a DSN configured AND outside TESTING.
+
+    Serial test runs on the server inherit the real .env DSN — without the TESTING
+    guard, test-generated errors ship to the production Sentry project as live events.
+    """
+    return bool(settings.sentry_dsn) and not os.environ.get("TESTING")
+
+
 @asynccontextmanager
 async def lifespan(app):
     """App startup/shutdown — launches background scheduler."""
@@ -96,8 +105,8 @@ async def lifespan(app):
                 "the ACS webhook will reject all events until it's configured."
             )
 
-    # Sentry error tracking (conditional on DSN being set)
-    if settings.sentry_dsn:
+    # Sentry error tracking (DSN set and not under TESTING)
+    if _sentry_enabled():
         import sentry_sdk
         from sentry_sdk.integrations.fastapi import FastApiIntegration
         from sentry_sdk.integrations.httpx import HttpxIntegration

--- a/app/models/crm.py
+++ b/app/models/crm.py
@@ -58,8 +58,13 @@ class Company(Base):
     last_activity_at = Column(UTCDateTime, index=True)
     account_owner_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"))
 
-    # Step 3: Account-level primary contact (distinct from per-site is_primary)
-    primary_contact_id = Column(Integer, ForeignKey("site_contacts.id", ondelete="SET NULL"))
+    # Step 3: Account-level primary contact (distinct from per-site is_primary).
+    # use_alter breaks the companies → site_contacts → customer_sites FK cycle in
+    # metadata sorting (name matches the live constraint; use_alter DDL needs one).
+    primary_contact_id = Column(
+        Integer,
+        ForeignKey("site_contacts.id", ondelete="SET NULL", use_alter=True, name="fk_companies_primary_contact"),
+    )
     # Step 3: Parent company (self-referential hierarchy)
     parent_company_id = Column(Integer, ForeignKey("companies.id", ondelete="SET NULL"))
 

--- a/app/services/buyplan_workflow/buyplan_approval.py
+++ b/app/services/buyplan_workflow/buyplan_approval.py
@@ -55,8 +55,9 @@ def submit_buy_plan(
 ) -> BuyPlan:
     """Submit a draft buy plan with SO# and optional line edits.
 
-    Flow: draft → pending (needs manager) OR draft → active (auto-approved).
-    Auto-approve when total cost < threshold AND no critical AI flags.
+    Flow: draft → pending, always. Every plan routes to the single manager
+    approval regardless of value — no auto-approve (frozen scope; the old
+    sub-$5K rule was removed, ``auto_approved`` column is vestigial).
     """
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines)])
     if not plan:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,12 +105,13 @@ Base.metadata.create_all(bind=engine, tables=_sqlite_safe)
 
 # Pre-compute delete order (respects FK dependencies via reversed create order).
 #
-# The companies <-> customer_sites <-> site_contacts trio is an FK cycle that
-# ``sorted_tables`` cannot topologically order (it emits SAWarning 'unresolvable
-# cycles' and drops those FK edges from the sort). Delete the cycle explicitly in
-# child -> parent order FIRST, then everything else in reverse-create order. The
-# per-table resilient cleanup below is what actually guarantees isolation, but a
-# correct base order means the happy path never needs the retry.
+# The companies <-> customer_sites <-> site_contacts trio forms an FK cycle whose
+# back-edge (companies.primary_contact_id) is declared use_alter=True, so
+# ``sorted_tables`` orders it cleanly (guarded by tests/test_metadata_hygiene.py).
+# The explicit child -> parent order below is kept as belt-and-suspenders: it stays
+# correct even if a future FK re-forms the cycle. The per-table resilient cleanup
+# below is what actually guarantees isolation, but a correct base order means the
+# happy path never needs the retry.
 _CYCLE_DELETE_FIRST = ("site_contacts", "customer_sites", "companies")
 _tables_by_name = {t.name: t for t in Base.metadata.sorted_tables}
 _delete_order_names = [n for n in _CYCLE_DELETE_FIRST if n in _tables_by_name] + [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1131,3 +1131,34 @@ class TestModuleLevelBranches:
 
 
 # ── Cache warmup (lines 121-123) ───────────────────────────────────────
+
+
+# ── Sentry init guard (_sentry_enabled) ────────────────────────────────
+class TestSentryEnabled:
+    """Sentry must never initialize under TESTING, even when the .env DSN is set (serial
+    test runs on the server inherit the real .env — test noise must not reach the
+    production Sentry project)."""
+
+    def test_disabled_under_testing_even_with_dsn(self, monkeypatch):
+        from app.config import settings
+        from app.main import _sentry_enabled
+
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setattr(settings, "sentry_dsn", "https://key@sentry.example/1")
+        assert _sentry_enabled() is False
+
+    def test_enabled_with_dsn_outside_testing(self, monkeypatch):
+        from app.config import settings
+        from app.main import _sentry_enabled
+
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.setattr(settings, "sentry_dsn", "https://key@sentry.example/1")
+        assert _sentry_enabled() is True
+
+    def test_disabled_without_dsn(self, monkeypatch):
+        from app.config import settings
+        from app.main import _sentry_enabled
+
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.setattr(settings, "sentry_dsn", "")
+        assert _sentry_enabled() is False

--- a/tests/test_metadata_hygiene.py
+++ b/tests/test_metadata_hygiene.py
@@ -1,0 +1,31 @@
+"""test_metadata_hygiene.py — Declarative-metadata FK-graph hygiene.
+
+Guards that ``Base.metadata.sorted_tables`` can topologically order EVERY
+table without dropping FK edges: an unresolvable cycle makes SQLAlchemy emit
+``SAWarning: Cannot correctly sort tables`` and silently ignore those FK
+constraints in the sort — noise in every test run and a trap for anything
+that relies on create/delete ordering. The known companies → site_contacts →
+customer_sites → companies cycle must stay broken (back-edge FK declared with
+``use_alter=True``).
+
+Called by: pytest
+Depends on: app/models (Base + every model module's table metadata)
+"""
+
+import warnings
+
+from sqlalchemy.exc import SAWarning
+
+from app.models import Base
+
+
+def test_sorted_tables_emits_no_unresolvable_cycle_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        order = Base.metadata.sorted_tables
+
+    cycle_warnings = [
+        w for w in caught if issubclass(w.category, SAWarning) and "cannot correctly sort" in str(w.message).lower()
+    ]
+    assert cycle_warnings == [], f"unresolvable FK cycle(s): {[str(w.message) for w in cycle_warnings]}"
+    assert len(order) == len(Base.metadata.tables)


### PR DESCRIPTION
Three hygiene items from the 2026-07-28 discovery-baseline audit backlog. No migration, no templates, no behavior change outside TESTING.

## 1. The 'Cannot correctly sort tables' SAWarning is gone

`companies.primary_contact_id` is the back-edge of the companies → site_contacts → customer_sites FK cycle. It's now declared `use_alter=True` with the explicit name **`fk_companies_primary_contact`** — the exact name migration 136 created it with (`op.create_foreign_key`) and the live DB carries (verified in `pg_constraint`). Schema is byte-identical → **no migration**. `sorted_tables` now orders every table cleanly; the SAWarning that fired in every single test run is gone (warning count in targeted runs dropped 27 → 9). Guarded by new `tests/test_metadata_hygiene.py`, which fails on revert.

Empirically verified before writing: named `use_alter` FK round-trips create→drop→create on a throwaway PG16 with zero warnings, and SQLite inlines the FK regardless (its `create_all` path unaffected).

## 2. Sentry never initializes under TESTING

New `_sentry_enabled()` (DSN set AND no `TESTING` env) gates the lifespan Sentry init. Serial test runs on the server inherit the real `.env` DSN and were shipping test-generated errors to the production Sentry project. TDD'd three-branch unit tests; the pre-existing `TestLifespanSentry` (which pops TESTING) remains compatible.

## 3. `submit_buy_plan` docstring

No longer claims a draft → active auto-approve path — removed in frozen scope; the code four lines down already said so.

## Verification

- Full suite in the worktree: **23,600 passed / 28 skipped / 0 failed** (`grep ^FAILED` = 0)
- pre-commit fully green (incl. mypy)
- Adversarial review agent: attacked FK-name-vs-drift-gate, PG `create_all` paths, `sorted_tables` consumers, TESTING seam, existing Sentry tests, xdist stability — **no findings** (drift gate also compares FKs by signature, not name, per the migration 188 docstring's documented precedent)

Also verified this session (no code): all three CRM Wave-4 leftovers (vendor dup-check, stale-offset pagination, vendor detail hx-target) shipped in #789 — that backlog line is closed. New residual worth a future item: the vendors list lacks the `offset >= total` snap-back clamp its customer-contacts sibling got in #789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)