### PR TITLE
fix(quotes): quote-number wedge + HTMX delete CASCADE guard (QC cluster 2)

### DIFF
--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -157,6 +157,16 @@ async def delete_quote_htmx(
     if quote.status != QuoteStatus.DRAFT:
         raise HTTPException(400, "Only draft quotes can be deleted")
 
+    # Same guard as the JSON path (routers/crm/quotes.py): deleting a quote
+    # CASCADEs into its buy plan -> lines -> quality plan -> prepayments
+    # (including PAID ones). A reopened-to-draft quote must never take that
+    # chain down silently (QC 2026-08-08).
+    from ...models import BuyPlan
+
+    linked_buy_plans = db.query(BuyPlan).filter(BuyPlan.quote_id == quote.id).count()
+    if linked_buy_plans:
+        raise HTTPException(400, f"Cannot delete quote with {linked_buy_plans} linked buy plans.")
+
     db.delete(quote)
     db.commit()
     logger.info("Quote {} deleted by {}", quote_id, user.email)

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -11,6 +11,7 @@ Depends on: app/models (Company, CustomerSite, SiteContact, Quote),
     app/models/auth (User), app/utils/search_builder
 """
 
+import re
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_, func, or_, select
@@ -32,25 +33,31 @@ STALENESS_DUE_SOON_DAYS = 14
 def next_quote_number(db: Session) -> str:
     """Generate next sequential quote number: Q-YYYY-NNNN.
 
-    Uses SELECT FOR UPDATE to prevent race conditions.
+    Takes the MAX numeric sequence across the year's quote numbers rather than
+    trusting the newest row: revising a non-latest quote re-issues its
+    canonical number on a NEW row (the old one becomes ...-R{n}), so
+    newest-by-id can lag the real maximum and every subsequent create would
+    collide on the unique constraint (QC 2026-08-08). The newest-row SELECT
+    FOR UPDATE is retained as the concurrency mutex it always was.
     """
     year = datetime.now(UTC).year
     prefix = f"Q-{year}-"
-    last = (
-        db.query(Quote)
+    # Serialize concurrent generators (same lock target as before).
+    (
+        db.query(Quote.id)
         .filter(Quote.quote_number.like(f"{prefix}%"))
         .order_by(Quote.id.desc())
         .with_for_update()
         .first()
     )
-    if last:
-        try:
-            seq = int(last.quote_number.split("-")[-1]) + 1
-        except ValueError:
-            seq = 1
-    else:
-        seq = 1
-    return f"{prefix}{seq:04d}"
+    pattern = re.compile(rf"^{re.escape(prefix)}(\d+)")
+    numbers = db.query(Quote.quote_number).filter(Quote.quote_number.like(f"{prefix}%")).all()
+    seq = 0
+    for (number,) in numbers:
+        match = pattern.match(number or "")
+        if match:
+            seq = max(seq, int(match.group(1)))
+    return f"{prefix}{seq + 1:04d}"
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_qc_quote_lifecycle.py
+++ b/tests/test_qc_quote_lifecycle.py
@@ -1,0 +1,115 @@
+"""tests/test_qc_quote_lifecycle.py — QC 2026-08-08 cluster 2 regressions.
+
+Two confirmed criticals: (1) next_quote_number trusted the newest ROW, so
+revising a non-latest quote (which re-issues its canonical number on a new
+row) wedged every subsequent create into a unique-constraint 500; (2) the
+HTMX quote delete lacked the JSON path's buy-plan guard, so reopen-to-draft
+then delete CASCADE-destroyed the buy plan, quality plan, and PAID
+prepayments.
+
+Called by: pytest autodiscovery
+Depends on: conftest fixtures (client, db_session, test_user)
+"""
+
+from datetime import UTC, datetime
+
+from app.models import BuyPlan, Quote, Requisition
+from app.services.crm_service import next_quote_number
+from tests.conftest import engine  # noqa: F401
+
+YEAR = datetime.now(UTC).year
+
+
+def _req(db, user):
+    r = Requisition(name="qc-quote-req", status="quoted", created_by=user.id)
+    db.add(r)
+    db.flush()
+    return r
+
+
+def _quote(db, req, number, status="draft"):
+    q = Quote(requisition_id=req.id, quote_number=number, line_items=[], status=status)
+    db.add(q)
+    db.commit()
+    return q
+
+
+# ── next_quote_number: max-sequence, never newest-row ────────────────────
+
+
+def test_next_number_survives_revising_a_non_latest_quote(db_session, test_user):
+    """The wedge: revise #1 while #2 exists → newest row carries #1's canonical
+    number again; the generator must still produce #3, not collide on #2."""
+    req = _req(db_session, test_user)
+    q1 = _quote(db_session, req, f"Q-{YEAR}-0001", status="sent")
+    _quote(db_session, req, f"Q-{YEAR}-0002", status="sent")
+
+    # Simulate the revise flow: old row renamed to -R1, canonical number
+    # re-issued on a NEW (newest-id) row.
+    q1.quote_number = f"Q-{YEAR}-0001-R1"
+    db_session.commit()
+    _quote(db_session, req, f"Q-{YEAR}-0001", status="draft")
+
+    assert next_quote_number(db_session) == f"Q-{YEAR}-0003"
+
+
+def test_next_number_parses_past_revision_suffixes(db_session, test_user):
+    """A ...-R{n} row as the only/latest match must neither crash the parse nor reset
+    the sequence to 1."""
+    req = _req(db_session, test_user)
+    _quote(db_session, req, f"Q-{YEAR}-0005-R1", status="sent")
+    assert next_quote_number(db_session) == f"Q-{YEAR}-0006"
+
+
+def test_next_number_empty_year_starts_at_one(db_session):
+    assert next_quote_number(db_session) == f"Q-{YEAR}-0001"
+
+
+def test_next_number_repeated_calls_never_collide_after_revision(db_session, test_user):
+    """Regression for the permanent-wedge symptom: creating quotes after a
+    revision must keep working, not 500 on every retry."""
+    req = _req(db_session, test_user)
+    for i in range(1, 4):
+        _quote(db_session, req, f"Q-{YEAR}-{i:04d}", status="sent")
+    q1 = db_session.query(Quote).filter(Quote.quote_number == f"Q-{YEAR}-0001").one()
+    q1.quote_number = f"Q-{YEAR}-0001-R1"
+    db_session.commit()
+    _quote(db_session, req, f"Q-{YEAR}-0001", status="draft")
+
+    n1 = next_quote_number(db_session)
+    _quote(db_session, req, n1, status="draft")
+    n2 = next_quote_number(db_session)
+    assert (n1, n2) == (f"Q-{YEAR}-0004", f"Q-{YEAR}-0005")
+
+
+# ── HTMX quote delete: buy-plan guard ────────────────────────────────────
+
+
+def test_htmx_delete_blocked_when_buy_plan_linked(client, db_session, test_user):
+    """Reopen-to-draft then delete must NOT cascade into the buy plan chain."""
+    req = _req(db_session, test_user)
+    quote = _quote(db_session, req, f"Q-{YEAR}-0900", status="draft")
+    plan = BuyPlan(
+        quote_id=quote.id,
+        requisition_id=req.id,
+        status="active",
+        so_status="approved",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(plan)
+    db_session.commit()
+
+    resp = client.delete(f"/v2/partials/quotes/{quote.id}")
+    assert resp.status_code == 400
+    assert "linked buy plans" in resp.text
+    assert db_session.get(Quote, quote.id) is not None
+    assert db_session.get(BuyPlan, plan.id) is not None  # chain intact
+
+
+def test_htmx_delete_still_works_without_buy_plan(client, db_session, test_user):
+    req = _req(db_session, test_user)
+    quote = _quote(db_session, req, f"Q-{YEAR}-0901", status="draft")
+    resp = client.delete(f"/v2/partials/quotes/{quote.id}")
+    assert resp.status_code == 200
+    assert resp.headers.get("HX-Redirect") == "/v2/requisitions"
+    assert db_session.get(Quote, quote.id) is None

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -149,16 +149,16 @@ def test_quote_to_dict_sent():
 
 
 def _mock_db_with_last_quote(last_quote_number):
-    """Build a mock db whose query chain returns a Quote with the given number (or
-    None)."""
-    last = None
-    if last_quote_number is not None:
-        last = MagicMock()
-        last.quote_number = last_quote_number
+    """Build a mock db for next_quote_number (QC 2026-08-08 contract).
+
+    The generator now takes a lock via the newest-row chain (result unused) and computes
+    the MAX sequence from a quote_number column scan — feed the number through .all() as
+    (number,) rows.
+    """
     db = MagicMock()
-    db.query.return_value.filter.return_value.order_by.return_value.with_for_update.return_value.first.return_value = (
-        last
-    )
+    chain = db.query.return_value.filter.return_value
+    chain.order_by.return_value.with_for_update.return_value.first.return_value = None
+    chain.all.return_value = [(last_quote_number,)] if last_quote_number is not None else []
     return db
 
 


### PR DESCRIPTION
QC audit cluster 2 — both critical (findings 1–2 in specs/qc-review-2026-08-08.md).

**Quote-number wedge:** `next_quote_number` trusted the newest row and parsed its tail. Revising a non-latest quote re-issues its canonical number on a new row (old becomes `...-R{n}`), so the generator re-produced an existing number and **every subsequent quote create 500'd permanently** — retries recomputed the same collision. Now takes the MAX numeric sequence across the year's numbers (regex; revision suffixes handled), keeping the newest-row `SELECT FOR UPDATE` as the concurrency mutex.

**CASCADE-deleting quote delete:** the HTMX delete path was missing the JSON path's buy-plan guard — reopen-to-draft then delete silently destroyed the BuyPlan → lines → QualityPlan → **Prepayments including PAID rows**. Same guard on both paths now.

**Verification:** exact-wedge regression, revision-suffix parsing, post-revision continuity, guarded/unguarded delete tests; quote+CRM sweep 1,711 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)