### PR TITLE
fix(notifications): ownership-warning email deep link 404s — point at /v2/customers/{id}

### DIFF
--- a/app/services/ownership_service.py
+++ b/app/services/ownership_service.py
@@ -307,7 +307,7 @@ async def _send_warning_alert(company: Company, days_inactive: int, inactivity_l
             <p>No activity has been logged on <strong>{html.escape(str(company.name))}</strong> in <strong>{days_inactive} days</strong>.</p>
             <p>You'll lose ownership in <strong>{days_remaining} day{"s" if days_remaining != 1 else ""}</strong> unless you make contact.</p>
             <p style="margin-top: 20px;">
-                <a href="{settings.app_url}/companies/{company.id}"
+                <a href="{settings.app_url}/v2/customers/{company.id}"
                    style="background: #2563eb; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">
                     View Account & Re-engage
                 </a>

--- a/tests/test_notification_links.py
+++ b/tests/test_notification_links.py
@@ -1,0 +1,61 @@
+"""Notification outbound links resolve to real pages.
+
+Every URL the app puts into an email or push notification must land on a registered
+route — a renamed page must fail here, not in a user's inbox. Born from the ownership-
+warning email linking to /companies/{id}, a path that never existed as a page route (the
+account page is /v2/customers/{id}).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.routing import Match
+
+from app.models.auth import User
+from app.models.crm import Company
+from app.services.ownership_service import _send_warning_alert
+
+
+def _route_exists(path: str) -> bool:
+    """True if a GET for ``path`` matches any registered route (incl.
+
+    redirects).
+    """
+    from app.main import app
+
+    scope = {"type": "http", "path": path, "method": "GET", "root_path": ""}
+    return any(route.matches(scope)[0] == Match.FULL for route in app.router.routes)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v2/customers/1",  # ownership-warning email button
+        "/v2/buy-plans/1",  # buy-plan Teams deep link (308 shim into approvals)
+        "/v2/proactive",  # proactive Teams push card
+        "/p/confirm/some-token",  # prepayment tokenized pay link
+    ],
+)
+def test_notification_link_paths_resolve(path):
+    assert _route_exists(path), f"notification links to unregistered path: {path}"
+
+
+@pytest.mark.asyncio
+async def test_ownership_warning_email_links_to_customer_page(db_session, test_company: Company, sales_user: User):
+    """The warning email button must target /v2/customers/{id}, not the dead
+    /companies/{id}."""
+    test_company.account_owner_id = sales_user.id
+    db_session.flush()
+
+    gc = MagicMock()
+    gc.post_json = AsyncMock(return_value={})
+    with (
+        patch("app.scheduler.get_valid_token", AsyncMock(return_value="tok")),
+        patch("app.utils.graph_client.GraphClient", MagicMock(return_value=gc)),
+    ):
+        await _send_warning_alert(test_company, days_inactive=40, inactivity_limit=45, db=db_session)
+
+    assert gc.post_json.await_count == 1
+    body = gc.post_json.await_args.args[1]["message"]["body"]["content"]
+    assert f"/v2/customers/{test_company.id}" in body
+    assert f"/companies/{test_company.id}" not in body


### PR DESCRIPTION
The ownership-warning email's **View Account & Re-engage** button linked to `{app_url}/companies/{id}` — a path that never existed as a page route (404 live-reproduced). The account page is `/v2/customers/{id}`.

- One-line fix in `app/services/ownership_service.py`
- New `tests/test_notification_links.py`: asserts the email body targets the customer page (red before the fix), plus a route-integrity sweep that fails if any notification link path stops resolving against the route table.
- All other outbound notification links live-verified working (buy-plan 308 shim, proactive, pay link).

Suite: link tests + ownership suite → **34 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)