### PR TITLE
fix(graph): raise-by-default Graph client — nine send paths stop faking success (QC cluster 1)

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -452,6 +452,7 @@ class ProactiveOfferStatus(StrEnum):
 
     DRAFT = "draft"
     SENT = "sent"
+    FAILED = "failed"  # Graph rejected the send — matches FAILED too, never throttled
     CONVERTED = "converted"
     EXPIRED = "expired"
 

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -719,6 +719,7 @@ async def poll_inbox(
                     "$orderby": "receivedDateTime desc",
                     "$select": "id,subject,from,receivedDateTime,bodyPreview,body,conversationId",
                 },
+                raise_on_error=False,
             )
             if data and "error" in data:
                 # The retry layer signals exhausted retries / non-retryable 4xx

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -889,7 +889,7 @@ async def attach_from_onedrive(
     if not user.access_token:
         raise HTTPException(401, "Microsoft account not connected")
     gc = GraphClient(user.access_token)
-    item = await gc.get_json(f"/me/drive/items/{item_id}")
+    item = await gc.get_json(f"/me/drive/items/{item_id}", raise_on_error=False)
     if "error" in item:
         raise HTTPException(404, "OneDrive item not found")
     att = OfferAttachment(
@@ -946,6 +946,7 @@ async def browse_onedrive(
             "$top": "50",
             "$select": "id,name,size,file,folder,webUrl,lastModifiedDateTime",
         },
+        raise_on_error=False,
     )
     if "error" in data:
         raise HTTPException(502, "Failed to browse OneDrive")

--- a/app/routers/htmx/email_views.py
+++ b/app/routers/htmx/email_views.py
@@ -103,7 +103,7 @@ async def send_email_reply(
             },
             "saveToSentItems": "true",
         }
-        result = await gc.post_json("/me/sendMail", mail_payload)
+        result = await gc.post_json("/me/sendMail", mail_payload, raise_on_error=False)
         if "error" in result:
             error = f"Send failed: {result.get('detail', 'Unknown error')}"
     except HTTPException:

--- a/app/routers/htmx/offers/follow_ups.py
+++ b/app/routers/htmx/offers/follow_ups.py
@@ -156,7 +156,7 @@ async def _deliver_follow_up(
         "saveToSentItems": "true",
     }
     try:
-        result = await gc.post_json("/me/sendMail", payload)
+        result = await gc.post_json("/me/sendMail", payload, raise_on_error=False)
     except Exception as exc:
         logger.warning("Follow-up email send failed for contact {}: {}", contact.id, exc)
         return "failed"

--- a/app/routers/requisitions/attachments.py
+++ b/app/routers/requisitions/attachments.py
@@ -88,7 +88,7 @@ async def attach_requisition_from_onedrive(
     from ...utils.graph_client import GraphClient
 
     gc = GraphClient(token)
-    item = await gc.get_json(f"/me/drive/items/{item_id}")
+    item = await gc.get_json(f"/me/drive/items/{item_id}", raise_on_error=False)
     if "error" in item:
         error_code = item.get("error", {}).get("code", "") if isinstance(item.get("error"), dict) else ""
         if error_code in ("InvalidAuthenticationToken", "TokenExpired"):

--- a/app/routers/sources.py
+++ b/app/routers/sources.py
@@ -744,14 +744,14 @@ async def parse_response_attachments(
         raise HTTPException(400, "No message ID — cannot fetch attachments")
 
     from ..scheduler import get_valid_token
-    from ..utils.graph_client import GraphClient
+    from ..utils.graph_client import GraphAPIError, GraphClient
 
     token = await get_valid_token(user, db) or user.access_token
     gc = GraphClient(token)
 
     try:
         att_data = await gc.get_json(f"/me/messages/{vr.message_id}/attachments")
-    except (ConnectionError, TimeoutError, OSError, RuntimeError) as e:
+    except (GraphAPIError, ConnectionError, TimeoutError, OSError, RuntimeError) as e:
         raise HTTPException(502, "Graph API error. Please try again.") from e
 
     attachments = att_data.get("value", []) if att_data else []

--- a/app/services/ownership_service.py
+++ b/app/services/ownership_service.py
@@ -278,19 +278,9 @@ async def _send_warning_alert(company: Company, days_inactive: int, inactivity_l
 
     days_remaining = max(0, inactivity_limit - days_inactive)
 
-    # Log the warning as a system activity (also serves as dedup + dashboard notification)
-    warning_record = ActivityLog(
-        user_id=owner.id,
-        activity_type="ownership_warning",
-        channel="system",
-        company_id=company.id,
-        contact_name=company.name,
-        subject=f"Ownership warning: {days_remaining} days remaining on {company.name}",
-    )
-    db.add(warning_record)
-    db.flush()
-
-    # Send email alert
+    # Send email alert FIRST — the ActivityLog row below doubles as the daily
+    # dedup guard, so writing it before a send that then fails would silently
+    # suppress every retry for the rest of the day (QC 2026-08-08).
     try:
         from app.scheduler import get_valid_token
         from app.utils.graph_client import GraphClient
@@ -328,6 +318,19 @@ async def _send_warning_alert(company: Company, days_inactive: int, inactivity_l
         }
         await gc.post_json("/me/sendMail", payload)
         logger.info(f"Warning email sent to {owner.email} for {company.name} ({days_remaining} days remaining)")
+
+        # Delivered — NOW record the warning (dedup + dashboard notification).
+        db.add(
+            ActivityLog(
+                user_id=owner.id,
+                activity_type="ownership_warning",
+                channel="system",
+                company_id=company.id,
+                contact_name=company.name,
+                subject=f"Ownership warning: {days_remaining} days remaining on {company.name}",
+            )
+        )
+        db.flush()
 
     except Exception as e:
         logger.error(f"Failed to send warning email to {owner.email} for {company.name}: {e}")

--- a/app/services/prepayment_notifications.py
+++ b/app/services/prepayment_notifications.py
@@ -265,8 +265,10 @@ async def _notify_inner(db: Session, prepayment_id: int, event: str, reason: str
     if webhook:
         card = _card(prepayment, event, approver=approver_name, decided_at=decided_at, reason=effective_reason)
         try:
-            await post_teams_channel_card(card, webhook)
-            result["teams_sent"] = True
+            # post_teams_channel_card returns True only on confirmed 200/202
+            # delivery — a swallowed webhook failure must NOT count as sent, or
+            # the both-channels-failed honesty alert below can never fire.
+            result["teams_sent"] = bool(await post_teams_channel_card(card, webhook))
         except Exception as e:
             logger.error("Prepayment {} Teams channel failed: {}", prepayment_id, e)
 

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -487,6 +487,11 @@ async def send_proactive_offer(
         logger.error(f"Failed to send proactive offer email: {e}")
         for m in matches:
             m.status = ProactiveMatchStatus.FAILED
+        # The row was created with the model's 'sent'/sent_at defaults so the
+        # subject tag could carry its id — make it honest (QC 2026-08-08): a
+        # rejected send is FAILED, never counted or shown as delivered.
+        po.status = ProactiveOfferStatus.FAILED
+        po.sent_at = None
         send_succeeded = False
 
     # Upsert throttle entries only if the email was actually sent
@@ -704,7 +709,7 @@ async def send_draft_offer(db: Session, user: User, token: str, po_id: int, *, a
     entries as the prepare-page send. Raises ValueError on wrong status / no recipients
     / no permission.
     """
-    from ..utils.graph_client import GraphClient
+    from ..utils.graph_client import GraphAPIError, GraphClient
 
     po = db.get(ProactiveOffer, po_id)
     if not po or po.status != ProactiveOfferStatus.DRAFT:
@@ -717,17 +722,22 @@ async def send_draft_offer(db: Session, user: User, token: str, po_id: int, *, a
 
     tagged_subject = f"[AVAIL-PROACTIVE-{po.id}] {po.subject}"
     gc = GraphClient(token)
-    await gc.post_json(
-        "/me/sendMail",
-        {
-            "message": {
-                "subject": tagged_subject,
-                "body": {"contentType": "HTML", "content": po.email_body_html},
-                "toRecipients": [{"emailAddress": {"address": e}} for e in recipient_emails],
+    try:
+        await gc.post_json(
+            "/me/sendMail",
+            {
+                "message": {
+                    "subject": tagged_subject,
+                    "body": {"contentType": "HTML", "content": po.email_body_html},
+                    "toRecipients": [{"emailAddress": {"address": e}} for e in recipient_emails],
+                },
+                "saveToSentItems": "true",
             },
-            "saveToSentItems": "true",
-        },
-    )
+        )
+    except GraphAPIError as exc:
+        # Draft stays DRAFT, matches stay NEW, no throttle — retry is one click.
+        logger.error("Proactive draft #{} send rejected by Graph: {}", po.id, exc)
+        raise ValueError("Send failed — Microsoft rejected the message; the draft is untouched, try again") from exc
     now = datetime.now(UTC)
     po.status = ProactiveOfferStatus.SENT
     po.sent_at = now
@@ -965,8 +975,9 @@ def get_scorecard(db: Session, salesperson_id: int | None = None) -> dict:
             0,
         )
 
-    # Base filter — staged Process drafts are not outreach yet, never counted.
-    base_filter = [ProactiveOffer.status != ProactiveOfferStatus.DRAFT]
+    # Base filter — staged drafts aren't outreach yet and FAILED sends never
+    # reached the customer; neither may inflate the sent counts.
+    base_filter = [ProactiveOffer.status.notin_([ProactiveOfferStatus.DRAFT, ProactiveOfferStatus.FAILED])]
     if salesperson_id:
         base_filter.append(ProactiveOffer.salesperson_id == salesperson_id)
 

--- a/app/services/quote_send.py
+++ b/app/services/quote_send.py
@@ -130,7 +130,7 @@ async def send_quote_email(
             },
             "saveToSentItems": "true",
         }
-        result = await gc.post_json("/me/sendMail", payload)
+        result = await gc.post_json("/me/sendMail", payload, raise_on_error=False)
         if "error" in result:
             raise QuoteSendError(f"Failed to send quote email: {result.get('detail', '')}")
 

--- a/app/services/teams_notifications.py
+++ b/app/services/teams_notifications.py
@@ -14,7 +14,7 @@ from app.http_client import http
 from app.services.credential_service import get_credential_cached
 
 
-async def post_teams_channel(message: str) -> None:
+async def post_teams_channel(message: str) -> bool:
     """Post a message to the configured Teams channel via webhook.
 
     Uses an Adaptive Card wrapper so the message renders with markdown formatting in
@@ -23,7 +23,7 @@ async def post_teams_channel(message: str) -> None:
     webhook_url = get_credential_cached("teams_notifications", "TEAMS_WEBHOOK_URL")
     if not webhook_url:
         logger.debug("Teams webhook not configured — skipping channel post")
-        return
+        return False
     try:
         resp = await http.post(
             webhook_url,
@@ -45,17 +45,21 @@ async def post_teams_channel(message: str) -> None:
         )
         if resp.status_code not in (200, 202):
             logger.warning("Teams webhook returned {}: {}", resp.status_code, resp.text[:200])
+            return False
+        return True
     except Exception as e:
         logger.error("Teams channel post failed: {}", e)
+        return False
 
 
-async def post_teams_channel_card(card: dict, webhook_url: str | None = None) -> None:
+async def post_teams_channel_card(card: dict, webhook_url: str | None = None) -> bool:
     """Post a FULL Adaptive Card to the configured Teams channel via webhook.
 
     Sibling of :func:`post_teams_channel`, but the caller supplies the entire Adaptive
     Card ``content`` dict (so it can carry a FactSet, an ``Action.OpenUrl`` button, colored
     TextBlocks, etc.) rather than a single markdown string. The card is wrapped verbatim in
-    the same message envelope. Silently skips if no webhook URL is configured.
+    the same message envelope. Returns True only on a confirmed 200/202 delivery;
+    not-configured and every failure return False (never raises).
 
     ``webhook_url`` lets a caller target a specific channel webhook (e.g. the prepayment
     accounting/AP channel) instead of the shared ``TEAMS_WEBHOOK_URL`` credential. When
@@ -64,7 +68,7 @@ async def post_teams_channel_card(card: dict, webhook_url: str | None = None) ->
     webhook_url = webhook_url or get_credential_cached("teams_notifications", "TEAMS_WEBHOOK_URL")
     if not webhook_url:
         logger.debug("Teams webhook not configured — skipping channel card post")
-        return
+        return False
     try:
         resp = await http.post(
             webhook_url,
@@ -81,8 +85,11 @@ async def post_teams_channel_card(card: dict, webhook_url: str | None = None) ->
         )
         if resp.status_code not in (200, 202):
             logger.warning("Teams webhook (card) returned {}: {}", resp.status_code, resp.text[:200])
+            return False
+        return True
     except Exception as e:
         logger.error("Teams channel card post failed: {}", e)
+        return False
 
 
 async def _find_self_chat(gc, sender_id: str) -> str | None:

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -227,9 +227,13 @@ async def renew_subscription(sub: GraphSubscription, db: Session) -> bool:
 
     gc = GraphClient(token)
     try:
+        # raise_on_error=False is load-bearing: a 404/410 ERROR DICT means Graph
+        # confirmed the subscription is gone (delete + recreate), while a raised
+        # exception means transient (keep + retry). See the branch below.
         result = await gc.patch_json(
             f"/subscriptions/{sub.subscription_id}",
             {"expirationDateTime": new_expiration.strftime("%Y-%m-%dT%H:%M:%S.0000000Z")},
+            raise_on_error=False,
         )
     except Exception as e:
         # Network/timeout error — Graph has not confirmed the subscription is gone.

--- a/app/utils/graph_client.py
+++ b/app/utils/graph_client.py
@@ -156,9 +156,7 @@ class GraphClient:
             "$top": str(max_results),
             "$orderby": "sentDateTime desc",
         }
-        data = await self.get_json(path, params=params)
-        if isinstance(data, dict) and "error" in data:
-            raise RuntimeError(f"Graph API error searching sent messages: {data}")
+        data = await self.get_json(path, params=params)  # raises GraphAPIError on failure
         messages: list[dict] = data.get("value", [])  # Graph JSON boundary
         return messages
 

--- a/app/utils/graph_client.py
+++ b/app/utils/graph_client.py
@@ -27,13 +27,17 @@ class GraphSyncStateExpired(Exception):
 
 
 class GraphAPIError(Exception):
-    """Raised when a paged request (delta_query / get_all_pages) hits an error page.
+    """Raised when a Graph request fails after retries.
 
-    _request_with_retry returns ``{"error": <status>, "detail": ...}`` dicts for
-    non-retryable failures (401/4xx/max_retries) — a contract webhook_service
-    branches on, so it stays. Pagination helpers must NOT treat those dicts as
-    empty pages (that silently ends the round and lets callers persist a token
-    past unfetched data), so they raise this instead.
+    2026-08-08 QC fix: get_json/post_json/patch_json now RAISE this by default
+    instead of returning ``{"error": <status>, "detail": ...}`` dicts — nine
+    send paths were discarding those dicts and recording success (approval
+    outbox, prepayment wire notices, proactive offers, vendor replies...).
+    Callers that legitimately branch on the dict (webhook_service's
+    subscription contract) pass ``raise_on_error=False`` explicitly, which
+    keeps the old shape visible at the call site instead of as a foot-gun.
+    Pagination helpers (delta_query / get_all_pages) have always raised so a
+    token can never be persisted past unfetched data.
     """
 
     def __init__(self, status: int | str, detail: str = ""):
@@ -62,23 +66,41 @@ class GraphClient:
             **IMMUTABLE_ID_HEADER,
         }
 
-    async def get_json(self, path: str, params: dict | None = None, timeout: int = 30) -> dict:
+    @staticmethod
+    def _checked(data: dict, raise_on_error: bool) -> dict:
+        """Convert the retry layer's error dict into GraphAPIError unless opted out."""
+        if raise_on_error and isinstance(data, dict) and "error" in data:
+            raise GraphAPIError(data["error"], str(data.get("detail", "")))
+        return data
+
+    async def get_json(
+        self, path: str, params: dict | None = None, timeout: int = 30, *, raise_on_error: bool = True
+    ) -> dict:
         """GET → parsed JSON.
 
-        Raises on non-200 after retries.
+        Raises GraphAPIError on failure after retries.
         """
         url = path if path.startswith("http") else f"{GRAPH_BASE}{path}"
-        return await self._request_with_retry("GET", url, params=params, timeout=timeout)
+        data = await self._request_with_retry("GET", url, params=params, timeout=timeout)
+        return self._checked(data, raise_on_error)
 
-    async def post_json(self, path: str, json_data: dict, timeout: int = 30) -> dict:
-        """POST → parsed JSON or empty dict on 202."""
-        url = path if path.startswith("http") else f"{GRAPH_BASE}{path}"
-        return await self._request_with_retry("POST", url, json_data=json_data, timeout=timeout)
+    async def post_json(self, path: str, json_data: dict, timeout: int = 30, *, raise_on_error: bool = True) -> dict:
+        """POST → parsed JSON or empty dict on 202.
 
-    async def patch_json(self, path: str, json_data: dict, timeout: int = 30) -> dict:
-        """PATCH → parsed JSON or empty dict on 204."""
+        Raises GraphAPIError on failure.
+        """
         url = path if path.startswith("http") else f"{GRAPH_BASE}{path}"
-        return await self._request_with_retry("PATCH", url, json_data=json_data, timeout=timeout)
+        data = await self._request_with_retry("POST", url, json_data=json_data, timeout=timeout)
+        return self._checked(data, raise_on_error)
+
+    async def patch_json(self, path: str, json_data: dict, timeout: int = 30, *, raise_on_error: bool = True) -> dict:
+        """PATCH → parsed JSON or empty dict on 204.
+
+        Raises GraphAPIError on failure.
+        """
+        url = path if path.startswith("http") else f"{GRAPH_BASE}{path}"
+        data = await self._request_with_retry("PATCH", url, json_data=json_data, timeout=timeout)
+        return self._checked(data, raise_on_error)
 
     async def get_all_pages(
         self,

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -130,9 +130,15 @@ class TestGraphClientRetry:
         mock_http.get = AsyncMock(return_value=_mock_response(status_code, text=text))
 
         gc = GraphClient("test-token")
-        result = await gc.get_json("/me/messages")
-        assert result["error"] == status_code
+        # QC 2026-08-08: the JSON verbs RAISE on failure by default — nine send
+        # paths were persisting success off discarded error dicts.
+        with pytest.raises(GraphAPIError, match=str(status_code)):
+            await gc.get_json("/me/messages")
         mock_sleep.assert_not_called()
+
+        # Explicit opt-out preserves the legacy dict contract (webhook_service).
+        result = await gc.get_json("/me/messages", raise_on_error=False)
+        assert result["error"] == status_code
 
     @pytest.mark.asyncio
     @patch("app.utils.graph_client.asyncio.sleep", new_callable=AsyncMock)
@@ -587,15 +593,18 @@ class TestGraphClientAdditional:
     @pytest.mark.asyncio
     @patch("app.utils.graph_client.asyncio.sleep", new_callable=AsyncMock)
     @patch("app.utils.graph_client.http")
-    async def test_max_retries_exhausted_5xx_returns_error(self, mock_http, mock_sleep):
-        """After max retries on 5xx, returns error dict (line 189)."""
+    async def test_max_retries_exhausted_5xx_raises(self, mock_http, mock_sleep):
+        """After max retries on 5xx, the JSON verbs raise GraphAPIError."""
         mock_http.get = AsyncMock(return_value=_mock_response(503, text="Service Unavailable"))
 
         gc = GraphClient("test-token")
-        result = await gc.get_json("/me/messages")
-        # After MAX_RETRIES+1 attempts of 503, should return error dict
-        assert result["error"] == "max_retries" or result["error"] == 503
+        with pytest.raises(GraphAPIError):
+            await gc.get_json("/me/messages")
         assert mock_http.get.call_count >= 2  # At least initial + retries
+
+        # Opt-out still yields the dict for callers that branch on it.
+        result = await gc.get_json("/me/messages", raise_on_error=False)
+        assert result["error"] in ("max_retries", 503)
 
     @pytest.mark.asyncio
     @patch("app.utils.graph_client.http")

--- a/tests/test_m365_strengthen.py
+++ b/tests/test_m365_strengthen.py
@@ -335,7 +335,7 @@ def test_401_not_retried():
 
     with patch("app.utils.graph_client.http") as mock_http:
         mock_http.get = mock_get
-        result = asyncio.get_event_loop().run_until_complete(gc.get_json("/me/messages"))
+        result = asyncio.get_event_loop().run_until_complete(gc.get_json("/me/messages", raise_on_error=False))
 
     # Should only be called once (no retries for 401)
     assert call_count == 1
@@ -363,7 +363,7 @@ def test_429_returns_error_in_test_mode():
 
     with patch("app.utils.graph_client.http") as mock_http:
         mock_http.get = mock_get
-        result = asyncio.get_event_loop().run_until_complete(gc.get_json("/me/messages"))
+        result = asyncio.get_event_loop().run_until_complete(gc.get_json("/me/messages", raise_on_error=False))
 
     # In test mode MAX_RETRIES=0, so only 1 attempt total
     assert call_count == 1

--- a/tests/test_nightly_coverage_gaps.py
+++ b/tests/test_nightly_coverage_gaps.py
@@ -73,8 +73,10 @@ class TestGraphClientSearchSentMessages:
         mock_http.get = AsyncMock(
             return_value=MagicMock(status_code=200, json=lambda: {"error": {"code": "AccessDenied"}})
         )
+        from app.utils.graph_client import GraphAPIError
+
         gc = GraphClient("token-abc")
-        with pytest.raises(RuntimeError, match="Graph API error"):
+        with pytest.raises(GraphAPIError, match="Graph API error"):
             await gc.search_sent_messages("LM317T")
 
     @pytest.mark.asyncio

--- a/tests/test_ownership_service.py
+++ b/tests/test_ownership_service.py
@@ -494,9 +494,11 @@ class TestSendWarningAlert:
             mock_settings.app_url = "http://localhost:8000"
             await _send_warning_alert(test_company, 25, 30, db_session)
 
-        # Warning still logged even without email
+        # QC 2026-08-08: the ActivityLog row doubles as the daily dedup guard,
+        # so it is written ONLY after a successful send — no token, no record,
+        # and the next cycle retries instead of being silently suppressed.
         warnings = db_session.query(ActivityLog).filter(ActivityLog.activity_type == "ownership_warning").count()
-        assert warnings == 1
+        assert warnings == 0
 
     @pytest.mark.asyncio
     async def test_handles_email_send_failure(self, db_session: Session, test_company: Company, sales_user: User):
@@ -517,6 +519,11 @@ class TestSendWarningAlert:
             mock_settings.app_url = "http://localhost:8000"
             # Should NOT raise
             await _send_warning_alert(test_company, 25, 30, db_session)
+
+        # And the dedup/dashboard record must NOT exist — a failed send may not
+        # suppress the retry on the next sweep (QC 2026-08-08).
+        failed_warnings = db_session.query(ActivityLog).filter(ActivityLog.activity_type == "ownership_warning").count()
+        assert failed_warnings == 0
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_proactive_process.py
+++ b/tests/test_proactive_process.py
@@ -336,3 +336,64 @@ def test_sales_cannot_use_scope_all(db_session):
         assert "LTSR15-NP" in r.text
     finally:
         _clear_overrides()
+
+
+# ── QC 2026-08-08: Graph failures never fake success ─────────────────────
+
+
+@pytest.mark.anyio
+async def test_failed_draft_send_leaves_everything_untouched(db_session):
+    from app.utils.graph_client import GraphAPIError
+
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+
+    with patch(
+        "app.utils.graph_client.GraphClient.post_json",
+        new_callable=AsyncMock,
+        side_effect=GraphAPIError(401, "token expired"),
+    ):
+        with pytest.raises(ValueError, match="draft is untouched"):
+            await send_draft_offer(db_session, s["rep"], "tok", draft.id)
+
+    db_session.rollback()
+    db_session.refresh(draft)
+    assert draft.status == ProactiveOfferStatus.DRAFT
+    db_session.refresh(s["m1"])
+    assert s["m1"].status == ProactiveMatchStatus.NEW
+    assert db_session.query(ProactiveThrottle).count() == 0
+
+
+@pytest.mark.anyio
+async def test_failed_oneshot_send_marks_offer_failed_not_sent(db_session):
+    from app.services.proactive_service import get_scorecard, send_proactive_offer
+    from app.utils.graph_client import GraphAPIError
+
+    s = _scenario(db_session)
+    from app.models import SiteContact
+
+    contact = db_session.query(SiteContact).filter(SiteContact.email == "buyer@beckhoff.com").one()
+
+    with patch(
+        "app.utils.graph_client.GraphClient.post_json",
+        new_callable=AsyncMock,
+        side_effect=GraphAPIError(503, "graph down"),
+    ):
+        await send_proactive_offer(
+            db=db_session,
+            user=s["rep"],
+            token="tok",
+            match_ids=[s["m1"].id],
+            contact_ids=[contact.id],
+            sell_prices={},
+        )
+
+    po = db_session.query(ProactiveOffer).one()
+    assert po.status == ProactiveOfferStatus.FAILED  # never a phantom 'sent'
+    assert po.sent_at is None
+    db_session.refresh(s["m1"])
+    assert s["m1"].status == ProactiveMatchStatus.FAILED
+    assert db_session.query(ProactiveThrottle).count() == 0  # retry not suppressed
+    assert get_scorecard(db_session)["total_sent"] == 0  # never counted as outreach

--- a/tests/test_resource_notifications.py
+++ b/tests/test_resource_notifications.py
@@ -181,7 +181,8 @@ class TestPostTeamsChannelCard:
 
                 result = await post_teams_channel_card({"type": "AdaptiveCard"})
 
-        assert result is None
+        # QC 2026-08-08: helpers report delivery honestly — unconfigured = False.
+        assert result is False
         mock_http.post.assert_not_called()
         assert any("not configured" in m for m in captured)
 


### PR DESCRIPTION
QC audit cluster 1 — 3 criticals + the dominant high-severity family. Full context in specs/qc-review-2026-08-08.md (findings 3–5 + tooling appendix criticals 1–3).

**Root cause:** the Graph retry layer returned `{"error": status}` dicts; nine send/lookup paths discarded them and persisted success — approval outbox marked sent on 4xx (retry/dead-letter bypassed), prepayment OK/DO-NOT-WIRE notices to accounting recorded delivered on failure with the honesty alert unreachable, vendor replies marked REVIEWED, proactive offers/digests flipped SENT with retry-suppressing throttles, resell's duplicate-send guard defeated, ownership warnings dedup-suppressed after failing.

**Fix:** `get_json/post_json/patch_json` raise `GraphAPIError` by default; the seven call sites that legitimately branch on the dict opt out explicitly (`raise_on_error=False`) — the webhook subscription-gone contract is preserved and documented in place. Sites that already had correct try/except structures now work as their docstrings always claimed, with zero changes. Teams helpers return honest delivery bools; prepayment `teams_sent` uses them. Ownership's dedup record writes only after a successful send. Proactive gains `ProactiveOfferStatus.FAILED` — no phantom 'sent' rows, scorecard excludes failures, draft sends fail clean with everything untouched.

**Verification:** affected sweep 1,721 passed; 7 stale-contract tests updated to the raising contract with opt-out coverage; new failure-path regression tests for proactive one-shot + draft sends and ownership dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)