### PR TITLE
fix(connectors): classify per-minute rate-limit 403s as transient, not auth

### DIFF
--- a/app/connectors/element14.py
+++ b/app/connectors/element14.py
@@ -20,8 +20,13 @@ from ._vendor_spec_map import extract_vendor_specs
 from .errors import ConnectorAuthError, ConnectorRateLimitError
 from .sources import BaseConnector
 
-# Markers that mean a 403 is a credential rejection (not a transient QPS cap).
+# Markers that mean a 403 is a credential rejection (not a transient rate cap).
 _AUTH_MARKERS = ("invalid", "unauthorized", "forbidden", "api key", "not accepted")
+
+# Markers that mean a 403 is a transient rate cap — the per-second QPS cap ("Account
+# Over Queries Per Second Limit") or the per-minute account cap ("Account Over Rate
+# Limit"). Auth markers win over these (see _api_search).
+_RATE_LIMIT_MARKERS = ("queries per second", "rate limit", "per minute")
 
 
 def _product_category(prod: dict, attrs: Any) -> str | None:
@@ -108,12 +113,20 @@ class Element14Connector(BaseConnector):
         # circuits the keyword fallback in _do_search — auto-recovers
         # when the next ping returns 200. See
         # docs/APP_MAP_INTERACTIONS.md § Connector Failure Contract.
-        # element14 returns HTTP 403 for BOTH credential rejection AND a per-second
-        # rate cap ("Account Over Queries Per Second Limit"). Distinguish by body:
-        # QPS errors contain "queries per second" but no auth-failure markers.
+        # element14 returns HTTP 403 for BOTH credential rejection AND its transient
+        # rate caps — per-second ("Account Over Queries Per Second Limit") and
+        # per-minute ("Account Over Rate Limit"). Distinguish by body: rate-cap
+        # errors carry a _RATE_LIMIT_MARKERS phrase and no auth-failure markers;
+        # they raise ConnectorRateLimitError so fetch_authoritative cools the
+        # source down and re-enables it within the same run instead of disabling
+        # it run-long.
         body = r.text.lower()
-        if r.status_code == 403 and "queries per second" in body and not any(m in body for m in _AUTH_MARKERS):
-            raise ConnectorRateLimitError(f"element14 rate limited (QPS): {r.text[:200]}")
+        if (
+            r.status_code == 403
+            and any(m in body for m in _RATE_LIMIT_MARKERS)
+            and not any(m in body for m in _AUTH_MARKERS)
+        ):
+            raise ConnectorRateLimitError(f"element14 rate limited: {r.text[:200]}")
         if r.status_code in (401, 403):
             # 401 = bad/expired API key; 403 = key rejected for the requested
             # store/region. Both require operator credential rotation.

--- a/app/connectors/errors.py
+++ b/app/connectors/errors.py
@@ -29,7 +29,14 @@ class ConnectorAuthError(ConnectorError):
 
 
 class ConnectorRateLimitError(ConnectorError):
-    """429 — rate limited, persistent across in-connector retries.
+    """Transient rate cap: 429, or a 403 whose body names a rate/minute limit
+    (Mouser "Maximum calls per minute exceeded", element14 "Account Over Rate
+    Limit" / "Account Over Queries Per Second Limit"), persistent across
+    in-connector retries.
+
+    fetch_authoritative applies a short cooldown and re-enables the source
+    within the same run — never a run-long disable (that path is reserved for
+    ConnectorAuthError/ConnectorQuotaError).
 
     Operator action: usually none; auto-recovers when the upstream's
     rate-limit window expires and the next health ping returns 200.

--- a/app/connectors/mouser.py
+++ b/app/connectors/mouser.py
@@ -17,6 +17,10 @@ from ._core_attrs import clean_str, generic_attribute, map_lifecycle, safe_pin_c
 from .errors import ConnectorAuthError, ConnectorRateLimitError
 from .sources import BaseConnector
 
+# Body markers meaning a 403 is a transient rate cap (e.g. "Maximum calls per minute
+# exceeded"), not a credential rejection. Mouser returns HTTP 403 for BOTH.
+_RATE_LIMIT_MARKERS = ("per minute", "per second", "rate limit", "too many")
+
 
 class MouserConnector(BaseConnector):
     """Mouser Search API — simple API key auth."""
@@ -57,11 +61,16 @@ class MouserConnector(BaseConnector):
             timeout=self.timeout,
         )
 
-        # 403 — bad/revoked key, quota-rejected, or region-locked. Raise
-        # so health_monitor flips status='error' and the source is excluded
-        # from user searches; auto-recovers on next ping success if it was
-        # transient.
+        # Mouser returns HTTP 403 for BOTH a transient rate cap ("Maximum calls
+        # per minute exceeded") AND bad/revoked/region-locked keys. Distinguish
+        # by body: rate-cap 403s raise ConnectorRateLimitError so
+        # fetch_authoritative applies a short cooldown and re-enables the source
+        # within the same run; credential 403s raise ConnectorAuthError so
+        # health_monitor flips status='error' and the source is excluded from
+        # user searches until the operator rotates the key.
         if r.status_code == 403:
+            if any(m in r.text.lower() for m in _RATE_LIMIT_MARKERS):
+                raise ConnectorRateLimitError(f"Mouser rate limited: HTTP 403 {r.text[:200]}")
             raise ConnectorAuthError(f"Mouser auth error: HTTP 403 {r.text[:200]}")
 
         # 429 — explicit rate limit. Auto-recovers on next ping success.

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -550,9 +550,24 @@ connector._do_search(part_number)
     +-- 400 (bad input) --> log + return []   (input-domain error, not contract)
     +-- 401/403 (auth)  --> raise ConnectorAuthError
     +-- 429 (rate)      --> raise ConnectorRateLimitError
+    +-- 403 (rate body) --> raise ConnectorRateLimitError
     +-- explicit quota  --> raise ConnectorQuotaError
     +-- 5xx             --> raise (httpx.HTTPStatusError via raise_for_status)
 ```
+
+**403 rate-vs-auth body classification (2026-08-03).** Mouser and element14
+return HTTP 403 for BOTH credential rejection AND their transient rate caps
+(Mouser "Maximum calls per minute exceeded"; element14 "Account Over Rate
+Limit" / "Account Over Queries Per Second Limit"). Each connector classifies
+by body markers: a 403 whose body names a rate/minute/second limit (and, for
+element14, carries no auth-failure marker — auth wins) raises
+`ConnectorRateLimitError`; every other 401/403 stays `ConnectorAuthError`.
+This matters for the nightly enrichment run:
+`authoritative_enrichment_service.fetch_authoritative` puts a
+`ConnectorRateLimitError` source on a 5-min in-run cooldown and re-enables it
+automatically, while `ConnectorAuthError`/`ConnectorQuotaError` disable the
+source for the rest of the run (oemsecrets 401 "User is not accepted or has
+run out of api calls" stays on this disable path by design).
 
 The `BaseConnector.search` wrapper:
 - Re-raises `ConnectorError` immediately without retry (hard failures

--- a/tests/test_connector_rate_limits.py
+++ b/tests/test_connector_rate_limits.py
@@ -186,6 +186,24 @@ class TestMouser403:
                 await c._do_search("SN74HC595N")
 
     @pytest.mark.asyncio
+    async def test_403_per_minute_rate_limit_raises_rate_limit_error(self):
+        """HTTP 403 'Maximum calls per minute exceeded' is a transient per-minute cap.
+
+        Must raise ConnectorRateLimitError (NOT ConnectorAuthError) so
+        fetch_authoritative applies a short cooldown instead of disabling mouser for the
+        entire nightly run.
+        """
+        from app.connectors.errors import ConnectorRateLimitError
+
+        c = self._make_connector()
+        resp = _mock_response(403, text="Maximum calls per minute exceeded")
+
+        with patch("app.connectors.mouser.http") as mock_http:
+            mock_http.post = AsyncMock(return_value=resp)
+            with pytest.raises(ConnectorRateLimitError, match="Mouser rate limited"):
+                await c._do_search("SN74HC595N")
+
+    @pytest.mark.asyncio
     async def test_429_raises_rate_limit_error(self):
         """HTTP 429 raises ConnectorRateLimitError.
 

--- a/tests/test_element14_connector.py
+++ b/tests/test_element14_connector.py
@@ -232,11 +232,16 @@ async def test_exact_miss_returns_empty_single_call(connector, monkeypatch):
         # ConnectorRateLimitError so fetch_authoritative applies a cooldown instead of
         # disabling the source.
         ("Account Over Queries Per Second Limit", "ConnectorRateLimitError"),
+        # 403 'Account Over Rate Limit' (the nightly per-minute cap, no auth marker) is
+        # ALSO transient → ConnectorRateLimitError, not a run-long disable.
+        ("Account Over Rate Limit", "ConnectorRateLimitError"),
         # 403 whose body contains BOTH 'queries per second' AND an auth marker is a
         # credential rejection → ConnectorAuthError (auth wins over rate limit).
         ("Invalid API key - queries per second", "ConnectorAuthError"),
+        # A plain 403 with no rate marker stays a credential rejection.
+        ("Forbidden", "ConnectorAuthError"),
     ],
-    ids=["qps_only_rate_limit", "qps_with_auth_marker_auth"],
+    ids=["qps_only_rate_limit", "over_rate_limit_rate_limit", "qps_with_auth_marker_auth", "plain_403_auth"],
 )
 async def test_403_body_classification(connector, monkeypatch, body, expected_error_attr):
     """A 403 body is classified as a rate-limit vs.

--- a/tests/test_enrichment_rate_limit.py
+++ b/tests/test_enrichment_rate_limit.py
@@ -1,7 +1,24 @@
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
 
 from app.connectors.errors import ConnectorQuotaError, ConnectorRateLimitError
 from app.services.authoritative_enrichment_service import fetch_authoritative
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    """Build a fake httpx.Response (same shape as test_connector_rate_limits)."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = text or str(json_data)
+    resp.headers = {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=MagicMock(), response=resp)
+    return resp
 
 
 def _rl_conn(name="element14"):
@@ -40,3 +57,66 @@ def test_quota_still_disables():
     disabled: set[str] = set()
     asyncio.run(fetch_authoritative("A", "a", [_Q()], disabled, {}))
     assert "oemsecrets" in disabled
+
+
+@pytest.mark.asyncio
+async def test_mouser_403_rate_limit_recovers_within_run(monkeypatch):
+    """A mouser-style HTTP 403 'Maximum calls per minute exceeded' (real connector,
+    mocked HTTP) must land in ``cooldown`` — NOT ``disabled`` — and the connector must
+    be queried again once the cooldown expires, all within the same run."""
+    import app.services.authoritative_enrichment_service as aes
+    from app.connectors.mouser import MouserConnector
+
+    monkeypatch.setattr(aes, "_RATE_COOLDOWN_SECONDS", 0.05)
+    conn = MouserConnector(api_key="test-key")
+    conn._breaker.record_success()  # breakers are class-global — reset from prior tests
+
+    rate_403 = _mock_response(403, text="Maximum calls per minute exceeded")
+    ok = _mock_response(
+        200,
+        json_data={"SearchResults": {"Parts": [{"ManufacturerPartNumber": "LM317T", "Description": "1.5A regulator"}]}},
+    )
+
+    with patch("app.connectors.mouser.http") as mock_http:
+        mock_http.post = AsyncMock(side_effect=[rate_403, ok])
+        disabled: set[str] = set()
+        cooldown: dict[str, float] = {}
+
+        await fetch_authoritative("LM317T", "lm317t", [conn], disabled, cooldown)
+        assert "mouser" not in disabled, "per-minute 403 must not disable mouser for the run"
+        assert "mouser" in cooldown
+
+        # Still cooling down: skipped, no upstream call burned.
+        await fetch_authoritative("LM317T", "lm317t", [conn], disabled, cooldown)
+        assert mock_http.post.call_count == 1
+
+        # Cooldown expired: re-enabled within the same run and contributing again.
+        await asyncio.sleep(0.06)
+        results = await fetch_authoritative("LM317T", "lm317t", [conn], disabled, cooldown)
+        assert mock_http.post.call_count == 2
+        assert results["mouser"][0]["mpn_matched"] == "LM317T"
+
+
+@pytest.mark.asyncio
+async def test_oemsecrets_401_still_disables_for_run():
+    """A true auth/quota failure (oemsecrets HTTP 401 'User is not accepted or has run
+    out of api calls', real connector, mocked HTTP) must still disable the source for
+    the rest of the run."""
+    from app.connectors.oemsecrets import OEMSecretsConnector
+
+    conn = OEMSecretsConnector(api_key="test-key")
+    conn._breaker.record_success()  # breakers are class-global — reset from prior tests
+
+    resp_401 = _mock_response(401, text="User is not accepted or has run out of api calls")
+
+    with patch("app.connectors.oemsecrets.http") as mock_http:
+        mock_http.get = AsyncMock(return_value=resp_401)
+        disabled: set[str] = set()
+        cooldown: dict[str, float] = {}
+
+        await fetch_authoritative("LM358N", "lm358n", [conn], disabled, cooldown)
+        assert "oemsecrets" in disabled
+
+        # Disabled for the run: skipped, no further upstream calls.
+        await fetch_authoritative("LM358N", "lm358n", [conn], disabled, cooldown)
+        assert mock_http.get.call_count == 1


### PR DESCRIPTION
## Problem

Both of the last two nightly enrichment runs lost an entire night of mouser and element14 contributions. Both APIs return **HTTP 403 for transient rate caps** (mouser `"Maximum calls per minute exceeded"`, element14 `"Account Over Rate Limit"`), and the connectors raised those as `ConnectorAuthError` — so `fetch_authoritative` (app/services/authoritative_enrichment_service.py:149-154) disabled the source for the **entire run** instead of using its existing 5-minute in-run cooldown path for `ConnectorRateLimitError`.

## Root cause + fix

The cooldown/resume mechanism already existed in the service and worker (`cooldown` dict, `_RATE_COOLDOWN_SECONDS = 300`, re-enables automatically within the run). The bug was purely upstream misclassification in the connectors:

- **mouser** (app/connectors/mouser.py:22, 71-74): previously ALL 403s → `ConnectorAuthError`. Now a 403 whose body names a rate/minute/second limit raises `ConnectorRateLimitError` (cooldown + resume); other 403s (revoked key, region lock) stay on the auth/disable path.
- **element14** (app/connectors/element14.py:29, 123-129): 403 rate detection broadened from `"queries per second"` only to `_RATE_LIMIT_MARKERS` (`"queries per second"`, `"rate limit"`, `"per minute"`), so `"Account Over Rate Limit"` is now transient. Auth markers still win over rate markers.
- **oemsecrets 401** (`"User is not accepted or has run out of api calls"`): unchanged — still `ConnectorAuthError`, still disables for the run by design.
- 429s already raised `ConnectorRateLimitError` everywhere — no change needed.

Docs: `ConnectorRateLimitError` taxonomy docstring (app/connectors/errors.py:31) and APP_MAP_INTERACTIONS.md § Connector Failure Contract updated with the 403 body-classification rule.

## Tests (red-first)

Shown red before the fix, green after:
- `tests/test_connector_rate_limits.py:189` — mouser 403 `"Maximum calls per minute exceeded"` → `ConnectorRateLimitError` (was `ConnectorAuthError`); plain 403 `"Forbidden"` still auth.
- `tests/test_element14_connector.py` — parametrized 403 body classification extended: `"Account Over Rate Limit"` → rate limit; plain `"Forbidden"` → auth.
- `tests/test_enrichment_rate_limit.py:63` — end-to-end through the REAL `MouserConnector` (mocked HTTP): per-minute 403 lands in `cooldown` not `disabled`, is skipped during cooldown, and is re-queried and contributes again after the cooldown expires — all within the same run.
- `tests/test_enrichment_rate_limit.py:101` — oemsecrets 401 through the real connector still disables the source for the rest of the run.

Regression net: 805 passed across 18 connector/enrichment/search/worker test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
