### PR TITLE
chore(deps): cryptography 50.0.0 — clear tonight's CVE-2026-69247 pip-audit failure

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,7 +41,7 @@ click==8.4.1
     #   schemathesis
 coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   -c requirements.txt
     #   types-pyopenssl

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ jinja2==3.1.6
 filetype==1.2.0
 charset-normalizer==3.4.9
 # Credential encryption
-cryptography==49.0.0
+cryptography==50.0.0
 # Observability
 loguru==0.7.3
 # Pinned >=1.3.1 to fix CVE-2026-54283 (urlencoded form DoS) + CVE-2026-54282

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ charset-normalizer==3.4.9
     #   requests
 click==8.4.1
     # via uvicorn
-cryptography==49.0.0
+cryptography==50.0.0
     # via -r requirements.in
 cssselect2==0.9.0
     # via weasyprint


### PR DESCRIPTION
Third repo-wide advisory event today, Python side this time: cryptography 49.0.0 flagged by pip-audit (CVE-2026-69247, PKCS#7 decryption oracle, fixed in 50.0.0) — fails the `security` check on every branch including #821. Surgical pin bump in all three requirements files; no recompile (transitives unchanged 49→50; avoids the known Py3.12-local/Py3.13-CI lockfile skew). AVAIL has no S/MIME decryption surface, so this was gate hygiene, not live exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)