### PR TITLE
fix(contacts-sync): drop unsupported OData params from /me/contacts/delta

### DIFF
--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -621,13 +621,13 @@ async def _sync_user_contacts(user, db):
         # No initial_lookback_days: contacts deltas don't support the
         # receivedDateTime filter, and an address book is a finite collection —
         # draining it fully on the initial round IS the desired full sync.
+        # No OData params either: change tracking over the Contacts resource
+        # rejects $select/$top/$filter/etc. with 400 ErrorInvalidUrlQuery —
+        # page size rides the Prefer: odata.maxpagesize header (max_page_size)
+        # and full contact objects come back, which is fine.
         contacts, new_token = await gc.delta_query(
             "/me/contacts/delta",
             delta_token=delta_token,
-            params={
-                "$select": "displayName,emailAddresses,businessPhones,mobilePhone,companyName",
-                "$top": "100",
-            },
             max_items=2500,
             max_page_size=100,
         )

--- a/tests/test_jobs_email.py
+++ b/tests/test_jobs_email.py
@@ -908,6 +908,55 @@ def test_sync_user_contacts_skips_short_company(scheduler_db, test_user):
         mock_merge.assert_not_called()
 
 
+def test_sync_user_contacts_delta_call_sends_no_odata_params(scheduler_db, test_user):
+    """Graph 400s ErrorInvalidUrlQuery on $select/$top with /me/contacts/delta.
+
+    Change tracking over the Contacts resource supports NO OData query params —
+    page size must travel via the Prefer: odata.maxpagesize header (delta_query's
+    max_page_size). A normal delta page must still flow into the VendorCard
+    sync path (merge calls fire, delta token persisted).
+    """
+    test_user.access_token = "at_sync"
+    scheduler_db.commit()
+
+    mock_gc = MagicMock()
+    mock_gc.delta_query = AsyncMock(
+        return_value=(
+            [
+                {
+                    "companyName": "Delta Page Co",
+                    "displayName": "Del Ta",
+                    "emailAddresses": [{"address": "del@deltapageco.com"}],
+                    "businessPhones": ["+1-555-0100"],
+                    "mobilePhone": None,
+                }
+            ],
+            "delta-token",
+        )
+    )
+
+    with (
+        patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+        patch("app.vendor_utils.normalize_vendor_name", return_value="delta page co"),
+        patch("app.vendor_utils.merge_emails_into_card", return_value=1) as mock_merge_e,
+        patch("app.vendor_utils.merge_phones_into_card") as mock_merge_p,
+    ):
+        from app.jobs.email_jobs import _sync_user_contacts
+
+        asyncio.run(_sync_user_contacts(test_user, scheduler_db))
+
+    call = mock_gc.delta_query.call_args
+    assert call.args[0] == "/me/contacts/delta"
+    sent_params = call.kwargs.get("params")
+    assert not sent_params, f"contacts delta must not send OData query params, got: {sent_params}"
+    # Page size rides the Prefer: odata.maxpagesize header instead
+    assert call.kwargs.get("max_page_size") == 100
+    # Normal delta page still processes into the sync path
+    mock_merge_e.assert_called_once()
+    mock_merge_p.assert_called_once()
+    assert test_user.last_contacts_sync is not None
+
+
 def test_sync_user_contacts_graph_error(scheduler_db, test_user):
     """Graph API error during contacts sync is handled."""
     test_user.access_token = "at_sync"


### PR DESCRIPTION
## Bug (live, daily at 06:17)

The daily Outlook → VendorCards contacts sync has been silently no-oping. `_sync_user_contacts` (app/jobs/email_jobs.py) called:

```
gc.delta_query("/me/contacts/delta", params={"$select": ..., "$top": "100"}, ...)
```

Graph 400s this with `ErrorInvalidUrlQuery` — `$orderby, $filter, $select, $expand, $search, $top` are not supported with change tracking over the Contacts resource — and the per-user wrapper (email_jobs.py:139) downgrades the failure to a WARNING, so nothing surfaced.

## Fix

- Removed the `params` dict from the contacts delta call (app/jobs/email_jobs.py:624-636). Change tracking on Contacts accepts no OData query params.
- Page size is preserved: the call already passed `max_page_size=100`, which `delta_query` sends as `Prefer: odata.maxpagesize=100` (app/utils/graph_client.py:195-198) — the documented page-size control for delta queries. Full contact objects per page are acceptable.
- The `GraphSyncStateExpired` full-resync fallback keeps its `$select`/`$top` — it hits the plain `/me/contacts` list endpoint, where those params ARE supported.
- No behavior change for any other `delta_query` caller (message deltas support `$select`/`$filter`); `delta_query` itself is untouched.

## Tests (TDD)

New test `test_sync_user_contacts_delta_call_sends_no_odata_params` (tests/test_jobs_email.py:911-957):
- shown RED first against the old code — failed with `got: {'$select': 'displayName,emailAddresses,businessPhones,mobilePhone,companyName', '$top': '100'}` — then GREEN after the fix
- asserts the contacts delta call passes NO OData params and still passes `max_page_size=100`
- asserts a normal delta page still flows into the sync path (email/phone merges fire, `last_contacts_sync` set)

## Verification

- Full suite in the worktree: **24040 passed, 28 skipped** in 10:41
- `pre-commit` (ruff, ruff format, docformatter, mypy, status-enum + Query-API ratchets): all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
