### PR TITLE
fix(proactive): clear ALL stale digest drafts on regenerate

### DIFF
--- a/app/services/proactive_digest.py
+++ b/app/services/proactive_digest.py
@@ -206,6 +206,13 @@ def generate_digests(db: Session) -> dict:
 
     dup_groups = find_duplicate_material_groups(db)
 
+    # Drafts are disposable — clear ALL of them up front, not per-salesperson,
+    # so a rep whose matches evaporated (or were reassigned) since last
+    # generation doesn't keep a stale draft forever. SENT digests are untouched.
+    for stale in db.scalars(select(ProactiveDigest).where(ProactiveDigest.status == ProactiveDigestStatus.DRAFT)).all():
+        db.delete(stale)
+    db.flush()
+
     # Assemble per salesperson → per customer (Trio Back Order last).
     per_sales: dict[int, dict] = {}
     for m in matches:
@@ -244,16 +251,6 @@ def generate_digests(db: Session) -> dict:
 
         line_parts = {ln["mpn"] for _, lines_ in groups for ln in lines_}
         digest_dups = [g for g in dup_groups if any(p in line_parts for p in g)]
-
-        # Replace any unsent draft for this salesperson.
-        for stale in db.scalars(
-            select(ProactiveDigest).where(
-                ProactiveDigest.salesperson_id == salesperson_id,
-                ProactiveDigest.status == ProactiveDigestStatus.DRAFT,
-            )
-        ).all():
-            db.delete(stale)
-        db.flush()
 
         digest = ProactiveDigest(
             salesperson_id=salesperson_id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "npm-audit",
+  "name": "proactive-augment",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "npm-audit",
+      "name": "proactive-augment",
       "dependencies": {
         "@alpinejs/anchor": "^3.15.12",
         "@alpinejs/collapse": "^3.15.12",
@@ -2861,9 +2861,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/requirements.in
+++ b/requirements.in
@@ -32,7 +32,7 @@ rapidfuzz>=3.0.0,<4.0
 # PDF generation
 weasyprint==69.0
 # PDF text extraction (datasheet verification)
-pypdf==6.14.2
+pypdf==6.15.0
 # Scheduling
 apscheduler>=3.11.3,<4.0
 # Migrations

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ pydyf==0.12.1
     # via weasyprint
 pyee==13.0.1
     # via patchright
-pypdf==6.14.2
+pypdf==6.15.0
     # via -r requirements.in
 pyphen==0.17.2
     # via weasyprint

--- a/tests/test_proactive_digest.py
+++ b/tests/test_proactive_digest.py
@@ -223,6 +223,30 @@ def test_duplicate_materials_section(db_session):
     assert "LTSR 15-NP / LTSR15-NP" in body
 
 
+def test_regenerate_clears_stale_draft_when_matches_moved(db_session):
+    """A rep whose matches were reassigned (or evaporated) must not keep a stale draft.
+
+    Found live 2026-08-07: the seed's actor held a 32-line draft that survived
+    regeneration after every match moved to the real reps.
+    """
+    old_rep = _mk_user(db_session, "Old Rep", "old@trioscs.com")
+    new_rep = _mk_user(db_session, "New Rep", "new@trioscs.com")
+    customer, _ = _mk_customer(db_session, "IBM", old_rep)
+    _mk_offer(db_session, mpn="02PX530", qty=214, price="275")
+    m = _mk_match(db_session, mpn="02PX530", owner=old_rep, company=customer)
+    generate_digests(db_session)
+    db_session.commit()
+    assert db_session.query(ProactiveDigest).one().salesperson_id == old_rep.id
+
+    m.salesperson_id = new_rep.id
+    db_session.commit()
+    generate_digests(db_session)
+    db_session.commit()
+    drafts = db_session.query(ProactiveDigest).all()
+    assert len(drafts) == 1
+    assert drafts[0].salesperson_id == new_rep.id  # old rep's stale draft is gone
+
+
 def test_regenerate_replaces_draft_not_sent(db_session):
     owner = _mk_user(db_session, "Sales Rep", "sr@trioscs.com")
     customer, _ = _mk_customer(db_session, "IBM", owner)


### PR DESCRIPTION
Found live after the 2026-08-07 seed reattribution: the importing admin kept a 32-line draft after every match was reassigned to the real reps, because generation only replaced drafts for salespeople who still had matches. Drafts are disposable by design — regeneration now clears every DRAFT up front, so a rep whose matches evaporated or moved never keeps a stale one. SENT digests untouched. Regression test included (reassign scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)