### PR TITLE
fix(security): 2 XSS, attachment stored-XSS, approvals authority + prepayment dispatch (QC cluster 3)

### DIFF
--- a/app/routers/approvals.py
+++ b/app/routers/approvals.py
@@ -26,7 +26,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
-from ..constants import RESTRICTED_ROLES, ApprovalRecipientStatus
+from ..constants import RESTRICTED_ROLES, ApprovalGateType, ApprovalRecipientStatus
 from ..database import get_db
 from ..dependencies import require_approval_gatekeeper, require_user
 from ..models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
@@ -116,7 +116,7 @@ def _can_view_request(db: Session, request: ApprovalRequest, user: User) -> bool
 
 
 @router.post("/v2/approvals/requests/{id}/decision")
-def post_decision(
+async def post_decision(
     id: int,
     action: str = Form(...),
     comment: str | None = Form(default=None),
@@ -136,6 +136,20 @@ def post_decision(
         raise HTTPException(403, str(exc)) from exc
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"error": str(exc)})
+
+    # svc_decide() already stamped the prepayment lifecycle (status + pay_token /
+    # void) atomically; fan out the accounting/AP notice here so this JSON path
+    # is no longer silent about wire authorizations (QC 2026-08-08). Best-effort,
+    # isolated by the runner — a failed notice never unwinds the committed decision.
+    if request.gate_type == ApprovalGateType.PREPAYMENT and request.subject_id is not None:
+        from ..services.prepayment_notifications import (
+            notify_prepayment_approved,
+            notify_prepayment_voided,
+            run_prepayment_notify_bg,
+        )
+
+        notifier = notify_prepayment_approved if action == "approve" else notify_prepayment_voided
+        await run_prepayment_notify_bg(notifier, request.subject_id)
 
     return {"id": request.id, "status": request.status}
 

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -13,8 +13,7 @@ Depends on: app.models, app.dependencies, app.database, app.services.approvals,
 """
 
 import json
-import secrets
-from datetime import UTC, datetime
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -391,7 +390,6 @@ async def prepay_request_decide(
     # committed. APPROVE → approved + mint the single-use pay_token (the "OK TO WIRE" email
     # link); REJECT → void + the "DO NOT WIRE" stand-down.
     if ar.subject_id is not None and action in ("approve", "reject"):
-        from ...constants import PrepaymentStatus
         from ...models.quality_plan import Prepayment
         from ...services.prepayment_notifications import (
             notify_prepayment_approved,
@@ -399,20 +397,13 @@ async def prepay_request_decide(
             run_prepayment_notify_bg,
         )
 
+        # svc_decide() now stamps the prepayment lifecycle (status + pay_token /
+        # void) atomically for every path (QC 2026-08-08); this endpoint only
+        # fans out the accounting/AP notice + the reject note thread.
         pp = db.get(Prepayment, ar.subject_id)
         if action == "approve":
-            if pp is not None:
-                pp.status = PrepaymentStatus.APPROVED.value
-                pp.approved_by_id = user.id
-                pp.approved_at = datetime.now(UTC)
-                pp.pay_token = secrets.token_urlsafe(32)
-                db.commit()
             await run_prepayment_notify_bg(notify_prepayment_approved, ar.subject_id)
-        elif pp is not None:  # reject
-            pp.status = PrepaymentStatus.VOID.value
-            pp.void_reason = "rejected by approver"
-            pp.voided_at = datetime.now(UTC)
-            pp.voided_by_id = user.id
+        elif pp is not None:  # reject — decide() already set VOID; add the note thread
             # Note-to-the-fixer (2.2): the (required) reject reason lands on the
             # prepayment's notes thread tagged with the decision, and the requester
             # (the fixer) gets an in-app notification.

--- a/app/services/approvals/events.py
+++ b/app/services/approvals/events.py
@@ -128,6 +128,32 @@ def reassign(
     if from_recipient is None:
         raise ValueError(f"User {from_user.id} has no pending recipient row on request {request_id}")
 
+    # Row-locked read (matches decide()): serializes against a concurrent decide()
+    # that could move the request to a terminal status, which would otherwise leave
+    # a new PENDING recipient orphaned on an already-resolved request. SQLite
+    # ignores FOR UPDATE; the status guard below is what enforces correctness there.
+    # Read BEFORE any mutation so an ineligible target aborts cleanly.
+    request = db.execute(
+        select(ApprovalRequest).where(ApprovalRequest.id == request_id).with_for_update()
+    ).scalar_one_or_none()
+    if request is None:
+        raise ValueError(f"ApprovalRequest {request_id} not found")
+    if request.status != ApprovalRequestStatus.REQUESTED:
+        raise ValueError(f"ApprovalRequest {request_id} is not open (status={request.status!r})")
+
+    # Authority gate (QC 2026-08-08): reassignment may only hand a slot to a user
+    # who is genuinely eligible for THIS gate at THIS amount — the same
+    # per-user toggle + amount-limit rule route_request enforces. Without this a
+    # single reassign could grant wire/PO approval authority to anyone.
+    from .routing import _eligible_approvers
+
+    eligible_ids = {u.id for u in _eligible_approvers(db, request.gate_type, request.amount)}
+    if to_user.id not in eligible_ids:
+        raise ValueError(
+            f"User {to_user.id} is not eligible to approve gate {request.gate_type} "
+            f"for amount {request.amount} — reassignment refused"
+        )
+
     # Mark the original slot as reassigned.
     from_recipient.status = ApprovalRecipientStatus.REASSIGNED
     from_recipient.reassigned_to_id = to_user.id
@@ -140,18 +166,6 @@ def reassign(
     )
     db.add(new_recipient)
     db.flush()
-
-    # Row-locked read (matches decide()): serializes against a concurrent decide()
-    # that could move the request to a terminal status, which would otherwise leave
-    # this new PENDING recipient orphaned on an already-resolved request. SQLite
-    # ignores FOR UPDATE; the status guard below is what enforces correctness there.
-    request = db.execute(
-        select(ApprovalRequest).where(ApprovalRequest.id == request_id).with_for_update()
-    ).scalar_one_or_none()
-    if request is None:
-        raise ValueError(f"ApprovalRequest {request_id} not found")
-    if request.status != ApprovalRequestStatus.REQUESTED:
-        raise ValueError(f"ApprovalRequest {request_id} is not open (status={request.status!r})")
 
     record(
         db,

--- a/app/services/approvals/service.py
+++ b/app/services/approvals/service.py
@@ -249,4 +249,35 @@ def decide(
                 _run_reject_side_effects(plan, user, db, reason=comment or "Rejected")
             db.flush()
 
+    # Prepayment lifecycle side effects (QC 2026-08-08): previously only the
+    # HTMX prepay endpoint stamped these, so a prepayment decided via the JSON
+    # /decision endpoint closed APPROVED yet stayed 'requested' forever — no
+    # pay_token, no OK-TO-WIRE, and the duplicate-request guard permanently
+    # blocked re-request. Stamping here makes EVERY decide() path atomic; the
+    # accounting/AP notification stays a router concern (both endpoints fan it
+    # out after commit).
+    if (
+        request.gate_type == ApprovalGateType.PREPAYMENT
+        and request.subject_type == ApprovalSubjectType.PREPAYMENT
+        and request.subject_id is not None
+    ):
+        import secrets
+
+        from ...constants import PrepaymentStatus
+
+        prepayment = db.get(Prepayment, request.subject_id)
+        if prepayment is not None:
+            if approved:
+                prepayment.status = PrepaymentStatus.APPROVED.value
+                prepayment.approved_by_id = user.id
+                prepayment.approved_at = datetime.now(UTC)
+                if not prepayment.pay_token:  # single-use; don't rotate on a repeat call
+                    prepayment.pay_token = secrets.token_urlsafe(32)
+            else:
+                prepayment.status = PrepaymentStatus.VOID.value
+                prepayment.void_reason = "rejected by approver"
+                prepayment.voided_at = datetime.now(UTC)
+                prepayment.voided_by_id = user.id
+            db.flush()
+
     return request

--- a/app/services/attachment_service.py
+++ b/app/services/attachment_service.py
@@ -48,6 +48,32 @@ def _safe_name(name: str) -> str:
     return (name or "unnamed_file").replace("/", "_").replace("\\", "_")
 
 
+# Trusted content type derived from the (validated) extension — the client's
+# UploadFile.content_type is attacker-controlled and must never drive serving
+# (QC 2026-08-08 stored-XSS fix). Only images + PDF are safe to render inline;
+# everything else is forced to download.
+_EXT_CONTENT_TYPE = {
+    ".pdf": "application/pdf",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".csv": "text/csv",
+    ".txt": "text/plain",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".xls": "application/vnd.ms-excel",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".zip": "application/zip",
+}
+_INLINE_SAFE_TYPES = {"application/pdf", "image/png", "image/jpeg"}
+
+
+def _trusted_content_type(file_name: str | None) -> str:
+    """Content type from the file extension, never the client-supplied header."""
+    ext = os.path.splitext(file_name or "")[1].lower()
+    return _EXT_CONTENT_TYPE.get(ext, "application/octet-stream")
+
+
 def _validate(file: UploadFile, content: bytes) -> None:
     """Raise HTTPException(400) if the file exceeds the size limit or has a disallowed
     extension."""
@@ -208,7 +234,9 @@ async def store_and_attach(
         library_item_id=item_id,
         library_drive_id=drive_id,
         library_web_url=web_url,
-        content_type=file.content_type,
+        # Store the extension-derived type, NOT the attacker-controlled client
+        # header — the stored value drives inline serving (QC 2026-08-08).
+        content_type=_trusted_content_type(safe),
         size_bytes=len(content),
         uploaded_by_id=user.id,
     )
@@ -301,10 +329,19 @@ async def open_attachment(att, user) -> StreamingResponse | RedirectResponse:
             )
             raise HTTPException(404, "Attachment file not found in library")
         safe = "".join(c for c in (att.file_name or "") if c.isalnum() or c in "._- ") or "file"
+        # Re-derive from the filename so a legacy row carrying a spoofed stored
+        # content_type can't render inline either; only images + PDF inline, and
+        # nosniff blocks MIME-sniffing an HTML payload out of a .txt/.csv/.zip
+        # (QC 2026-08-08 stored-XSS fix).
+        media_type = _trusted_content_type(att.file_name)
+        disposition = "inline" if media_type in _INLINE_SAFE_TYPES else "attachment"
         return StreamingResponse(
             BytesIO(data),
-            media_type=att.content_type or "application/octet-stream",
-            headers={"Content-Disposition": f'inline; filename="{safe}"'},
+            media_type=media_type,
+            headers={
+                "Content-Disposition": f'{disposition}; filename="{safe}"',
+                "X-Content-Type-Options": "nosniff",
+            },
         )
 
     # OneDrive fallback — redirect

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -6,7 +6,11 @@
    (input-focus / .btn / .card — see styles.css).
 #}
 
-<div class="page-fluid" x-data="{ selectedIds: new Set(), rStatus: '{{ status }}', rSort: '{{ sort }}', rDir: '{{ dir }}', collapsed: $persist({}).as('saleshub-group-collapse') }">
+<div class="page-fluid"
+     {# XSS fix (QC 2026-08-08): filter params seed Alpine state via data-* /
+        $el.dataset (HTML-escaped, never evaluated), not single-quoted interpolation. #}
+     data-status="{{ status }}" data-sort="{{ sort }}" data-dir="{{ dir }}"
+     x-data="{ selectedIds: new Set(), rStatus: $el.dataset.status, rSort: $el.dataset.sort, rDir: $el.dataset.dir, collapsed: $persist({}).as('saleshub-group-collapse') }">
 
   {# Refresh hook — the create-requisition modal fires `reqListRefresh` on success; on this
      surface (no #parts-list) reload the list into #main-content so the new req appears. #}
@@ -160,7 +164,7 @@
         <span class="text-xs text-gray-600 self-center mr-1">Urgency:</span>
         <input type="hidden" name="urgency" value="{{ urgency }}">
         {% for u_val, u_label in [('hot', 'Hot'), ('critical', 'Critical')] %}
-        <button type="button" x-data="{ active: '{{ urgency }}' === '{{ u_val }}' }"
+        <button type="button" data-urgency="{{ urgency }}" x-data="{ active: $el.dataset.urgency === '{{ u_val }}' }"
                 @click="let inp=$el.closest('form').querySelector('[name=urgency]'); inp.value = inp.value==='{{ u_val }}' ? '' : '{{ u_val }}'; active=inp.value==='{{ u_val }}'; htmx.trigger($el.closest('form').querySelector('[name=q]'), 'changed')"
                 :class="active ? '{{ 'bg-amber-100 text-amber-700' if u_val == 'hot' else 'bg-rose-100 text-rose-700' }}' : 'bg-white text-gray-700 border border-gray-200 hover:bg-accent-50'"
                 class="px-3 py-1 text-xs font-medium rounded-full transition-colors">

--- a/app/templates/htmx/partials/search/vendor_card.html
+++ b/app/templates/htmx/partials/search/vendor_card.html
@@ -23,10 +23,14 @@
   <div class="min-w-0">
     <div class="flex items-center gap-1.5 flex-wrap">
       {# Shortlist checkbox — at the row-left (existing $store.shortlist). #}
+      {# XSS fix (QC 2026-08-08): external vendor_name/mpn/source_type flow through
+         data-* (HTML-escaped, never evaluated) and are read via $el.dataset —
+         single-quoted Alpine interpolation was HTML-decode-then-eval injectable. #}
       <input aria-label="Shortlist {{ card.vendor_name }}" type="checkbox"
              class="accent-brand-500 mr-1"
-             :checked="$store.shortlist.has('{{ card.vendor_name }}', '{{ card.mpn_matched }}')"
-             @change="$store.shortlist.toggle({vendor_name: '{{ card.vendor_name }}', mpn: '{{ card.mpn_matched }}', unit_price: {{ card.unit_price or 0 }}, qty_available: {{ card.qty_available or 0 }}, source_type: '{{ card.source_type }}'})">
+             data-vn="{{ card.vendor_name }}" data-mpn="{{ card.mpn_matched }}" data-st="{{ card.source_type }}"
+             :checked="$store.shortlist.has($el.dataset.vn, $el.dataset.mpn)"
+             @change="$store.shortlist.toggle({vendor_name: $el.dataset.vn, mpn: $el.dataset.mpn, unit_price: {{ card.unit_price or 0 }}, qty_available: {{ card.qty_available or 0 }}, source_type: $el.dataset.st})">
       <span class="lg:hidden h-2.5 w-2.5 rounded-full {% if conf == 'green' %}bg-emerald-500{% elif conf == 'amber' %}bg-amber-500{% else %}bg-rose-500{% endif %}"></span>
       <span class="text-sm font-semibold text-brand-900 truncate">{{ card.vendor_name }}</span>
       {% if card.is_authorized %}

--- a/tests/test_approval_events.py
+++ b/tests/test_approval_events.py
@@ -183,6 +183,8 @@ def test_decide_writes_exactly_one_activity_log(db_session, open_request, approv
 def test_reassign_marks_from_recipient_reassigned(db_session, open_request, approver, delegate):
     """Reassign() sets the from-user's recipient status to REASSIGNED with
     reassigned_to_id."""
+    delegate.can_approve_prepayments = True  # QC 2026-08-08: reassign target must be eligible
+    db_session.flush()
     reassign(db_session, open_request.id, from_user=approver, to_user=delegate, actor=approver)
 
     from_recipient = db_session.execute(
@@ -199,6 +201,8 @@ def test_reassign_marks_from_recipient_reassigned(db_session, open_request, appr
 
 def test_reassign_adds_new_pending_recipient(db_session, open_request, approver, delegate):
     """Reassign() adds a new PENDING recipient row for to_user."""
+    delegate.can_approve_prepayments = True  # QC 2026-08-08: reassign target must be eligible
+    db_session.flush()
     reassign(db_session, open_request.id, from_user=approver, to_user=delegate, actor=approver)
 
     new_recipient = db_session.execute(
@@ -215,6 +219,8 @@ def test_reassign_adds_new_pending_recipient(db_session, open_request, approver,
 
 def test_reassign_records_event(db_session, open_request, approver, delegate):
     """Reassign() records one ApprovalEvent + one ActivityLog."""
+    delegate.can_approve_prepayments = True  # QC 2026-08-08: reassign target must be eligible
+    db_session.flush()
     reassign(db_session, open_request.id, from_user=approver, to_user=delegate, actor=approver)
     events = (
         db_session.execute(select(ApprovalEvent).where(ApprovalEvent.request_id == open_request.id)).scalars().all()

--- a/tests/test_qc_security_cluster.py
+++ b/tests/test_qc_security_cluster.py
@@ -1,0 +1,222 @@
+"""tests/test_qc_security_cluster.py — QC 2026-08-08 cluster 3 regressions.
+
+- Attachment stored-XSS: served content type is derived from the (validated)
+  extension, never the attacker-controlled client header; non-image/pdf types
+  download with X-Content-Type-Options: nosniff.
+- Approvals reassign() authority: a slot may only be handed to a user genuinely
+  eligible for the gate at the amount.
+- Approvals decide() prepayment lifecycle: a prepayment decided through the
+  engine is stamped APPROVED + pay_token (or VOID), not left 'requested'.
+
+The two XSS template fixes are structural (data-* + $el.dataset); their inertness
+is proven in the QC session against the app Jinja env — asserted here at the
+template-render level for the requisitions filter params.
+
+Called by: pytest autodiscovery
+Depends on: conftest fixtures (db_session, test_user)
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.attachment_service import _INLINE_SAFE_TYPES, _trusted_content_type
+from tests.conftest import engine  # noqa: F401
+
+# ── Attachment stored-XSS ────────────────────────────────────────────────
+
+
+def test_content_type_is_extension_derived_not_client_supplied():
+    # A .csv the attacker labeled text/html serves as text/csv, and CSV is not
+    # inline-safe, so it downloads.
+    assert _trusted_content_type("evil.csv") == "text/csv"
+    assert "text/csv" not in _INLINE_SAFE_TYPES
+    # .txt with HTML content likewise never renders as HTML.
+    assert _trusted_content_type("payload.txt") == "text/plain"
+    assert "text/plain" not in _INLINE_SAFE_TYPES
+
+
+def test_only_images_and_pdf_are_inline_safe():
+    for name, ct in [("a.pdf", "application/pdf"), ("b.png", "image/png"), ("c.jpg", "image/jpeg")]:
+        assert _trusted_content_type(name) == ct
+        assert ct in _INLINE_SAFE_TYPES
+
+
+def test_unknown_extension_falls_back_to_octet_stream():
+    assert _trusted_content_type("weird.svg") == "application/octet-stream"
+    assert _trusted_content_type(None) == "application/octet-stream"
+
+
+# ── XSS template inertness (requisitions filter params) ──────────────────
+
+
+def test_requisitions_filter_params_render_inert_in_data_attribute():
+    from app.template_env import templates
+
+    env = templates.env
+    payload = "'; alert(document.cookie); //"
+    rendered = env.from_string('data-status="{{ status }}"').render(status=payload)
+    # HTML-escaped in the attribute — no raw quote to break out of; $el.dataset
+    # reads it as a pure string, never evaluated.
+    assert "alert(document.cookie)" in rendered
+    assert "&#39;" in rendered
+    assert "data-status=\"'" not in rendered  # the breakout quote never appears raw
+
+
+# ── Approvals reassign() authority ───────────────────────────────────────
+
+
+def _approver(db, email, azure, *, prepay=True, limit=None):
+    from app.models import User
+
+    u = User(
+        email=email,
+        name=email.split("@")[0],
+        role="manager",
+        azure_id=azure,
+        is_active=True,
+        can_approve_prepayments=prepay,
+        prepayment_approval_limit=limit,
+        created_at=datetime.now(UTC),
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _prepayment_request(db, requester, amount):
+    from app.constants import BuyPlanLineStatus, PaymentMethod
+    from app.models import Company, CustomerSite, Quote, Requisition
+    from app.models.buy_plan import BuyPlan, BuyPlanLine
+    from app.services.prepayment_service import create_prepayment
+
+    company = Company(name="Test Co", is_active=True, created_at=datetime.now(UTC))
+    db.add(company)
+    db.flush()
+    site = CustomerSite(company_id=company.id, site_name="HQ")
+    db.add(site)
+    db.flush()
+    req = Requisition(name="REQ-QC", customer_name="Test Co", status="active", created_by=requester.id)
+    db.add(req)
+    db.flush()
+    quote = Quote(
+        requisition_id=req.id,
+        customer_site_id=site.id,
+        quote_number="Q-QC-1",
+        status="sent",
+        line_items=[],
+        subtotal=Decimal("1000"),
+        total_cost=Decimal("800"),
+        total_margin_pct=Decimal("20"),
+        created_by_id=requester.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(quote)
+    db.flush()
+    bp = BuyPlan(quote_id=quote.id, requisition_id=req.id, status="draft", so_status="pending")
+    db.add(bp)
+    db.flush()
+    line = BuyPlanLine(
+        buy_plan_id=bp.id,
+        status=BuyPlanLineStatus.PENDING_VERIFY.value,
+        unit_cost=10.0,
+        quantity=10,
+        po_number="PO-QC-1",
+        po_confirmed_at=datetime.now(UTC),
+    )
+    db.add(line)
+    db.flush()
+    _pp, request = create_prepayment(
+        db,
+        buy_plan_id=bp.id,
+        buy_plan_line_id=line.id,
+        vendor_card_id=None,
+        payment_method=PaymentMethod.WIRE,
+        total_incl_fees=amount,
+        test_report_sent=False,
+        buyer_remarks="x",
+        created_by=requester,
+    )
+    db.commit()
+    return request, _pp
+
+
+def test_reassign_refuses_ineligible_target(db_session, test_user):
+    from app.services.approvals.events import reassign
+
+    eligible = _approver(db_session, "e@trioscs.com", "az-e", prepay=True)
+    ineligible = _approver(db_session, "i@trioscs.com", "az-i", prepay=False)
+    db_session.commit()
+    request, _pp = _prepayment_request(db_session, test_user, Decimal("400"))
+
+    with pytest.raises(ValueError, match="not eligible to approve gate"):
+        reassign(db_session, request.id, from_user=eligible, to_user=ineligible, actor=test_user)
+
+
+def test_reassign_refuses_target_over_amount_limit(db_session, test_user):
+    from app.services.approvals.events import reassign
+
+    eligible = _approver(db_session, "e2@trioscs.com", "az-e2", prepay=True)
+    capped = _approver(db_session, "c@trioscs.com", "az-c", prepay=True, limit=Decimal("100"))
+    db_session.commit()
+    request, _pp = _prepayment_request(db_session, test_user, Decimal("2500"))
+
+    with pytest.raises(ValueError, match="not eligible to approve gate"):
+        reassign(db_session, request.id, from_user=eligible, to_user=capped, actor=test_user)
+
+
+def test_reassign_allows_eligible_target(db_session, test_user):
+    from app.constants import ApprovalRecipientStatus
+    from app.services.approvals.events import reassign
+
+    a = _approver(db_session, "a@trioscs.com", "az-a", prepay=True)
+    # b is NOT eligible at routing time, so it isn't auto-added as a recipient;
+    # it becomes eligible just before the reassign (the real delegation flow).
+    b = _approver(db_session, "b@trioscs.com", "az-b", prepay=False)
+    db_session.commit()
+    request, _pp = _prepayment_request(db_session, test_user, Decimal("400"))
+
+    b.can_approve_prepayments = True
+    db_session.flush()
+    new_recipient = reassign(db_session, request.id, from_user=a, to_user=b, actor=test_user)
+    assert new_recipient.user_id == b.id
+    assert new_recipient.status == ApprovalRecipientStatus.PENDING
+
+
+# ── decide() stamps the prepayment lifecycle for every path ──────────────
+
+
+def test_decide_approve_stamps_prepayment_and_mints_pay_token(db_session, test_user):
+    from app.constants import PrepaymentStatus
+    from app.models.quality_plan import Prepayment
+    from app.services.approvals.service import decide
+
+    approver = _approver(db_session, "ap@trioscs.com", "az-ap", prepay=True)
+    db_session.commit()
+    request, pp = _prepayment_request(db_session, test_user, Decimal("400"))
+
+    decide(db_session, request.id, approver, "approve", comment=None)
+    db_session.commit()
+
+    fresh = db_session.get(Prepayment, pp.id)
+    assert fresh.status == PrepaymentStatus.APPROVED.value  # no longer stuck 'requested'
+    assert fresh.pay_token  # OK-TO-WIRE link exists
+    assert fresh.approved_by_id == approver.id
+
+
+def test_decide_reject_voids_prepayment(db_session, test_user):
+    from app.constants import PrepaymentStatus
+    from app.models.quality_plan import Prepayment
+    from app.services.approvals.service import decide
+
+    approver = _approver(db_session, "ap2@trioscs.com", "az-ap2", prepay=True)
+    db_session.commit()
+    request, pp = _prepayment_request(db_session, test_user, Decimal("400"))
+
+    decide(db_session, request.id, approver, "reject", comment="bad docs")
+    db_session.commit()
+
+    fresh = db_session.get(Prepayment, pp.id)
+    assert fresh.status == PrepaymentStatus.VOID.value
+    assert fresh.pay_token is None  # never wire a rejected prepayment


### PR DESCRIPTION
QC audit cluster 3 — all high (findings 6–10 in specs/qc-review-2026-08-08.md).

- **Alpine expression-injection XSS** (search vendor_card, requisitions list + urgency): external vendor names and filter params were HTML-escaped into single-quoted Alpine JS-string contexts, then browser-decoded back to quotes and eval'd. Moved to `data-*` attributes read via `$el.dataset` — HTML-escaped, never evaluated; proven inert against the app Jinja env.
- **Attachment stored-XSS:** validation was extension-only and the attacker-controlled `content_type` was stored + served inline same-origin. Serving now derives type from the extension (never the client header), sends `X-Content-Type-Options: nosniff`, and inlines only images + PDF — everything else downloads.
- **Approvals reassign() authority:** granted a PENDING slot to any user with no eligibility/amount-limit check — one reassign could hand wire-approval authority outside the approver set. Now gated by `_eligible_approvers` for the gate + amount before any mutation. Three existing tests encoded the vulnerable behavior and were updated to the secure contract.
- **decide() prepayment dispatch:** ran side effects for BUY_PLAN only, so a prepayment decided via the JSON endpoint closed APPROVED yet stayed 'requested' forever (no pay_token, no OK-TO-WIRE, duplicate guard blocking re-request). The lifecycle stamp now lives in decide() so every path is atomic; both routers fan out the notice; HTMX duplicate stamping removed.

**Verification:** new regression cluster + 3 updated tests; affected sweep 2,192 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)