### PR TITLE
fix(teams): self-DM posts to the existing self-chat — Graph cannot create one

### DIFF
--- a/app/services/teams_notifications.py
+++ b/app/services/teams_notifications.py
@@ -85,27 +85,49 @@ async def post_teams_channel_card(card: dict, webhook_url: str | None = None) ->
         logger.error("Teams channel card post failed: {}", e)
 
 
+async def _find_self_chat(gc, sender_id: str) -> str | None:
+    """Return the id of the caller's Teams self-chat ("Chat with self"), or None.
+
+    The self-chat is the oneOnOne chat in ``/me/chats`` whose only member is the
+    caller. Follows @odata.nextLink a few pages in case it is buried below more
+    recently active chats.
+    """
+    url = "/me/chats?$expand=members&$top=50"
+    for _ in range(4):
+        page = await gc.get_json(url)
+        for chat in page.get("value", []):
+            members = chat.get("members") or []
+            member_ids = {m.get("userId") for m in members if m.get("userId")}
+            if chat.get("chatType") == "oneOnOne" and members and member_ids <= {sender_id}:
+                chat_id = chat.get("id")
+                return chat_id if isinstance(chat_id, str) else None
+        url = page.get("@odata.nextLink")
+        if not url:
+            break
+    return None
+
+
 async def send_teams_dm(user, message: str, db=None) -> None:
     """Send a direct Teams message to a user via Graph API.
 
-    Resolves the sending account (the token owner) via Graph ``/me``, then
-    creates (or gets) the chat and posts the message. Graph requires a
-    ``oneOnOne`` chat's members array to list EVERY participant including the
-    caller, so:
+    Resolves the sending account (the token owner) via Graph ``/me``, then:
 
-    - Sender != recipient → two members: the token owner bound by AAD object
-      id and the recipient bound by email.
+    - Sender != recipient → POST /chats with two members (token owner bound by
+      AAD object id, recipient bound by email), then post the message.
     - Sender == recipient (the usual case here — DMs are sent with the
-      recipient's own delegated token) → the Graph self-chat form: a single
-      member bound by the caller's AAD object id. Chosen over skipping because
-      it actually delivers — the message lands in the user's Teams self-chat
-      and surfaces as a notification. (The old single-member payload bound by
-      EMAIL is what Graph rejected with "Creation of 'OneOnOne' chat requires
-      2 members".)
+      recipient's own delegated token) → find the EXISTING Teams self-chat
+      ("Chat with self") in ``/me/chats`` — the oneOnOne chat whose only
+      member is the caller — and post to it. Graph cannot CREATE a
+      single-member oneOnOne chat at all: v1.0 and beta both reject it with
+      "Creation of 'OneOnOne' chat requires 2 members" regardless of bind
+      format (verified live 2026-08-04), so creation is never attempted.
 
-    Silently skips (DEBUG/WARNING log, never raises) if no valid token is
-    available, ``/me`` cannot be resolved, or Graph rejects the chat creation
-    (e.g. missing Chat.ReadWrite permissions).
+    Never raises. Skips with a DEBUG log when no valid token is available and
+    a WARNING when ``/me`` cannot be resolved, the self-chat is missing
+    (user must open "Chat with self" in Teams once), or Graph rejects the
+    chat creation / message post — the retry layer returns
+    ``{"error": status}`` dicts on 4xx, which are treated as failures here,
+    never as silent success.
 
     Args:
         user: User model instance (needs .email, .access_token)
@@ -136,29 +158,39 @@ async def send_teams_dm(user, message: str, db=None) -> None:
             logger.warning("Teams DM to {} skipped — could not resolve sender via /me: {}", user.email, me)
             return
         sender_emails = {e.lower() for e in (me.get("mail"), me.get("userPrincipalName")) if isinstance(e, str) and e}
-        graph_users = "https://graph.microsoft.com/v1.0/users"
-        sender_member = {
-            "@odata.type": "#microsoft.graph.aadUserConversationMember",
-            "roles": ["owner"],
-            "user@odata.bind": f"{graph_users}/{sender_id}",
-        }
         if (user.email or "").lower() in sender_emails:
-            # Self-chat: exactly one member — the caller, bound by AAD id.
-            members = [sender_member]
+            chat_id = await _find_self_chat(gc, sender_id)
+            if not chat_id:
+                logger.warning(
+                    "Teams DM to {} skipped — self-chat not found via /me/chats "
+                    "(open 'Chat with self' in Teams once to provision it)",
+                    user.email,
+                )
+                return
         else:
+            graph_users = "https://graph.microsoft.com/v1.0/users"
             members = [
-                sender_member,
+                {
+                    "@odata.type": "#microsoft.graph.aadUserConversationMember",
+                    "roles": ["owner"],
+                    "user@odata.bind": f"{graph_users}/{sender_id}",
+                },
                 {
                     "@odata.type": "#microsoft.graph.aadUserConversationMember",
                     "roles": ["owner"],
                     "user@odata.bind": f"{graph_users}/{user.email}",
                 },
             ]
-        # Create or get the 1:1 chat (Graph returns the existing chat if one exists)
-        chat = await gc.post_json("/chats", {"chatType": "oneOnOne", "members": members})
-        chat_id = chat.get("id")
-        if chat_id:
-            await gc.post_json(f"/chats/{chat_id}/messages", {"body": {"content": message}})
-            logger.info("Teams DM sent to {}", user.email)
+            # Create or get the 1:1 chat (Graph returns the existing chat if one exists)
+            chat = await gc.post_json("/chats", {"chatType": "oneOnOne", "members": members})
+            chat_id = chat.get("id")
+            if not chat_id:
+                logger.warning("Teams DM to {} failed — chat creation rejected: {}", user.email, chat)
+                return
+        resp = await gc.post_json(f"/chats/{chat_id}/messages", {"body": {"content": message}})
+        if isinstance(resp, dict) and resp.get("error"):
+            logger.warning("Teams DM to {} failed — message post rejected: {}", user.email, resp)
+            return
+        logger.info("Teams DM sent to {}", user.email)
     except Exception as e:
         logger.warning("Teams DM to {} failed (may not have Chat permissions): {}", user.email, e)

--- a/tests/test_teams_notifications.py
+++ b/tests/test_teams_notifications.py
@@ -155,12 +155,37 @@ def _make_user(email="buyer@trioscs.com", access_token="tok-123"):
     return SimpleNamespace(email=email, access_token=access_token)
 
 
-def _make_gc(me=SENDER_ME, chat={"id": "chat-id-123"}):
-    """Mock GraphClient instance: /me identity + chat-create/message-post responses."""
+def _make_gc(me=SENDER_ME, chat={"id": "chat-id-123"}, chats_page=None):
+    """Mock GraphClient instance: routes /me and /me/chats GETs; POSTs create+send."""
     gc = MagicMock()
-    gc.get_json = AsyncMock(return_value=me)
+
+    async def _get(url, *a, **k):
+        if url.startswith("/me/chats") or "chats" in url:
+            return chats_page if chats_page is not None else {"value": []}
+        return me
+
+    gc.get_json = AsyncMock(side_effect=_get)
     gc.post_json = AsyncMock(side_effect=[chat, {}])
     return gc
+
+
+def _self_chats_page(self_guid="self-guid", chat_id="self-chat-id-9"):
+    """A /me/chats page: one 2-member chat (decoy) + the single-member self-chat."""
+    return {
+        "value": [
+            {
+                "id": "other-chat-1",
+                "chatType": "oneOnOne",
+                "members": [{"userId": self_guid}, {"userId": "someone-else"}],
+            },
+            {"id": "group-1", "chatType": "group", "members": [{"userId": self_guid}]},
+            {
+                "id": chat_id,
+                "chatType": "oneOnOne",
+                "members": [{"userId": self_guid}],
+            },
+        ]
+    }
 
 
 @pytest.mark.asyncio
@@ -240,14 +265,16 @@ async def test_send_teams_dm_creates_chat_with_two_members():
 
 @pytest.mark.asyncio
 async def test_send_teams_dm_self_chat_when_sender_is_recipient():
-    """Sender == recipient → Graph self-chat: ONE member bound by the caller's AAD id.
+    """Sender == recipient → find the EXISTING self-chat via /me/chats and post to it.
 
-    Duplicate members would be rejected, and the old email-bound single member is
-    exactly the payload Graph 400s on. Email match is case-insensitive.
+    Graph cannot CREATE a single-member oneOnOne chat at all — both v1.0 and beta reject
+    it with "Creation of 'OneOnOne' chat requires 2 members" (verified live 2026-08-04,
+    both /users/{id} and /users('{id}') bind formats). The Teams-provisioned self-chat
+    ("Chat with self") is the only deliverable channel. Email match is case-insensitive.
     """
     user = _make_user(email="Buyer@trioscs.com")
     me = {"id": "self-guid", "mail": "buyer@trioscs.com", "userPrincipalName": "buyer@trioscs.com"}
-    mock_gc_instance = _make_gc(me=me)
+    mock_gc_instance = _make_gc(me=me, chats_page=_self_chats_page())
 
     with patch(
         "app.utils.graph_client.GraphClient",
@@ -257,17 +284,82 @@ async def test_send_teams_dm_self_chat_when_sender_is_recipient():
 
         await send_teams_dm(user, "self note")
 
-    chat_call = mock_gc_instance.post_json.await_args_list[0]
-    assert chat_call.args[0] == "/chats"
-    members = chat_call.args[1]["members"]
-    assert len(members) == 1
-    # Bound by AAD object id, NOT by email
-    assert members[0]["user@odata.bind"] == f"{GRAPH_USERS}/self-guid"
-
-    mock_gc_instance.post_json.assert_any_await(
-        "/chats/chat-id-123/messages",
+    # NO chat creation attempted — the message goes straight to the found self-chat.
+    posted_urls = [c.args[0] for c in mock_gc_instance.post_json.await_args_list]
+    assert "/chats" not in posted_urls
+    mock_gc_instance.post_json.assert_awaited_once_with(
+        "/chats/self-chat-id-9/messages",
         {"body": {"content": "self note"}},
     )
+
+
+@pytest.mark.asyncio
+async def test_send_teams_dm_self_chat_not_found_warns_and_skips():
+    """No single-member self-chat in /me/chats → warn and skip; never attempt a single-
+    member /chats create (Graph rejects it)."""
+    user = _make_user(email="buyer@trioscs.com")
+    me = {"id": "self-guid", "mail": "buyer@trioscs.com", "userPrincipalName": "buyer@trioscs.com"}
+    no_self = {
+        "value": [{"id": "c1", "chatType": "oneOnOne", "members": [{"userId": "self-guid"}, {"userId": "other"}]}]
+    }
+    mock_gc_instance = _make_gc(me=me, chats_page=no_self)
+
+    with _capture_logs("WARNING") as captured:
+        with patch(
+            "app.utils.graph_client.GraphClient",
+            return_value=mock_gc_instance,
+        ):
+            from app.services.teams_notifications import send_teams_dm
+
+            await send_teams_dm(user, "never sent")
+
+        assert any("self-chat not found" in m for m in captured)
+    mock_gc_instance.post_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_teams_dm_warns_when_chat_create_rejected():
+    """Two-member path: an error dict from POST /chats is a FAILURE — warn, do not
+    silently report success (the retry layer returns {"error": status} on 4xx
+    instead of raising)."""
+    user = _make_user(email="other.person@trioscs.com")
+    mock_gc_instance = _make_gc()
+    mock_gc_instance.post_json = AsyncMock(return_value={"error": 400, "detail": "requires 2 members"})
+
+    with _capture_logs("WARNING") as captured:
+        with patch(
+            "app.utils.graph_client.GraphClient",
+            return_value=mock_gc_instance,
+        ):
+            from app.services.teams_notifications import send_teams_dm
+
+            await send_teams_dm(user, "never sent")
+
+        assert any("chat creation" in m for m in captured)
+    # Only the /chats attempt — no message post after a rejected create.
+    assert mock_gc_instance.post_json.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_send_teams_dm_warns_when_message_post_rejected():
+    """Self path: an error dict from the message POST is a FAILURE — warn, and do
+    not log the 'Teams DM sent' success line."""
+    user = _make_user(email="buyer@trioscs.com")
+    me = {"id": "self-guid", "mail": "buyer@trioscs.com", "userPrincipalName": "buyer@trioscs.com"}
+    mock_gc_instance = _make_gc(me=me, chats_page=_self_chats_page())
+    mock_gc_instance.post_json = AsyncMock(return_value={"error": 403, "detail": "forbidden"})
+
+    with _capture_logs("INFO") as captured:
+        with patch(
+            "app.utils.graph_client.GraphClient",
+            return_value=mock_gc_instance,
+        ):
+            from app.services.teams_notifications import send_teams_dm
+
+            await send_teams_dm(user, "rejected message")
+
+        assert any("message post" in m and "WARNING" in m for m in captured)
+        assert not any("Teams DM sent" in m for m in captured)
 
 
 @pytest.mark.asyncio
@@ -318,19 +410,22 @@ async def test_send_teams_dm_refreshes_token_via_db():
 
 @pytest.mark.asyncio
 async def test_send_teams_dm_skips_message_when_no_chat_id():
-    """If /chats returns no id, the message post is skipped."""
+    """If /chats returns no id, the message post is skipped and a warning is logged (an
+    id-less create is a failure, not a silent no-op)."""
     user = _make_user()
     mock_gc_instance = _make_gc()
     mock_gc_instance.post_json = AsyncMock(return_value={})  # no "id" key
 
-    with patch(
-        "app.utils.graph_client.GraphClient",
-        return_value=mock_gc_instance,
-    ):
-        from app.services.teams_notifications import send_teams_dm
+    with _capture_logs("WARNING") as captured:
+        with patch(
+            "app.utils.graph_client.GraphClient",
+            return_value=mock_gc_instance,
+        ):
+            from app.services.teams_notifications import send_teams_dm
 
-        await send_teams_dm(user, "should not send message")
+            await send_teams_dm(user, "should not send message")
 
+        assert any("chat creation" in m for m in captured)
     # Only one call (/chats), no second call for messages
     assert mock_gc_instance.post_json.call_count == 1
 


### PR DESCRIPTION
## Root cause (verified live, not inferred)

The overnight proof point for #816 FAILED: 4x `Creation of 'OneOnOne' chat requires 2 members` Graph 400s (02:20/06:20 UTC), zero DMs delivered. Live probe against the tenant shows the self-chat branch WAS taken and the email gate worked — the premise itself is wrong: **Graph rejects creating a single-member oneOnOne chat entirely** (v1.0 and beta, both `/users/{id}` and `/users('{id}')` binds; the v1.0/beta Create-chat docs contain no self-chat support).

The Teams-provisioned self-chat ("Chat with self") DOES exist and is discoverable: `GET /me/chats?$expand=members` returns a oneOnOne chat whose only member is the caller. Posting to it works — **delivery confirmed live 2026-08-04 17:55:53Z** (test message visible in the owner's Teams self-chat).

## Fix

- Self-DM path: discover the existing self-chat via `/me/chats` (nextLink-paged, 4-page cap) and post straight to it; never attempt a single-member create. Missing self-chat → WARNING + skip (user must open 'Chat with self' once).
- Distinct-recipient path unchanged (documented two-member create).
- Silent-failure hardening (what hid this for two nights): the retry layer returns `{'error': status}` dicts on 4xx; `send_teams_dm` treated those as success and the nudge job logged 'executed successfully'. Chat-create rejections, id-less creates, and message-post rejections now WARN; `Teams DM sent` logs only on real success.

## Tests

TDD: 5 failing tests written first against current code, then fix → `tests/test_teams_notifications.py` 16/16, `tests/test_buyplan_notifications.py` + `tests/test_services_coverage.py` green (73 + 75). pre-commit incl. mypy: Passed.

Proof point after deploy: next nudge tick with due lines must log `Teams DM sent to` and zero `requires 2 members`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)