### PR TITLE
feat(proactive): Matches-tab Process flow — send/ignore checks, per-customer draft offers, review strip; manager See-All

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -444,8 +444,13 @@ ROLE_ACCESS_DEFAULTS: dict[UserRole, frozenset] = {
 
 
 class ProactiveOfferStatus(StrEnum):
-    """Status lifecycle for ProactiveOffer records."""
+    """Status lifecycle for ProactiveOffer records.
 
+    DRAFT rows are per-customer prepared offers staged by the Matches tab's Process flow
+    — reviewed and sent one click at a time, never automatically.
+    """
+
+    DRAFT = "draft"
     SENT = "sent"
     CONVERTED = "converted"
     EXPIRED = "expired"

--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -41,6 +41,31 @@ from ._shared import _base_ctx
 router = APIRouter(tags=["htmx-views"])
 
 
+def _render_matches_tab(request: Request, user: User, db: Session, *, scope: str = "mine", success_msg: str = ""):
+    """One renderer for every endpoint that lands back on the Matches tab.
+
+    ``scope=all`` (manager/admin only) shows every rep's matches with rep
+    attribution; everyone else always gets their own. The prepared strip
+    (staged per-customer draft offers from Process) rides along.
+    """
+    from ...dependencies import is_manager_or_admin
+    from ...services.proactive_service import get_matches_for_user, list_draft_offers
+
+    can_see_all = is_manager_or_admin(user)
+    admin_all = scope == "all" and can_see_all
+    result = get_matches_for_user(db, user.id, status=ProactiveMatchStatus.NEW, admin_all=admin_all)
+    ctx = _base_ctx(request, user, "proactive")
+    ctx["matches"] = result.get("groups", []) if isinstance(result, dict) else result
+    ctx["sent"] = []
+    ctx["tab"] = "matches"
+    ctx["match_count"] = result.get("stats", {}).get("total", 0) if isinstance(result, dict) else 0
+    ctx["success_msg"] = success_msg
+    ctx["scope"] = "all" if admin_all else "mine"
+    ctx["can_see_all"] = can_see_all
+    ctx["prepared"] = list_draft_offers(db, user, allow_all=admin_all)
+    return template_response("htmx/partials/proactive/list.html", ctx)
+
+
 # ── Proactive Part Match ─────────────────────────────────────────────
 
 
@@ -48,12 +73,18 @@ router = APIRouter(tags=["htmx-views"])
 async def proactive_list_partial(
     request: Request,
     tab: str = "matches",
+    scope: str = "mine",
     user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Proactive matches list partial — Matches / Sent / Digests tabs."""
     from ...dependencies import is_manager_or_admin
     from ...services.proactive_service import get_matches_for_user, get_sent_offers
+
+    if tab == "matches":
+        return _render_matches_tab(
+            request, user, db, scope=scope, success_msg=request.query_params.get("success_msg", "")
+        )
 
     result = get_matches_for_user(db, user.id, status=ProactiveMatchStatus.NEW)
     groups = result.get("groups", []) if isinstance(result, dict) else result
@@ -84,21 +115,9 @@ async def proactive_refresh(
 ):
     """Trigger a proactive scan then return the matches list partial."""
     from ...services.proactive_matching import run_proactive_scan
-    from ...services.proactive_service import get_matches_for_user
 
     await asyncio.to_thread(run_proactive_scan, db)
-
-    result = get_matches_for_user(db, user.id, status=ProactiveMatchStatus.NEW)
-    groups = result.get("groups", []) if isinstance(result, dict) else result
-    match_count = result.get("stats", {}).get("total", 0) if isinstance(result, dict) else 0
-
-    ctx = _base_ctx(request, user, "proactive")
-    ctx["matches"] = groups
-    ctx["sent"] = []
-    ctx["tab"] = "matches"
-    ctx["match_count"] = match_count
-    ctx["success_msg"] = ""
-    return template_response("htmx/partials/proactive/list.html", ctx)
+    return _render_matches_tab(request, user, db)
 
 
 @router.post("/v2/partials/proactive/batch-dismiss", response_class=HTMLResponse)
@@ -115,28 +134,20 @@ async def proactive_batch_dismiss(
     match_ids = [int(mid) for mid in match_ids_raw if mid and str(mid).isdigit()]
 
     if match_ids:
-        db.query(ProactiveMatch).filter(
+        from ...dependencies import is_manager_or_admin
+
+        query = db.query(ProactiveMatch).filter(
             ProactiveMatch.id.in_(match_ids),
-            ProactiveMatch.salesperson_id == user.id,
             ProactiveMatch.status == ProactiveMatchStatus.NEW,
-        ).update(
+        )
+        if not is_manager_or_admin(user):
+            query = query.filter(ProactiveMatch.salesperson_id == user.id)
+        query.update(
             {"status": ProactiveMatchStatus.DISMISSED, "dismiss_reason": "batch_dismiss"}, synchronize_session=False
         )
         db.commit()
 
-    # Re-render list
-    from ...services.proactive_service import get_matches_for_user
-
-    result = get_matches_for_user(db, user.id, status=ProactiveMatchStatus.NEW)
-    groups = result.get("groups", []) if isinstance(result, dict) else result
-    match_count = result.get("stats", {}).get("total", 0) if isinstance(result, dict) else 0
-    ctx = _base_ctx(request, user, "proactive")
-    ctx["matches"] = groups
-    ctx["sent"] = []
-    ctx["tab"] = "matches"
-    ctx["match_count"] = match_count
-    ctx["success_msg"] = ""
-    return template_response("htmx/partials/proactive/list.html", ctx)
+    return _render_matches_tab(request, user, db)
 
 
 @router.post("/v2/proactive/prepare/{site_id}", response_class=HTMLResponse)
@@ -161,11 +172,12 @@ async def proactive_prepare_page(
 
         return RedirectResponse("/v2/proactive", status_code=303)
 
-    matches = (
-        db.query(ProactiveMatch)
-        .filter(ProactiveMatch.id.in_(match_ids), ProactiveMatch.salesperson_id == user.id)
-        .all()
-    )
+    from ...dependencies import is_manager_or_admin
+
+    match_query = db.query(ProactiveMatch).filter(ProactiveMatch.id.in_(match_ids))
+    if not is_manager_or_admin(user):
+        match_query = match_query.filter(ProactiveMatch.salesperson_id == user.id)
+    matches = match_query.all()
     if not matches:
         from starlette.responses import RedirectResponse
 
@@ -280,15 +292,12 @@ async def proactive_add_contact(
     if site is None:
         raise HTTPException(404, "Site not found")
 
-    owns_match = (
-        db.query(ProactiveMatch.id)
-        .filter(
-            ProactiveMatch.customer_site_id == site_id,
-            ProactiveMatch.salesperson_id == user.id,
-        )
-        .first()
-    )
-    if not owns_match:
+    from ...dependencies import is_manager_or_admin
+
+    owns_query = db.query(ProactiveMatch.id).filter(ProactiveMatch.customer_site_id == site_id)
+    if not is_manager_or_admin(user):
+        owns_query = owns_query.filter(ProactiveMatch.salesperson_id == user.id)
+    if not owns_query.first():
         raise HTTPException(403, "Not authorized to add a contact for this site")
 
     full_name = full_name.strip()
@@ -353,11 +362,12 @@ async def proactive_draft_for_prepare(
     if not match_ids:
         return HTMLResponse('<div class="text-sm text-rose-600">No matches selected.</div>')
 
-    matches = (
-        db.query(ProactiveMatch)
-        .filter(ProactiveMatch.id.in_(match_ids), ProactiveMatch.salesperson_id == user.id)
-        .all()
-    )
+    from ...dependencies import is_manager_or_admin
+
+    draft_query = db.query(ProactiveMatch).filter(ProactiveMatch.id.in_(match_ids))
+    if not is_manager_or_admin(user):
+        draft_query = draft_query.filter(ProactiveMatch.salesperson_id == user.id)
+    matches = draft_query.all()
     if not matches:
         return HTMLResponse('<div class="text-sm text-rose-600">No valid matches found.</div>')
 
@@ -501,6 +511,8 @@ async def proactive_send_offer(
             body_html = html_mod.escape(body).replace("\n", "<br>")
             email_html = f'<div style="font-family:Arial,sans-serif;max-width:700px"><p>{body_html}</p></div>'
 
+        from ...dependencies import is_manager_or_admin
+
         result = await send_proactive_offer(
             db=db,
             user=user,
@@ -510,24 +522,15 @@ async def proactive_send_offer(
             sell_prices=sell_prices,
             subject=subject or None,
             email_html=email_html,
+            allow_all=is_manager_or_admin(user),
         )
 
         # Success — reload matches list with success banner
-        from ...services.proactive_service import get_matches_for_user
-
-        match_result = get_matches_for_user(db, user.id, status=ProactiveMatchStatus.NEW)
-        groups = match_result.get("groups", []) if isinstance(match_result, dict) else match_result
-        match_count = match_result.get("stats", {}).get("total", 0) if isinstance(match_result, dict) else 0
         parts_count = len(result.get("line_items", []))
         contacts_count = len(result.get("recipient_emails", []))
-
-        ctx = _base_ctx(request, user, "proactive")
-        ctx["matches"] = groups
-        ctx["sent"] = []
-        ctx["tab"] = "matches"
-        ctx["match_count"] = match_count
-        ctx["success_msg"] = f"Offer sent to {contacts_count} contact(s) ({parts_count} parts)."
-        return template_response("htmx/partials/proactive/list.html", ctx)
+        return _render_matches_tab(
+            request, user, db, success_msg=f"Offer sent to {contacts_count} contact(s) ({parts_count} parts)."
+        )
 
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
@@ -823,3 +826,83 @@ async def proactive_line_tracking(
         "can_edit": can_manage or line.salesperson_id == user.id,
     }
     return template_response("htmx/partials/proactive/_outreach_line_cells.html", ctx)
+
+
+# ── Process flow: check send/ignore → stage per-customer drafts → review → send ──
+
+
+@router.post("/v2/partials/proactive/process", response_class=HTMLResponse)
+async def proactive_process(
+    request: Request,
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
+    db: Session = Depends(get_db),
+):
+    """Process the checked matches: dismiss the ignores, stage one draft offer
+    per customer for review. Nothing is emailed here."""
+    from ...dependencies import is_manager_or_admin
+    from ...services.proactive_service import process_matches
+
+    form = await request.form()
+    send_ids = [int(x) for x in form.getlist("send_ids") if str(x).isdigit()]
+    ignore_ids = [int(x) for x in form.getlist("ignore_ids") if str(x).isdigit()]
+    if not send_ids and not ignore_ids:
+        return _render_matches_tab(request, user, db, scope=form.get("scope", "mine"))
+
+    stats = process_matches(db, user, send_ids=send_ids, ignore_ids=ignore_ids, allow_all=is_manager_or_admin(user))
+    db.commit()
+
+    parts = []
+    if stats.get("drafts_created"):
+        parts.append(f"{stats['drafts_created']} offer(s) prepared for review")
+    if stats.get("ignored"):
+        parts.append(f"{stats['ignored']} ignored")
+    if stats.get("needs_contact"):
+        parts.append(f"{stats['needs_contact']} need a contact")
+    if stats.get("skipped_backorder"):
+        parts.append(f"{stats['skipped_backorder']} back-order line(s) skipped (no customer account)")
+    if stats.get("skipped_already_queued"):
+        parts.append(f"{stats['skipped_already_queued']} already staged")
+    logger.info("Proactive process by {}: {}", user.email, stats)
+    return _render_matches_tab(request, user, db, scope=form.get("scope", "mine"), success_msg="; ".join(parts) + ".")
+
+
+@router.post("/v2/partials/proactive/prepared/{po_id}/send", response_class=HTMLResponse)
+async def proactive_prepared_send(
+    request: Request,
+    po_id: int,
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
+    db: Session = Depends(get_db),
+):
+    """Send one staged per-customer draft from the review strip."""
+    from ...dependencies import is_manager_or_admin
+    from ...scheduler import get_valid_token
+    from ...services.proactive_service import send_draft_offer
+
+    token = await get_valid_token(user, db)
+    if not token:
+        raise HTTPException(400, "No valid Microsoft token — sign in again to send")
+    try:
+        result = await send_draft_offer(db, user, token, po_id, allow_all=is_manager_or_admin(user))
+    except ValueError as e:
+        raise HTTPException(403 if "Not your" in str(e) else 400, str(e)) from e
+    recipients = ", ".join(result.get("recipient_emails", []))
+    return _render_matches_tab(request, user, db, success_msg=f"Offer sent to {recipients}.")
+
+
+@router.post("/v2/partials/proactive/prepared/{po_id}/discard", response_class=HTMLResponse)
+async def proactive_prepared_discard(
+    request: Request,
+    po_id: int,
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
+    db: Session = Depends(get_db),
+):
+    """Discard a staged draft; its matches stay in the list (nothing was sent)."""
+    from ...dependencies import is_manager_or_admin
+    from ...services.proactive_service import discard_draft_offer
+
+    try:
+        discard_draft_offer(db, user, po_id, allow_all=is_manager_or_admin(user))
+    except ValueError as e:
+        raise HTTPException(403 if "Not your" in str(e) else 400, str(e)) from e
+    db.commit()
+    return _render_matches_tab(request, user, db, success_msg="Draft discarded — matches back in the list.")

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 
 from loguru import logger
-from sqlalchemy import case, func
+from sqlalchemy import case, func, select, update
 from sqlalchemy.orm import Session, joinedload
 
 from ..constants import (
@@ -103,6 +103,13 @@ def get_matches_for_user(
 
     rollups = compute_offer_rollups(db, parts={(m.mpn or "").strip().upper() for m in matches if m.mpn})
 
+    # Rep attribution for the manager's See-All view.
+    rep_names: dict[int, str] = {}
+    if admin_all:
+        rep_ids = {m.salesperson_id for m in matches if m.salesperson_id}
+        if rep_ids:
+            rep_names = dict(db.execute(select(User.id, User.name).where(User.id.in_(rep_ids))).all())
+
     for m in matches:
         # Skip matches suppressed by do-not-offer
         site = m.customer_site
@@ -122,6 +129,7 @@ def get_matches_for_user(
                 "company_id": company_id,
                 "company_name": company_name,
                 "site_name": site.site_name if site else "",
+                "salesperson_name": rep_names.get(m.salesperson_id, "") if admin_all else "",
                 "matches": [],
             }
         offer = m.offer
@@ -234,8 +242,6 @@ def get_top_picks(db: Session, user_id: int, *, limit: int = 10) -> list[dict]:
     cost spread, recent wins, and ask age (2026-08-06 rework). The cache is busted by
     the scan/rematch paths via PICKS_CACHE_PREFIX.
     """
-    from sqlalchemy import select
-
     from ..cache.intel_cache import get_cached, set_cached
     from .proactive_matching import compute_offer_rollups
 
@@ -285,6 +291,91 @@ def get_top_picks(db: Session, user_id: int, *, limit: int = 10) -> list[dict]:
 # ── Send Proactive Offer ──────────────────────────────────────────────────
 
 
+def _build_line_items(matches: list, sell_prices: dict) -> tuple[list, Decimal, Decimal]:
+    """Line items + totals for a customer offer email.
+
+    Shared by the prepare-page send and the Process draft builder. Missing sell prices
+    default to cost x 1.3.
+    """
+    line_items = []
+    total_sell = Decimal("0")
+    total_cost = Decimal("0")
+    for m in matches:
+        offer = m.offer
+        if not offer:
+            continue
+        cost = float(offer.unit_price) if offer.unit_price else 0
+        sell = sell_prices.get(str(m.id), cost * 1.3)
+        target = m.requirement.target_qty if m.requirement else 0
+        avail = offer.qty_available or 0
+        qty = min(avail, target) if target > 0 else avail
+        total_sell += Decimal(str(sell)) * qty
+        total_cost += Decimal(str(cost)) * qty
+        line_items.append(
+            {
+                "match_id": m.id,
+                "offer_id": offer.id,
+                "mpn": m.mpn,
+                "vendor_name": offer.vendor_name,
+                "manufacturer": offer.manufacturer,
+                "qty": qty,
+                "unit_price": cost,
+                "sell_price": float(sell),
+                "condition": offer.condition,
+                "lead_time": offer.lead_time,
+            }
+        )
+    return line_items, total_sell, total_cost
+
+
+def _template_email_html(salesperson_name: str, contacts: list, line_items: list, notes: str | None) -> str:
+    """Deterministic customer-offer email body (no AI).
+
+    Shared template fallback.
+    """
+    rows_html = ""
+    for item in line_items:
+        rows_html += f"""<tr>
+            <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item["mpn"]))}</td>
+            <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item.get("manufacturer", "")))}</td>
+            <td style="padding:6px 10px;border:1px solid #e5e7eb;text-align:right">{item["qty"]:,}</td>
+            <td style="padding:6px 10px;border:1px solid #e5e7eb;text-align:right">${item["sell_price"]:.4f}</td>
+            <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item.get("condition", "")))}</td>
+            <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item.get("lead_time", "")))}</td>
+        </tr>"""
+
+    contact_names = ", ".join(c.full_name for c in contacts if c.full_name)
+    if len(contacts) == 1 and contacts[0].full_name:
+        greeting = f"Hi {html.escape(str(contacts[0].full_name))},"
+    elif contact_names:
+        greeting = f"Hi {html.escape(str(contact_names))},"
+    else:
+        greeting = "Hello,"
+
+    notes_html = f'<p style="margin-top:12px">{html.escape(str(notes))}</p>' if notes else ""
+
+    return f"""
+    <div style="font-family:Arial,sans-serif;max-width:700px">
+        <p>{greeting}</p>
+        <p>We have the following parts available that may be of interest based on your previous requirements:</p>
+        <table style="border-collapse:collapse;width:100%;margin:16px 0">
+            <thead><tr style="background:#f3f4f6">
+                <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Part Number</th>
+                <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Manufacturer</th>
+                <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Qty Available</th>
+                <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Unit Price</th>
+                <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Condition</th>
+                <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Lead Time</th>
+            </tr></thead>
+            <tbody>{rows_html}</tbody>
+        </table>
+        {notes_html}
+        <p>Please reply to this email if you'd like to place an order or need more details on any of these items.</p>
+        <p>Best regards,<br>{html.escape(str(salesperson_name))}<br>Trio Supply Chain Solutions</p>
+    </div>
+    """
+
+
 async def send_proactive_offer(
     db: Session,
     user: User,
@@ -295,20 +386,19 @@ async def send_proactive_offer(
     subject: str | None = None,
     notes: str | None = None,
     email_html: str | None = None,
+    allow_all: bool = False,
 ) -> dict:
     """Send a proactive offer email to a customer.
 
-    Returns the created ProactiveOffer dict.
+    ``allow_all`` lets a manager/admin send on a rep's matches; the offer is
+    always attributed to the matches' salesperson, the mail goes out from the
+    ACTOR's mailbox. Returns the created ProactiveOffer dict.
     """
     # Load and validate matches
-    matches = (
-        db.query(ProactiveMatch)
-        .filter(
-            ProactiveMatch.id.in_(match_ids),
-            ProactiveMatch.salesperson_id == user.id,
-        )
-        .all()
-    )
+    query = db.query(ProactiveMatch).filter(ProactiveMatch.id.in_(match_ids))
+    if not allow_all:
+        query = query.filter(ProactiveMatch.salesperson_id == user.id)
+    matches = query.all()
     if not matches:
         raise ValueError("No valid matches found")
 
@@ -334,38 +424,12 @@ async def send_proactive_offer(
         raise ValueError("Selected contacts have no email addresses")
 
     # Build line items
-    line_items = []
-    total_sell = Decimal("0")
-    total_cost = Decimal("0")
-    for m in matches:
-        offer = m.offer
-        if not offer:
-            continue
-        cost = float(offer.unit_price) if offer.unit_price else 0
-        sell = sell_prices.get(str(m.id), cost * 1.3)
-        target = m.requirement.target_qty if m.requirement else 0
-        avail = offer.qty_available or 0
-        qty = min(avail, target) if target > 0 else avail
-        line_total_sell = Decimal(str(sell)) * qty
-        line_total_cost = Decimal(str(cost)) * qty
-        total_sell += line_total_sell
-        total_cost += line_total_cost
-        line_items.append(
-            {
-                "match_id": m.id,
-                "offer_id": offer.id,
-                "mpn": m.mpn,
-                "vendor_name": offer.vendor_name,
-                "manufacturer": offer.manufacturer,
-                "qty": qty,
-                "unit_price": cost,
-                "sell_price": float(sell),
-                "condition": offer.condition,
-                "lead_time": offer.lead_time,
-            }
-        )
+    line_items, total_sell, total_cost = _build_line_items(matches, sell_prices)
 
-    # Build email HTML
+    # Build email HTML — signed by the relationship owner (the matches' rep),
+    # even when a manager is the one clicking send.
+    owner_id = matches[0].salesperson_id or user.id
+    owner = user if owner_id == user.id else (db.get(User, owner_id) or user)
     if not subject:
         subject = f"Parts Available — {company_name}"
 
@@ -373,54 +437,13 @@ async def send_proactive_offer(
         # Use AI-drafted or user-edited HTML
         html_body = email_html
     else:
-        # Fallback: build template HTML
-        rows_html = ""
-        for item in line_items:
-            rows_html += f"""<tr>
-                <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item["mpn"]))}</td>
-                <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item.get("manufacturer", "")))}</td>
-                <td style="padding:6px 10px;border:1px solid #e5e7eb;text-align:right">{item["qty"]:,}</td>
-                <td style="padding:6px 10px;border:1px solid #e5e7eb;text-align:right">${item["sell_price"]:.4f}</td>
-                <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item.get("condition", "")))}</td>
-                <td style="padding:6px 10px;border:1px solid #e5e7eb">{html.escape(str(item.get("lead_time", "")))}</td>
-            </tr>"""
-
-        contact_names = ", ".join(c.full_name for c in contacts if c.full_name)
-        if len(contacts) == 1 and contacts[0].full_name:
-            greeting = f"Hi {html.escape(str(contacts[0].full_name))},"
-        elif contact_names:
-            greeting = f"Hi {html.escape(str(contact_names))},"
-        else:
-            greeting = "Hello,"
-
-        notes_html = f'<p style="margin-top:12px">{html.escape(str(notes))}</p>' if notes else ""
-        salesperson_name = user.name or user.email.split("@")[0]
-
-        html_body = f"""
-        <div style="font-family:Arial,sans-serif;max-width:700px">
-            <p>{greeting}</p>
-            <p>We have the following parts available that may be of interest based on your previous requirements:</p>
-            <table style="border-collapse:collapse;width:100%;margin:16px 0">
-                <thead><tr style="background:#f3f4f6">
-                    <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Part Number</th>
-                    <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Manufacturer</th>
-                    <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Qty Available</th>
-                    <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Unit Price</th>
-                    <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Condition</th>
-                    <th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Lead Time</th>
-                </tr></thead>
-                <tbody>{rows_html}</tbody>
-            </table>
-            {notes_html}
-            <p>Please reply to this email if you'd like to place an order or need more details on any of these items.</p>
-            <p>Best regards,<br>{html.escape(str(salesperson_name))}<br>Trio Supply Chain Solutions</p>
-        </div>
-        """
+        salesperson_name = owner.name or owner.email.split("@")[0]
+        html_body = _template_email_html(salesperson_name, contacts, line_items, notes)
 
     # Create ProactiveOffer record first to get ID for subject tag
     po = ProactiveOffer(
         customer_site_id=site_id,
-        salesperson_id=user.id,
+        salesperson_id=owner_id,
         line_items=line_items,
         recipient_contact_ids=[c.id for c in contacts],
         recipient_emails=recipient_emails,
@@ -490,8 +513,264 @@ async def send_proactive_offer(
                 # Mirror autoflush: a later match with the same MPN updates this row.
                 throttle_by_mpn[m.mpn] = new_throttle
 
+        # A full prepare-page send supersedes any staged Process draft that
+        # references the same matches — drop it so nothing double-sends.
+        sent_match_ids = {m.id for m in matches}
+        for draft in db.scalars(
+            select(ProactiveOffer).where(
+                ProactiveOffer.customer_site_id == site_id,
+                ProactiveOffer.status == ProactiveOfferStatus.DRAFT,
+            )
+        ).all():
+            draft_match_ids = {li.get("match_id") for li in (draft.line_items or [])}
+            if draft_match_ids & sent_match_ids:
+                db.delete(draft)
+
     db.commit()
     return _proactive_offer_to_dict(po)
+
+
+# ── Process flow: per-customer draft offers (check → Process → review → send) ──
+
+
+def _draft_queued_match_ids(db: Session) -> set[int]:
+    """Match ids already referenced by a staged DRAFT offer (double-queue guard)."""
+    queued: set[int] = set()
+    for draft in db.scalars(select(ProactiveOffer).where(ProactiveOffer.status == ProactiveOfferStatus.DRAFT)).all():
+        queued |= {li.get("match_id") for li in (draft.line_items or []) if li.get("match_id")}
+    return queued
+
+
+def process_matches(
+    db: Session,
+    user: User,
+    *,
+    send_ids: list[int],
+    ignore_ids: list[int],
+    allow_all: bool = False,
+) -> dict:
+    """The Matches tab's Process action: dismiss the ignores, stage the sends.
+
+    Ignored matches are dismissed immediately (a future rematch can resurface the part).
+    Send-marked matches become ONE DRAFT ProactiveOffer per customer — default contact,
+    sell prices seeded from the last quote on the part (else cost x 1.3), template email
+    body — staged for review. Nothing is emailed here. Caller commits.
+    """
+    ignored = 0
+    if ignore_ids:
+        conditions = [
+            ProactiveMatch.id.in_(ignore_ids),
+            ProactiveMatch.status == ProactiveMatchStatus.NEW,
+        ]
+        if not allow_all:
+            conditions.append(ProactiveMatch.salesperson_id == user.id)
+        ignored = db.execute(
+            update(ProactiveMatch)
+            .where(*conditions)
+            .values(status=ProactiveMatchStatus.DISMISSED, dismiss_reason="processed_ignore")
+            .execution_options(synchronize_session=False)
+        ).rowcount
+    staged = build_draft_offers(db, user, send_ids, allow_all=allow_all) if send_ids else {}
+    return {"ignored": ignored, **staged}
+
+
+def build_draft_offers(db: Session, user: User, match_ids: list[int], *, allow_all: bool = False) -> dict:
+    """Stage one DRAFT ProactiveOffer per customer from the given matches."""
+    from .pricing_history import last_quote_for_part
+
+    stmt = select(ProactiveMatch).where(
+        ProactiveMatch.id.in_(match_ids),
+        ProactiveMatch.status == ProactiveMatchStatus.NEW,
+    )
+    if not allow_all:
+        stmt = stmt.where(ProactiveMatch.salesperson_id == user.id)
+    matches = list(
+        db.scalars(stmt.options(joinedload(ProactiveMatch.offer), joinedload(ProactiveMatch.requirement))).unique()
+    )
+
+    queued = _draft_queued_match_ids(db)
+    skipped_queued = len([m for m in matches if m.id in queued])
+    matches = [m for m in matches if m.id not in queued]
+
+    by_site: dict[int, list] = {}
+    skipped_backorder = 0
+    for m in matches:
+        if m.customer_site_id:
+            by_site.setdefault(m.customer_site_id, []).append(m)
+        else:
+            skipped_backorder += 1  # no customer account — nowhere to email
+
+    drafts_created = 0
+    needs_contact = 0
+    for site_id, site_matches in by_site.items():
+        site = db.get(CustomerSite, site_id)
+        company_name = site.company.name if site and site.company else "Customer"
+        contact = db.scalars(
+            select(SiteContact)
+            .where(
+                SiteContact.customer_site_id == site_id,
+                SiteContact.email.isnot(None),
+                SiteContact.email != "",
+            )
+            .order_by(SiteContact.id)
+        ).first()
+        if not contact:
+            needs_contact += 1
+
+        sell_prices: dict[str, float] = {}
+        for m in site_matches:
+            anchor = last_quote_for_part(db, part=(m.mpn or "").strip().upper())
+            if anchor and anchor["price"]:
+                sell_prices[str(m.id)] = float(anchor["price"])
+
+        line_items, total_sell, total_cost = _build_line_items(site_matches, sell_prices)
+        if not line_items:
+            continue
+
+        owner_id = site_matches[0].salesperson_id or user.id
+        owner = user if owner_id == user.id else (db.get(User, owner_id) or user)
+        owner_name = owner.name or owner.email.split("@")[0]
+        contacts = [contact] if contact else []
+
+        db.add(
+            ProactiveOffer(
+                customer_site_id=site_id,
+                salesperson_id=owner_id,
+                status=ProactiveOfferStatus.DRAFT,
+                sent_at=None,
+                line_items=line_items,
+                recipient_contact_ids=[c.id for c in contacts],
+                recipient_emails=[c.email for c in contacts],
+                subject=f"Parts Available — {company_name}",
+                email_body_html=_template_email_html(owner_name, contacts, line_items, None),
+                total_sell=total_sell,
+                total_cost=total_cost,
+            )
+        )
+        drafts_created += 1
+
+    return {
+        "drafts_created": drafts_created,
+        "needs_contact": needs_contact,
+        "skipped_backorder": skipped_backorder,
+        "skipped_already_queued": skipped_queued,
+    }
+
+
+def list_draft_offers(db: Session, user: User, *, allow_all: bool = False) -> list[dict]:
+    """Staged per-customer drafts for the review strip, newest first."""
+    stmt = select(ProactiveOffer).where(ProactiveOffer.status == ProactiveOfferStatus.DRAFT)
+    if not allow_all:
+        stmt = stmt.where(ProactiveOffer.salesperson_id == user.id)
+    drafts = (
+        db.scalars(
+            stmt.options(joinedload(ProactiveOffer.customer_site).joinedload(CustomerSite.company)).order_by(
+                ProactiveOffer.id.desc()
+            )
+        )
+        .unique()
+        .all()
+    )
+    rep_names = dict(db.execute(select(User.id, User.name)).all())
+    out = []
+    for po in drafts:
+        site = po.customer_site
+        out.append(
+            {
+                "id": po.id,
+                "customer_site_id": po.customer_site_id,
+                "company_name": site.company.name if site and site.company else "Customer",
+                "salesperson_name": rep_names.get(po.salesperson_id) or "—",
+                "salesperson_id": po.salesperson_id,
+                "recipient_emails": po.recipient_emails or [],
+                "subject": po.subject,
+                "body_html": po.email_body_html,
+                "line_count": len(po.line_items or []),
+                "match_ids": [li.get("match_id") for li in (po.line_items or []) if li.get("match_id")],
+                "total_sell": float(po.total_sell) if po.total_sell else 0.0,
+            }
+        )
+    return out
+
+
+async def send_draft_offer(db: Session, user: User, token: str, po_id: int, *, allow_all: bool = False) -> dict:
+    """Send one staged draft to its customer with the ACTOR's mailbox.
+
+    Marks the offer SENT, flips its matches to SENT, and writes the same throttle
+    entries as the prepare-page send. Raises ValueError on wrong status / no recipients
+    / no permission.
+    """
+    from ..utils.graph_client import GraphClient
+
+    po = db.get(ProactiveOffer, po_id)
+    if not po or po.status != ProactiveOfferStatus.DRAFT:
+        raise ValueError("Draft offer not found")
+    if not allow_all and po.salesperson_id != user.id:
+        raise ValueError("Not your draft")
+    recipient_emails = po.recipient_emails or []
+    if not recipient_emails:
+        raise ValueError("No contact on file — open Prepare to pick or add one")
+
+    tagged_subject = f"[AVAIL-PROACTIVE-{po.id}] {po.subject}"
+    gc = GraphClient(token)
+    await gc.post_json(
+        "/me/sendMail",
+        {
+            "message": {
+                "subject": tagged_subject,
+                "body": {"contentType": "HTML", "content": po.email_body_html},
+                "toRecipients": [{"emailAddress": {"address": e}} for e in recipient_emails],
+            },
+            "saveToSentItems": "true",
+        },
+    )
+    now = datetime.now(UTC)
+    po.status = ProactiveOfferStatus.SENT
+    po.sent_at = now
+
+    match_ids = [li.get("match_id") for li in (po.line_items or []) if li.get("match_id")]
+    matches = list(db.scalars(select(ProactiveMatch).where(ProactiveMatch.id.in_(match_ids)))) if match_ids else []
+    throttle_by_mpn = {
+        t.mpn: t
+        for t in db.scalars(
+            select(ProactiveThrottle).where(
+                ProactiveThrottle.mpn.in_({m.mpn for m in matches} or {""}),
+                ProactiveThrottle.customer_site_id == po.customer_site_id,
+            )
+        )
+    }
+    for m in matches:
+        m.status = ProactiveMatchStatus.SENT
+        existing_throttle = throttle_by_mpn.get(m.mpn)
+        if existing_throttle:
+            existing_throttle.last_offered_at = now
+            existing_throttle.proactive_offer_id = po.id
+        else:
+            new_throttle = ProactiveThrottle(
+                mpn=m.mpn,
+                customer_site_id=po.customer_site_id,
+                last_offered_at=now,
+                proactive_offer_id=po.id,
+            )
+            db.add(new_throttle)
+            throttle_by_mpn[m.mpn] = new_throttle
+
+    logger.info("Proactive draft #{} sent to {} by {}", po.id, ", ".join(recipient_emails), user.email)
+    db.commit()
+    return _proactive_offer_to_dict(po)
+
+
+def discard_draft_offer(db: Session, user: User, po_id: int, *, allow_all: bool = False) -> None:
+    """Delete a staged draft; its matches stay NEW (nothing was sent).
+
+    Caller commits.
+    """
+    po = db.get(ProactiveOffer, po_id)
+    if not po or po.status != ProactiveOfferStatus.DRAFT:
+        raise ValueError("Draft offer not found")
+    if not allow_all and po.salesperson_id != user.id:
+        raise ValueError("Not your draft")
+    db.delete(po)
 
 
 # ── Conversion to Win ──────────────────────────────────────────────────────
@@ -682,8 +961,8 @@ def get_scorecard(db: Session, salesperson_id: int | None = None) -> dict:
             0,
         )
 
-    # Base filter
-    base_filter = []
+    # Base filter — staged Process drafts are not outreach yet, never counted.
+    base_filter = [ProactiveOffer.status != ProactiveOfferStatus.DRAFT]
     if salesperson_id:
         base_filter.append(ProactiveOffer.salesperson_id == salesperson_id)
 
@@ -813,6 +1092,7 @@ def get_sent_offers(db: Session, user_id: int) -> list[dict]:
         db.query(ProactiveOffer)
         .filter(
             ProactiveOffer.salesperson_id == user_id,
+            ProactiveOffer.status != ProactiveOfferStatus.DRAFT,  # staged, not sent
         )
         .options(joinedload(ProactiveOffer.customer_site).joinedload(CustomerSite.company))
         .order_by(ProactiveOffer.sent_at.desc())

--- a/app/templates/htmx/partials/proactive/_match_row.html
+++ b/app/templates/htmx/partials/proactive/_match_row.html
@@ -7,14 +7,27 @@
 {%- from "htmx/partials/proactive/_macros.html" import margin_badge %}
 <tr id="match-row-{{ match.id }}"
     class="hover:bg-gray-50 transition-colors"
-    :class="selected[{{ match.id }}] && 'bg-blue-50'">
-  {# Checkbox — accent via accent-color + input-focus ring (not brand-500) #}
-  <td class="w-10">
-    <input aria-label="Select match {{ match.mpn | default('') }}" type="checkbox"
-           :checked="selected[{{ match.id }}]"
-           @change="toggle({{ match.id }})"
-           class="rounded border-gray-300 input-focus"
-           style="accent-color:var(--accent)">
+    :class="sel[{{ match.id }}] === 'send' ? 'bg-emerald-50' : sel[{{ match.id }}] === 'ignore' ? 'bg-gray-100 opacity-60' : ''">
+  {# Send / Ignore — mutually exclusive marks feeding the global Process bar #}
+  <td class="w-[110px]">
+    <div class="flex items-center gap-2">
+      <label class="flex items-center gap-1 text-xs text-emerald-700 cursor-pointer" title="Offer this to the customer">
+        <input aria-label="Send {{ match.mpn | default('') }}" type="checkbox"
+               :checked="sel[{{ match.id }}] === 'send'"
+               @change="mark({{ match.id }}, 'send')"
+               class="rounded border-gray-300 input-focus"
+               style="accent-color:#059669">
+        Send
+      </label>
+      <label class="flex items-center gap-1 text-xs text-gray-500 cursor-pointer" title="Dismiss this match">
+        <input aria-label="Ignore {{ match.mpn | default('') }}" type="checkbox"
+               :checked="sel[{{ match.id }}] === 'ignore'"
+               @change="mark({{ match.id }}, 'ignore')"
+               class="rounded border-gray-300 input-focus"
+               style="accent-color:#6b7280">
+        Ignore
+      </label>
+    </div>
   </td>
   {# MPN + ask context #}
   <td>

--- a/app/templates/htmx/partials/proactive/_prepared_offers.html
+++ b/app/templates/htmx/partials/proactive/_prepared_offers.html
@@ -1,0 +1,61 @@
+{#
+  proactive/_prepared_offers.html — Review strip: staged per-customer draft offers.
+  One card per customer produced by Process; the rep reviews and fires each with
+  one click (or opens the full Prepare page to tweak contacts/prices/body).
+  Receives: prepared (list of dicts from list_draft_offers), scope.
+  Called by: proactive/list.html (Matches tab, above the groups).
+  Depends on: Alpine.js, Tailwind CSS, HTMX.
+#}
+{% if prepared %}
+<div class="mb-4">
+  <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+    Prepared offers — review and send ({{ prepared|length }})
+  </p>
+  {% for p in prepared %}
+  <div class="mb-2 bg-white rounded-lg border border-line-base overflow-hidden" x-data="{ open: false }">
+    <div class="flex items-center gap-3 px-4 py-2.5">
+      <button @click="open = !open" class="text-gray-400 hover:text-gray-600 transition-colors focus:outline-none focus:ring-2 rounded" style="--tw-ring-color:var(--accent-ring)" aria-label="Preview offer email">
+        <svg class="h-4 w-4 transition-transform" :class="open ? 'rotate-0' : '-rotate-90'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </button>
+      <div class="flex-1 min-w-0">
+        <p class="text-sm font-medium text-gray-900 truncate">{{ p.company_name }}</p>
+        <p class="text-xs text-gray-500 truncate">
+          {{ p.line_count }} part{{ 's' if p.line_count != 1 }} · ${{ "{:,.2f}".format(p.total_sell) }}
+          {% if scope == 'all' %} · {{ p.salesperson_name }}{% endif %}
+          ·
+          {% if p.recipient_emails %}to {{ p.recipient_emails | join(', ') }}{% else %}<span class="text-rose-600 font-medium">no contact on file</span>{% endif %}
+        </p>
+      </div>
+      {# Open in Prepare — full editor for contacts / prices / body #}
+      <form method="POST" action="/v2/proactive/prepare/{{ p.customer_site_id }}"
+            hx-post="/v2/proactive/prepare/{{ p.customer_site_id }}"
+            hx-target="#main-content" class="inline">
+        {% for mid in p.match_ids %}<input type="hidden" name="match_ids" value="{{ mid }}">{% endfor %}
+        <button type="submit" class="btn-secondary btn-sm">Prepare</button>
+      </form>
+      <button hx-post="/v2/partials/proactive/prepared/{{ p.id }}/discard"
+              hx-target="#main-content"
+              hx-confirm="Discard this prepared offer? Its matches go back in the list."
+              data-loading-disable
+              class="btn-secondary btn-sm">
+        Discard
+      </button>
+      <button hx-post="/v2/partials/proactive/prepared/{{ p.id }}/send"
+              hx-target="#main-content"
+              hx-confirm="Email this offer to {{ p.company_name | e }} ({{ p.recipient_emails | join(', ') | e }})?"
+              data-loading-disable
+              {% if not p.recipient_emails %}disabled title="No contact on file — open Prepare to pick or add one"{% endif %}
+              class="btn-primary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
+        Send
+      </button>
+    </div>
+    <div x-show="open" x-cloak class="border-t border-line-base px-4 py-3 text-sm bg-gray-50">
+      <p class="text-xs text-gray-500 mb-2">Subject: {{ p.subject }}</p>
+      <div class="bg-white rounded border border-line-base p-3 overflow-x-auto">{{ p.body_html | safe }}</div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}

--- a/app/templates/htmx/partials/proactive/list.html
+++ b/app/templates/htmx/partials/proactive/list.html
@@ -7,20 +7,44 @@
 #}
 {%- from "htmx/partials/proactive/_macros.html" import company_header, empty_state, margin_badge %}
 
-<div class="page-fluid" x-data="{ showScorecard: false }">
-  {# Header — page title + scorecard toggle #}
+<div class="page-fluid"
+     x-data="{
+       showScorecard: false,
+       sel: {},
+       mark(id, kind) {
+         this.sel[id] = this.sel[id] === kind ? undefined : kind;
+         this.sel = {...this.sel};
+       },
+       ids(kind) { return Object.keys(this.sel).filter(k => this.sel[k] === kind); },
+       get sendCount() { return this.ids('send').length },
+       get ignoreCount() { return this.ids('ignore').length },
+     }">
+  {# Header — page title + check-for-matches + scorecard toggle #}
   <div class="flex items-center justify-between mb-4">
     <div>
       <h1 class="h2">Proactive</h1>
       <p class="text-sm text-gray-600 mt-0.5">Live vendor stock matched to what customers asked for</p>
     </div>
-    <button @click="showScorecard = !showScorecard"
-            class="btn-secondary btn-sm inline-flex items-center gap-1.5">
-      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
-      </svg>
-      Scorecard
-    </button>
+    <div class="flex items-center gap-2">
+      <button hx-post="/v2/partials/proactive/refresh"
+              hx-target="#main-content"
+              hx-swap="innerHTML"
+              data-loading-disable
+              class="btn-secondary btn-sm inline-flex items-center gap-1.5"
+              title="Scan the latest offers for new matches">
+        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+        </svg>
+        Check for matches
+      </button>
+      <button @click="showScorecard = !showScorecard"
+              class="btn-secondary btn-sm inline-flex items-center gap-1.5">
+        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+        </svg>
+        Scorecard
+      </button>
+    </div>
   </div>
 
   {# Scorecard panel — lazy-loaded, explicit hx-target to prevent main-content takeover #}
@@ -95,28 +119,44 @@
        hx-target="this"
        hx-swap="innerHTML"
        hx-push-url="false"></div>
+
+  {# Scope toggle — managers/admins can work every rep's matches #}
+  {% if can_see_all %}
+  <div class="flex gap-2 mb-3">
+    <a hx-get="/v2/partials/proactive?tab=matches&scope=mine" hx-target="#main-content"
+       class="chip cursor-pointer {{ 'bg-gray-800 text-white border-gray-800' if scope == 'mine' else 'bg-gray-100 text-gray-600 border-gray-200' }}">My matches</a>
+    <a hx-get="/v2/partials/proactive?tab=matches&scope=all" hx-target="#main-content"
+       class="chip cursor-pointer {{ 'bg-gray-800 text-white border-gray-800' if scope == 'all' else 'bg-gray-100 text-gray-600 border-gray-200' }}">All salespeople</a>
+  </div>
+  {% endif %}
+
+  {# Prepared offers — staged per-customer drafts awaiting review/send #}
+  {% include "htmx/partials/proactive/_prepared_offers.html" %}
+
   {% if matches %}
+    {# Process bar — one action for everything checked across every customer #}
+    <form method="POST" action="/v2/partials/proactive/process"
+          hx-post="/v2/partials/proactive/process"
+          hx-target="#main-content"
+          data-loading-disable
+          class="sticky top-0 z-10 mb-3 bg-white rounded-lg border border-line-base px-4 py-2.5 flex items-center gap-3">
+      <p class="text-sm text-gray-600 flex-1">
+        Check <span class="font-medium text-emerald-700">Send</span> or
+        <span class="font-medium text-gray-500">Ignore</span> on each line, then process.
+      </p>
+      <input type="hidden" name="scope" value="{{ scope | default('mine') }}">
+      <template x-for="id in ids('send')" :key="'s'+id"><input type="hidden" name="send_ids" :value="id"></template>
+      <template x-for="id in ids('ignore')" :key="'i'+id"><input type="hidden" name="ignore_ids" :value="id"></template>
+      <button type="submit"
+              :disabled="sendCount === 0 && ignoreCount === 0"
+              class="btn-primary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
+        Process (<span x-text="sendCount">0</span> send / <span x-text="ignoreCount">0</span> ignore)
+      </button>
+    </form>
+
     {% for group in matches %}
     <div class="mb-4 bg-white rounded-lg overflow-hidden border border-line-base"
-         x-data="{
-           selected: {},
-           expanded: true,
-           offersOpen: {},
-           get selectedCount() { return Object.keys(this.selected).length },
-           get selectedIds() { return Object.keys(this.selected).map(Number) },
-           toggle(id) {
-             if (this.selected[id]) { delete this.selected[id]; this.selected = {...this.selected}; }
-             else { this.selected[id] = true; this.selected = {...this.selected}; }
-           },
-           selectAll() {
-             {% for match in group.matches %}this.selected[{{ match.id }}] = true;{% endfor %}
-             this.selected = {...this.selected};
-           },
-           deselectAll() { this.selected = {} },
-           toggleAll() {
-             this.selectedCount === {{ group.matches|length }} ? this.deselectAll() : this.selectAll();
-           },
-         }">
+         x-data="{ expanded: true, offersOpen: {} }">
 
       {# Group header — border-line-base hairline #}
       <div class="flex items-center gap-3 px-4 py-3 bg-gray-50 border-b border-line-base">
@@ -128,46 +168,16 @@
 {{ company_header(group, 'Unknown Customer') }}
         {# Per-group match count as .chip #}
         <span class="chip bg-gray-100 text-gray-600 border-gray-200 mr-2">{{ group.matches|length }} match{{ 'es' if group.matches|length != 1 }}</span>
+        {% if scope == 'all' and group.salesperson_name %}
+        <span class="chip bg-sky-50 text-sky-700 border-sky-200 mr-2">{{ group.salesperson_name }}</span>
+        {% endif %}
 
-        {# Select all checkbox — accent via accent-color + input-focus ring #}
-        <label class="flex items-center gap-1 text-xs text-gray-600 cursor-pointer mr-2">
-          <input type="checkbox" @change="toggleAll()"
-                 :checked="selectedCount === {{ group.matches|length }}"
-                 class="rounded border-gray-300 input-focus"
-                 style="accent-color:var(--accent)">
-          All
-        </label>
-
-        {# Prepare button — .btn-primary .btn-sm #}
-        <form method="POST" action="/v2/proactive/prepare/{{ group.customer_site_id }}"
-              hx-post="/v2/proactive/prepare/{{ group.customer_site_id }}"
-              hx-target="#main-content"
-              data-loading-disable>
-          <template x-for="id in selectedIds" :key="id">
-            <input type="hidden" name="match_ids" :value="id">
-          </template>
-          <button type="submit"
-                  :disabled="selectedCount === 0"
-                  class="btn-primary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
-            Prepare (<span x-text="selectedCount">0</span>)
-          </button>
-        </form>
-
-        {# Dismiss button — .btn-secondary .btn-sm #}
-        <form method="POST" action="/v2/partials/proactive/batch-dismiss"
-              data-loading-disable
-              hx-post="/v2/partials/proactive/batch-dismiss"
-              hx-target="#main-content"
-              hx-confirm="Dismiss selected matches?">
-          <template x-for="id in selectedIds" :key="id">
-            <input type="hidden" name="match_ids" :value="id">
-          </template>
-          <button type="submit"
-                  :disabled="selectedCount === 0"
-                  class="btn-secondary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
-            Dismiss (<span x-text="selectedCount">0</span>)
-          </button>
-        </form>
+        {# Mark the whole customer for send in one tap #}
+        <button type="button"
+                @click="{% for match in group.matches %}sel[{{ match.id }}] = 'send'; {% endfor %}sel = {...sel}"
+                class="text-xs font-medium px-2 py-1 rounded bg-emerald-50 text-emerald-700 hover:bg-emerald-100 transition-colors focus:outline-none focus:ring-2" style="--tw-ring-color:var(--accent-ring)">
+          All → send
+        </button>
       </div>
 
       {# Match table — .data-table for unified density + line tokens #}
@@ -176,7 +186,7 @@
           <table class="data-table w-full">
             <thead>
               <tr>
-                <th class="w-10 text-left"></th>
+                <th class="w-[110px] text-left">Send / Ignore</th>
                 <th class="text-left">MPN</th>
                 <th class="text-left w-[140px]">Supply</th>
                 <th class="text-right w-[90px]">Available</th>

--- a/tests/test_proactive_prepare.py
+++ b/tests/test_proactive_prepare.py
@@ -525,7 +525,9 @@ def test_send_form_path_includes_sell_price(db_session):
     # Capture what sell_prices dict is passed to the service
     captured: dict = {}
 
-    async def _fake_send(*, db, user, token, match_ids, contact_ids, sell_prices, subject=None, email_html=None):
+    async def _fake_send(
+        *, db, user, token, match_ids, contact_ids, sell_prices, subject=None, email_html=None, allow_all=False
+    ):
         captured["sell_prices"] = sell_prices
         # Return minimal result the route needs to render success
         return {

--- a/tests/test_proactive_process.py
+++ b/tests/test_proactive_process.py
@@ -1,0 +1,338 @@
+"""tests/test_proactive_process.py — Matches-tab Process flow + manager scope.
+
+Check send/ignore → Process stages ONE draft offer per customer (default
+contact, sell prices seeded from the last quote, template body) and dismisses
+the ignores; the review strip sends each draft with one click. Managers work
+every rep's matches via scope=all; drafts never leak into the scorecard or
+the Sent tab.
+
+Called by: pytest autodiscovery
+Depends on: conftest fixtures (db_session), app.main
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.constants import ProactiveMatchStatus, ProactiveOfferStatus
+from app.models import (
+    Company,
+    CustomerSite,
+    Offer,
+    ProactiveMatch,
+    ProactiveOffer,
+    ProactiveThrottle,
+    Quote,
+    QuoteLine,
+    Requisition,
+    SiteContact,
+    User,
+)
+from app.services.proactive_service import (
+    build_draft_offers,
+    discard_draft_offer,
+    get_scorecard,
+    get_sent_offers,
+    list_draft_offers,
+    process_matches,
+    send_draft_offer,
+)
+from tests.conftest import engine  # noqa: F401
+
+HX = {"HX-Request": "true"}
+
+
+def _mk_user(db, name, email, role="sales"):
+    u = User(email=email, name=name, role=role, azure_id=f"az-{email}")
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _mk_customer(db, name, owner, *, contact_email=None):
+    c = Company(name=name, is_active=True, account_owner_id=owner.id)
+    db.add(c)
+    db.flush()
+    s = CustomerSite(company_id=c.id, site_name=f"{name} HQ", is_active=True)
+    db.add(s)
+    db.flush()
+    if contact_email:
+        db.add(SiteContact(customer_site_id=s.id, full_name=f"{name} Buyer", email=contact_email))
+        db.flush()
+    return c, s
+
+
+def _mk_match(db, *, mpn, owner, company, site, price="8.00", qty=500, target=300):
+    offer = Offer(vendor_name="Arrow", mpn=mpn, qty_available=qty, unit_price=Decimal(price), status="active")
+    db.add(offer)
+    db.flush()
+    req = Requisition(name=f"req-{mpn}", customer_site_id=site.id if site else None, status="open", created_by=owner.id)
+    db.add(req)
+    db.flush()
+    from app.models import Requirement
+
+    requirement = Requirement(requisition_id=req.id, primary_mpn=mpn, target_qty=target)
+    db.add(requirement)
+    db.flush()
+    m = ProactiveMatch(
+        offer_id=offer.id,
+        requirement_id=requirement.id,
+        salesperson_id=owner.id,
+        mpn=mpn,
+        company_id=company.id if company else None,
+        customer_site_id=site.id if site else None,
+        status="new",
+        match_score=70,
+    )
+    db.add(m)
+    db.commit()
+    return m
+
+
+def _scenario(db):
+    rep = _mk_user(db, "Sales Rep", "rep@trio.com")
+    other = _mk_user(db, "Other Rep", "other@trio.com")
+    manager = _mk_user(db, "The Manager", "mgr@trio.com", role="manager")
+    beckhoff, beckhoff_site = _mk_customer(db, "Beckhoff", rep, contact_email="buyer@beckhoff.com")
+    siemens, siemens_site = _mk_customer(db, "Siemens", rep)  # no contact on file
+    m1 = _mk_match(db, mpn="LTSR15-NP", owner=rep, company=beckhoff, site=beckhoff_site, price="6.44")
+    m2 = _mk_match(db, mpn="GSOT36C-E3-08", owner=rep, company=beckhoff, site=beckhoff_site, price="0.05")
+    m3 = _mk_match(db, mpn="BSM300GA120DN2HOSA1", owner=rep, company=siemens, site=siemens_site, price="274")
+    m4 = _mk_match(db, mpn="EE-SY1200", owner=rep, company=beckhoff, site=beckhoff_site, price="1.80")
+    return {
+        "rep": rep,
+        "other": other,
+        "manager": manager,
+        "beckhoff": beckhoff,
+        "beckhoff_site": beckhoff_site,
+        "siemens": siemens,
+        "m1": m1,
+        "m2": m2,
+        "m3": m3,
+        "m4": m4,
+    }
+
+
+# ── Process: stage + dismiss ─────────────────────────────────────────────
+
+
+def test_process_stages_one_draft_per_customer_and_dismisses_ignores(db_session):
+    s = _scenario(db_session)
+    stats = process_matches(
+        db_session,
+        s["rep"],
+        send_ids=[s["m1"].id, s["m2"].id, s["m3"].id],
+        ignore_ids=[s["m4"].id],
+    )
+    db_session.commit()
+
+    assert stats["ignored"] == 1
+    assert stats["drafts_created"] == 2  # Beckhoff (m1+m2), Siemens (m3)
+    assert stats["needs_contact"] == 1  # Siemens has no contact
+    db_session.refresh(s["m4"])
+    assert s["m4"].status == ProactiveMatchStatus.DISMISSED
+    assert s["m4"].dismiss_reason == "processed_ignore"
+    db_session.refresh(s["m1"])
+    assert s["m1"].status == ProactiveMatchStatus.NEW  # staged, NOT sent
+
+    drafts = list_draft_offers(db_session, s["rep"])
+    assert len(drafts) == 2
+    beckhoff_draft = next(d for d in drafts if d["company_name"] == "Beckhoff")
+    assert beckhoff_draft["line_count"] == 2
+    assert beckhoff_draft["recipient_emails"] == ["buyer@beckhoff.com"]
+    siemens_draft = next(d for d in drafts if d["company_name"] == "Siemens")
+    assert siemens_draft["recipient_emails"] == []
+
+
+def test_process_seeds_sell_price_from_last_quote(db_session):
+    s = _scenario(db_session)
+    req = Requisition(name="q-req", customer_site_id=s["beckhoff_site"].id, status="quoted", created_by=s["rep"].id)
+    db_session.add(req)
+    db_session.flush()
+    quote = Quote(
+        requisition_id=req.id,
+        customer_site_id=s["beckhoff_site"].id,
+        quote_number="Q-77",
+        status="sent",
+        sent_at=datetime.now(UTC) - timedelta(days=10),
+        created_by_id=s["rep"].id,
+    )
+    db_session.add(quote)
+    db_session.flush()
+    db_session.add(QuoteLine(quote_id=quote.id, mpn="LTSR15-NP", sell_price=Decimal("8.10")))
+    db_session.commit()
+
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).filter(ProactiveOffer.status == ProactiveOfferStatus.DRAFT).one()
+    line = draft.line_items[0]
+    assert line["sell_price"] == 8.10  # last quote, not cost x 1.3
+    assert "$8.1000" in draft.email_body_html
+
+
+def test_process_double_queue_guard(db_session):
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    stats = build_draft_offers(db_session, s["rep"], [s["m1"].id, s["m2"].id])
+    db_session.commit()
+    assert stats["skipped_already_queued"] == 1
+    assert stats["drafts_created"] == 1  # m2 only
+
+
+def test_backorder_matches_are_skipped_with_note(db_session):
+    rep = _mk_user(db_session, "Trader", "t@trio.com", role="trader")
+    m = _mk_match(db_session, mpn="T521X477M016ATE020", owner=rep, company=None, site=None)
+    stats = build_draft_offers(db_session, rep, [m.id])
+    assert stats["skipped_backorder"] == 1
+    assert stats["drafts_created"] == 0
+
+
+# ── Send / discard drafts ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_send_draft_marks_everything_and_throttles(db_session):
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id, s["m2"].id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+
+    with patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock) as mock_send:
+        result = await send_draft_offer(db_session, s["rep"], "tok", draft.id)
+
+    assert mock_send.call_args.args[1]["message"]["toRecipients"][0]["emailAddress"]["address"] == "buyer@beckhoff.com"
+    assert f"[AVAIL-PROACTIVE-{draft.id}]" in mock_send.call_args.args[1]["message"]["subject"]
+    assert result["status"] == ProactiveOfferStatus.SENT
+    db_session.refresh(s["m1"])
+    db_session.refresh(s["m2"])
+    assert s["m1"].status == ProactiveMatchStatus.SENT
+    assert s["m2"].status == ProactiveMatchStatus.SENT
+    throttles = db_session.query(ProactiveThrottle).all()
+    assert {t.mpn for t in throttles} == {"LTSR15-NP", "GSOT36C-E3-08"}
+
+
+@pytest.mark.anyio
+async def test_send_draft_requires_recipients_and_ownership(db_session):
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m3"].id])  # Siemens — no contact
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+
+    with pytest.raises(ValueError, match="No contact on file"):
+        await send_draft_offer(db_session, s["rep"], "tok", draft.id)
+    with pytest.raises(ValueError, match="Not your draft"):
+        await send_draft_offer(db_session, s["other"], "tok", draft.id)
+    # Manager may act with allow_all — passes ownership, still blocked on contact.
+    with pytest.raises(ValueError, match="No contact on file"):
+        await send_draft_offer(db_session, s["manager"], "tok", draft.id, allow_all=True)
+
+
+def test_discard_draft_returns_matches_to_list(db_session):
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+    discard_draft_offer(db_session, s["rep"], draft.id)
+    db_session.commit()
+    assert db_session.query(ProactiveOffer).count() == 0
+    db_session.refresh(s["m1"])
+    assert s["m1"].status == ProactiveMatchStatus.NEW
+
+
+# ── Drafts never masquerade as outreach ──────────────────────────────────
+
+
+def test_drafts_excluded_from_scorecard_and_sent_tab(db_session):
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    assert get_scorecard(db_session)["total_sent"] == 0
+    assert get_sent_offers(db_session, s["rep"].id) == []
+
+
+# ── Routes + manager scope ───────────────────────────────────────────────
+
+
+def _make_client(db, user):
+    from fastapi.testclient import TestClient
+
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[require_user] = lambda: user
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _clear_overrides():
+    from app.main import app
+
+    app.dependency_overrides.clear()
+
+
+def test_process_endpoint_stages_and_reports(db_session):
+    s = _scenario(db_session)
+    try:
+        client = _make_client(db_session, s["rep"])
+        r = client.post(
+            "/v2/partials/proactive/process",
+            data={"send_ids": [str(s["m1"].id), str(s["m3"].id)], "ignore_ids": [str(s["m4"].id)]},
+            headers=HX,
+        )
+        assert r.status_code == 200
+        assert "2 offer(s) prepared for review" in r.text
+        assert "1 ignored" in r.text
+        assert "Prepared offers" in r.text
+    finally:
+        _clear_overrides()
+
+
+def test_prepared_send_endpoint_authz(db_session):
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+    try:
+        client = _make_client(db_session, s["other"])
+        r = client.post(f"/v2/partials/proactive/prepared/{draft.id}/send", headers=HX)
+        assert r.status_code in (400, 403)  # blocked before any send attempt
+        db_session.refresh(draft)
+        assert draft.status == ProactiveOfferStatus.DRAFT
+    finally:
+        _clear_overrides()
+
+
+def test_manager_scope_all_sees_rep_matches(db_session):
+    s = _scenario(db_session)
+    try:
+        client = _make_client(db_session, s["manager"])
+        r = client.get("/v2/partials/proactive?tab=matches&scope=all", headers=HX)
+        assert r.status_code == 200
+        assert "LTSR15-NP" in r.text
+        assert "Sales Rep" in r.text  # rep attribution chip
+        r = client.get("/v2/partials/proactive?tab=matches", headers=HX)
+        assert "LTSR15-NP" not in r.text  # manager's own list is empty
+    finally:
+        _clear_overrides()
+
+
+def test_sales_cannot_use_scope_all(db_session):
+    s = _scenario(db_session)
+    other_customer, other_site = _mk_customer(db_session, "Zeta", s["other"], contact_email="z@z.com")
+    _mk_match(db_session, mpn="ZETA-1", owner=s["other"], company=other_customer, site=other_site)
+    try:
+        client = _make_client(db_session, s["rep"])
+        r = client.get("/v2/partials/proactive?tab=matches&scope=all", headers=HX)
+        assert r.status_code == 200
+        assert "ZETA-1" not in r.text  # silently pinned to their own matches
+        assert "LTSR15-NP" in r.text
+    finally:
+        _clear_overrides()


### PR DESCRIPTION
The Matches tab becomes the working surface reps drive; the weekly digest stays the manager's lens.

**Process flow**: every match row carries mutually-exclusive **Send / Ignore** checks feeding one sticky **Process** bar that works across all customer groups. Process dismisses the ignores and stages **one DRAFT offer per customer** — default site contact, sell prices seeded from the last quote on the part (else cost × 1.3), deterministic template body, attributed to the matches' rep. Nothing is emailed by Process.

**Review strip**: staged drafts listed per customer — preview the exact email, one-click **Send** (actor's mailbox; identical throttle + match-SENT semantics to the prepare-page path), **Discard** (matches return to the list), or open the full **Prepare** editor. A prepare-page send supersedes any staged draft on the same matches; drafts are double-staging-guarded and excluded from the scorecard and Sent tab.

**Manager scope**: See-All toggle on Matches (rep attribution chips) with the ownership gates (dismiss/prepare/draft/send/process) widened to own-or-manager; offers stay attributed to and signed as the rep. 'Check for matches' scan button now in the header.

New ProactiveOfferStatus.DRAFT — string status, no migration.

**Verification**: 12 new tests (staging per customer, quote-seeded prices, double-queue guard, back-order skip, send/discard semantics + throttle, draft exclusion from scorecard/sent, endpoint authz, scope behavior); 2,214-test proactive-adjacent sweep green locally except two pre-existing prospecting add-domain flakes that reproduce on unmodified main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)