### PR TITLE
fix(deploy): CI gate matches matrix shards + DB-aware rollback (QC cluster 4)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,23 +17,35 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -uo pipefail
-          # Echo a check's status (if running) or conclusion (if completed),
-          # or empty if it has not reported for this commit yet.
-          check_state() {
+          # Aggregate state across EVERY check-run whose name is BASE or a matrix
+          # shard "BASE (N)". QC 2026-08-08: the test job is a 2-way matrix, so
+          # GitHub emits "test (0)" / "test (1)" — the old exact-match on "test"
+          # found nothing, so `T` stayed missing and every release-published
+          # deploy waited the full window then refused. Returns:
+          #   success  — >=1 matching run, all completed, all success
+          #   failure  — any matching run in a failing terminal state
+          #   pending  — none reported yet, or some still running
+          agg_state() {
             gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
-              --jq ".check_runs[] | select(.name==\"$1\") | (if .status!=\"completed\" then .status else .conclusion end)" \
-              2>/dev/null | head -1
+              --jq ".check_runs[] | select(.name==\"$1\" or (.name|startswith(\"$1 (\"))) | (if .status!=\"completed\" then \"pending\" else .conclusion end)" \
+              2>/dev/null \
+            | awk '
+                { n++
+                  if ($0=="failure"||$0=="cancelled"||$0=="timed_out"||$0=="action_required"||$0=="stale") bad=1
+                  if ($0!="success") notdone=1 }
+                END { if (n==0) print "pending"; else if (bad) print "failure"; else if (notdone) print "pending"; else print "success" }'
           }
-          # NOTE: check-runs are named after the JOB (test, security), not the
-          # workflow ("CI — Tests" / "Security Scanning"). Match the job names.
+          # Match the JOB names (test, security), not the workflow display names.
           for attempt in $(seq 1 40); do
-            T=$(check_state "test")
-            S=$(check_state "security")
-            echo "attempt $attempt — test=${T:-missing}  security=${S:-missing}"
-            case "$T" in failure|cancelled|timed_out|action_required|stale)
-              echo "ERROR: 'CI — Tests' for $SHA = $T — refusing to deploy." >&2; exit 1;; esac
-            case "$S" in failure|cancelled|timed_out|action_required|stale)
-              echo "ERROR: 'Security Scanning' for $SHA = $S — refusing to deploy." >&2; exit 1;; esac
+            T=$(agg_state "test")
+            S=$(agg_state "security")
+            echo "attempt $attempt — test=$T  security=$S"
+            if [ "$T" = failure ]; then
+              echo "ERROR: 'CI — Tests' shards for $SHA = failure — refusing to deploy." >&2; exit 1
+            fi
+            if [ "$S" = failure ]; then
+              echo "ERROR: 'Security Scanning' for $SHA = failure — refusing to deploy." >&2; exit 1
+            fi
             if [ "$T" = success ] && [ "$S" = success ]; then
               echo "All required checks green for $SHA — deploy may proceed."
               exit 0

--- a/deploy.sh
+++ b/deploy.sh
@@ -119,6 +119,14 @@ else
     echo "==> No running app container found — no rollback target (first deploy?)."
 fi
 
+# Capture the DB's alembic revision BEFORE the new container migrates on startup.
+# QC 2026-08-08: a migration-bearing deploy that then fails health used to roll
+# back only the app IMAGE, leaving the DB at the NEW head — the old image's
+# entrypoint `alembic upgrade head` then hits "Can't locate revision" and crash
+# loops. On rollback we downgrade the DB back to this revision first.
+PREV_DB_REVISION="$(docker compose exec -T db sh -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB" -tAc "select version_num from alembic_version"' 2>/dev/null | tr -d '[:space:]' || true)"
+echo "==> Recorded pre-deploy DB revision for rollback: ${PREV_DB_REVISION:-unknown}"
+
 # rollback_app: restore the previously-running app image and recreate the container
 # from it, then re-wait for health. Idempotent (safe to run even if the tag already
 # resolves to the previous image) and best-effort (each fallible step is guarded so the
@@ -130,6 +138,23 @@ rollback_app() {
         echo "==> ROLLBACK: no previous app image was recorded — cannot roll back automatically." >&2
         echo "==>          The failed container is left running for inspection; fix and redeploy." >&2
         return 1
+    fi
+    # DB first (QC 2026-08-08): if the failed deploy advanced the schema, downgrade
+    # it back to the pre-deploy revision using the NEW image's alembic (still the
+    # tagged `app` image at this point — it alone has the new migration files),
+    # so the restored OLD image's `alembic upgrade head` finds a revision it knows
+    # instead of crash-looping on "Can't locate revision".
+    if [ -n "$PREV_DB_REVISION" ]; then
+        CUR_DB_REVISION="$(docker compose exec -T db sh -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB" -tAc "select version_num from alembic_version"' 2>/dev/null | tr -d '[:space:]' || true)"
+        if [ -n "$CUR_DB_REVISION" ] && [ "$CUR_DB_REVISION" != "$PREV_DB_REVISION" ]; then
+            echo "==> ROLLBACK: DB advanced ${PREV_DB_REVISION} -> ${CUR_DB_REVISION}; downgrading before restoring the old image."
+            if ! docker compose run --rm --no-deps app alembic downgrade "$PREV_DB_REVISION"; then
+                echo "==> ROLLBACK CRITICAL: DB downgrade to ${PREV_DB_REVISION} FAILED — do NOT restart the old image (it will crash-loop); manual intervention required." >&2
+                return 1
+            fi
+        fi
+    else
+        echo "==> ROLLBACK WARNING: no pre-deploy DB revision recorded — if this deploy ran a migration, the old image may crash-loop; verify alembic_version manually." >&2
     fi
     echo "==> ROLLBACK: restoring previous app image ${PREV_APP_IMAGE_REF} -> ${PREV_APP_IMAGE_ID}"
     # Re-point the compose image tag back to the previous image, then force-recreate the

--- a/tests/test_qc_deploy_nets.py
+++ b/tests/test_qc_deploy_nets.py
@@ -79,8 +79,17 @@ def test_gate_matches_matrix_shard_names():
     assert 'select(.name==\\"$1\\") | (if .status' not in text
 
 
-def test_deploy_yml_parses():
-    assert yaml.safe_load(DEPLOY_YML.read_text()) is not None
+def test_deploy_yml_structure_intact():
+    """The gate edit must keep deploy.yml a valid workflow with the verify-ci gate still
+    guarding the deploy job."""
+    wf = yaml.safe_load(DEPLOY_YML.read_text())
+    jobs = wf["jobs"]
+    assert "verify-ci" in jobs, "the CI gate job was removed"
+    assert "deploy" in jobs, "the deploy job was removed"
+    # The deploy job must still depend on the gate (needs: verify-ci).
+    needs = jobs["deploy"].get("needs")
+    needs = [needs] if isinstance(needs, str) else (needs or [])
+    assert "verify-ci" in needs, "deploy no longer waits on the CI gate"
 
 
 def test_rollback_is_db_aware():

--- a/tests/test_qc_deploy_nets.py
+++ b/tests/test_qc_deploy_nets.py
@@ -1,0 +1,100 @@
+"""tests/test_qc_deploy_nets.py — QC 2026-08-08 cluster 4 (deploy safety nets).
+
+Both nets were broken-on-use:
+- deploy.yml verify-ci exact-matched a check named "test", but the CI test job
+  is a 2-way matrix, so GitHub emits "test (0)"/"test (1)" — the gate matched
+  nothing, waited the full window, then refused EVERY release-published deploy.
+- deploy.sh rollback restored the old app IMAGE but not the DB; after a
+  migration-bearing deploy the old image's `alembic upgrade head` hit
+  "Can't locate revision" and crash-looped.
+
+The gate's aggregation is shell awk, tested here behaviorally; the DB-aware
+rollback is asserted by content (its live path needs docker + a failed deploy).
+
+Called by: pytest autodiscovery
+Depends on: PyYAML, the workflow + deploy.sh files, bash + awk on PATH.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+DEPLOY_YML = REPO / ".github" / "workflows" / "deploy.yml"
+DEPLOY_SH = REPO / "deploy.sh"
+
+
+def _agg_awk() -> str:
+    """Extract the agg_state awk program from deploy.yml (single source of truth).
+
+    The awk body contains no single-quote, so the first \' after \"awk \'\" is the
+    terminating quote.
+    """
+    text = DEPLOY_YML.read_text()
+    m = re.search(r"awk '(.*?)'", text, re.DOTALL)
+    assert m, "agg_state awk program not found in deploy.yml"
+    return "awk '" + m.group(1) + "'"
+
+
+def _run_agg(states: list[str]) -> str:
+    prog = _agg_awk()
+    proc = subprocess.run(
+        ["bash", "-c", f"printf '%s\\n' {' '.join(repr(s) for s in states)} | {prog}"],
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+@pytest.mark.skipif(not shutil.which("awk"), reason="awk required")
+class TestGateAggregation:
+    def test_all_success_is_success(self):
+        assert _run_agg(["success", "success"]) == "success"
+
+    def test_any_failure_is_failure(self):
+        assert _run_agg(["success", "failure"]) == "failure"
+        assert _run_agg(["cancelled", "success"]) == "failure"
+        assert _run_agg(["timed_out"]) == "failure"
+
+    def test_any_pending_is_pending(self):
+        assert _run_agg(["success", "pending"]) == "pending"
+
+    def test_no_runs_is_pending_not_success(self):
+        # The old bug: zero matching runs must NEVER read as green.
+        assert _run_agg([]) == "pending"
+
+    def test_single_success_is_success(self):
+        assert _run_agg(["success"]) == "success"
+
+
+def test_gate_matches_matrix_shard_names():
+    """The jq selector must accept BASE and 'BASE (N)' shard names, not only exact."""
+    text = DEPLOY_YML.read_text()
+    assert 'startswith(\\"$1 (\\")' in text, "gate no longer matches matrix shard check names"
+    # And it must not have regressed to the exact-only matcher.
+    assert 'select(.name==\\"$1\\") | (if .status' not in text
+
+
+def test_deploy_yml_parses():
+    assert yaml.safe_load(DEPLOY_YML.read_text()) is not None
+
+
+def test_rollback_is_db_aware():
+    """Rollback must capture the pre-deploy revision and downgrade before restoring the
+    old image (else the old entrypoint crash-loops)."""
+    text = DEPLOY_SH.read_text()
+    assert "PREV_DB_REVISION=" in text, "pre-deploy DB revision is not captured"
+    assert "alembic downgrade" in text, "rollback never downgrades the DB"
+    # Ordering: the downgrade must precede the image re-tag in rollback_app.
+    downgrade_at = text.index("alembic downgrade")
+    retag_at = text.index('docker tag "$PREV_APP_IMAGE_ID"')
+    assert downgrade_at < retag_at, "DB downgrade must run BEFORE restoring the old image"
+
+
+def test_deploy_sh_syntax_valid():
+    proc = subprocess.run(["bash", "-n", str(DEPLOY_SH)], capture_output=True, text=True)
+    assert proc.returncode == 0, f"deploy.sh syntax error: {proc.stderr}"


### PR DESCRIPTION
QC audit cluster 4 — both high, both safety nets broken-on-use (findings 25–26 in specs/qc-review-2026-08-08.md).

- **Release CI gate never passes:** verify-ci exact-matched a check named `test`, but the CI test job is a 2-way matrix, so GitHub emits `test (0)`/`test (1)`. The gate matched nothing, waited its full window, then refused every release-published deploy (the draft v3.1.0 would have hit it). The gate now aggregates state across every check-run named `BASE` or `BASE (N)` — green only when ≥1 present and all completed success; zero runs read as pending, never green.
- **Rollback crash-loops after a migration deploy:** `deploy.sh` restored the previous app image but left the DB at the new head, so the old image's `alembic upgrade head` hit "Can't locate revision" and crash-looped. Rollback now captures the pre-deploy DB revision and, if the schema advanced, downgrades the DB back to it using the new image's alembic (which alone has the new migration files) before restoring the old image; a failed downgrade aborts the restore instead of crash-looping.

**Verification:** the gate's aggregation awk is extracted from deploy.yml and run behaviorally (all-success/any-failure/any-pending/zero-runs-not-green); content + ordering guards assert the shard matcher and the downgrade-before-retag sequence; deploy.sh syntax validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)