### PR TITLE
fix(jobs/cache): picks-cache no-op, xdist root cause, dedup loop-block, classify durability, $0 guard (QC cluster 5)

### DIFF
--- a/app/jobs/maintenance_jobs.py
+++ b/app/jobs/maintenance_jobs.py
@@ -5,6 +5,8 @@ Called by: app/jobs/__init__.py via register_maintenance_jobs()
 Depends on: app.database, app.models, app.services.*
 """
 
+import asyncio
+
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
@@ -94,7 +96,14 @@ async def _job_auto_dedup():
 
     db = SessionLocal()
     try:
-        stats = run_auto_dedup(db)
+        # QC 2026-08-08: run_auto_dedup is SYNC and makes sequential Claude calls
+        # (via _run_coro_sync, which .result()-blocks the calling thread up to
+        # ~90s each, uncapped). Called directly it froze the whole event loop and
+        # every other job/request. Run it off the loop in a thread — inside that
+        # thread _run_coro_sync sees no running loop and uses asyncio.run
+        # directly — bounded by a hard timeout so a hung batch can't run forever.
+        loop = asyncio.get_running_loop()
+        stats = await asyncio.wait_for(loop.run_in_executor(None, run_auto_dedup, db), timeout=900)
         total = stats["vendors_merged"] + stats["companies_merged"]
         if total:
             logger.info(

--- a/app/services/part_equivalence.py
+++ b/app/services/part_equivalence.py
@@ -242,11 +242,17 @@ async def classify_new_pairs(db: Session, spellings_by_key: dict[str, str], *, l
                     source="ai",
                 )
             )
+            # Commit each verdict as it lands (QC 2026-08-08): the scan job caps
+            # this pass with a hard timeout, and a single end-of-loop commit
+            # discarded every already-paid Claude verdict when the timeout fired
+            # mid-pass — then re-paid the identical calls next run. Per-verdict
+            # commits make paid work durable.
+            db.commit()
             stored += 1
         except Exception as exc:  # noqa: BLE001 — model down ≠ matching broken; pair retries next pass
+            db.rollback()
             logger.warning("Part-equivalence classification failed for {} / {}: {}", raw_a, raw_b, exc)
     if stored:
-        db.commit()
         logger.info("Part-equivalence: classified {} new pair(s)", stored)
     return stored
 

--- a/app/services/proactive_matching.py
+++ b/app/services/proactive_matching.py
@@ -52,7 +52,10 @@ _LIVE_STATUSES = [OfferStatus.ACTIVE.value, OfferStatus.APPROVED.value]
 
 # Per-user top-picks cache namespace (proactive_service.get_top_picks) — busted
 # here whenever new matches land so a 24h-cached strip never hides fresh work.
-PICKS_CACHE_PREFIX = "proactive_picks:"
+# QC 2026-08-08: no trailing colon — invalidate_prefix appends ":*", so a
+# trailing colon here produced "intel:proactive_picks::*" which matched
+# nothing and left the 24h picks cache never invalidated.
+PICKS_CACHE_PREFIX = "proactive_picks"
 
 
 def _bust_picks_cache() -> None:

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -236,7 +236,10 @@ def get_match_count(db: Session, user_id: int) -> int:
     )
 
 
-PICKS_CACHE_PREFIX = "proactive_picks:"
+# QC 2026-08-08: no trailing colon — invalidate_prefix appends ":*", so a
+# trailing colon here produced "intel:proactive_picks::*" which matched
+# nothing and left the 24h picks cache never invalidated.
+PICKS_CACHE_PREFIX = "proactive_picks"
 
 
 def get_top_picks(db: Session, user_id: int, *, limit: int = 10) -> list[dict]:
@@ -249,7 +252,7 @@ def get_top_picks(db: Session, user_id: int, *, limit: int = 10) -> list[dict]:
     from ..cache.intel_cache import get_cached, set_cached
     from .proactive_matching import compute_offer_rollups
 
-    cache_key = f"{PICKS_CACHE_PREFIX}{user_id}"
+    cache_key = f"{PICKS_CACHE_PREFIX}:{user_id}"
     cached = get_cached(cache_key)
     if isinstance(cached, dict) and isinstance(cached.get("picks"), list):
         return list(cached["picks"])
@@ -309,7 +312,17 @@ def _build_line_items(matches: list, sell_prices: dict) -> tuple[list, Decimal, 
         if not offer:
             continue
         cost = float(offer.unit_price) if offer.unit_price else 0
-        sell = sell_prices.get(str(m.id), cost * 1.3)
+        # QC 2026-08-08: a missing cost made the default 0*1.3=0, so a draft went
+        # out quoting the customer $0.00. A seeded sell_price (incl. an
+        # intentional 0) is honored; otherwise fall back to cost x 1.3 — and if
+        # there is NO price basis at all (no anchor, no cost) skip the line
+        # rather than stage a priceless offer. The match stays NEW and resurfaces.
+        sell = sell_prices.get(str(m.id))
+        if sell is None:
+            if not cost:
+                logger.warning("Proactive: skipping match {} ({}) — no price basis for a sell price", m.id, m.mpn)
+                continue
+            sell = cost * 1.3
         target = m.requirement.target_qty if m.requirement else 0
         avail = offer.qty_available or 0
         qty = min(avail, target) if target > 0 else avail

--- a/app/utils/async_helpers.py
+++ b/app/utils/async_helpers.py
@@ -48,7 +48,7 @@ async def safe_background_task(
     coro: Coroutine[Any, Any, Any],
     *,
     task_name: str = "background_task",
-    suppress_in_testing: bool = False,
+    suppress_in_testing: bool = True,
 ) -> None:
     """Fire-and-forget an async coroutine with error isolation.
 
@@ -70,10 +70,17 @@ async def safe_background_task(
         internally via hold_bg_task(), so no caller needs it back.
     """
     # Under the test suite, fire-and-forget tasks that open real async DB sessions
-    # cause nondeterministic xdist worker segfaults during teardown.  Close the
+    # cause nondeterministic xdist worker segfaults during teardown. Close the
     # coroutine immediately (suppresses "coroutine never awaited" warnings) and
     # schedule a trivial no-op task instead. Production (TESTING unset) is
     # completely unchanged.
+    # QC 2026-08-08: suppress_in_testing now DEFAULTS to True (see the signature).
+    # The old default False meant only the ~3 call sites that opted in were
+    # safe; the rest ran real coroutines that opened async DB sessions and
+    # crashed xdist workers at teardown, cross-attributing the failure to
+    # whatever test ran next (the long-standing flake). Default-safe fixes every
+    # caller; a test that needs the coroutine to actually run passes
+    # suppress_in_testing=False explicitly.
     if suppress_in_testing and os.environ.get("TESTING"):
         coro.close()
 

--- a/tests/test_async_helpers.py
+++ b/tests/test_async_helpers.py
@@ -30,7 +30,7 @@ async def test_happy_path_completes():
         return 42
 
     before = set(async_helpers._bg_tasks)
-    await safe_background_task(_work(), task_name="test_happy")
+    await safe_background_task(_work(), task_name="test_happy", suppress_in_testing=False)
     task = _new_task(before)
     result = await task
     assert result == 42
@@ -47,7 +47,7 @@ async def test_exception_is_caught_and_logged():
             raise ValueError("kaboom")
 
         before = set(async_helpers._bg_tasks)
-        await safe_background_task(_boom(), task_name="test_boom")
+        await safe_background_task(_boom(), task_name="test_boom", suppress_in_testing=False)
         task = _new_task(before)
         result = await task
         assert result is None
@@ -64,7 +64,7 @@ async def test_cancellation_is_reraised():
         await asyncio.sleep(100)
 
     before = set(async_helpers._bg_tasks)
-    await safe_background_task(_slow(), task_name="test_cancel")
+    await safe_background_task(_slow(), task_name="test_cancel", suppress_in_testing=False)
     task = _new_task(before)
     await asyncio.sleep(0)  # Let the task start running before cancelling
     task.cancel()
@@ -143,7 +143,7 @@ async def test_cancellation_logged():
             await asyncio.sleep(100)
 
         before = set(async_helpers._bg_tasks)
-        await safe_background_task(_slow(), task_name="cancel_log_test")
+        await safe_background_task(_slow(), task_name="cancel_log_test", suppress_in_testing=False)
         task = _new_task(before)
         await asyncio.sleep(0)  # Let the task start running before cancelling
         task.cancel()

--- a/tests/test_qc_jobs_cache.py
+++ b/tests/test_qc_jobs_cache.py
@@ -1,0 +1,169 @@
+"""tests/test_qc_jobs_cache.py — QC 2026-08-08 cluster 5 (jobs/loop hygiene + cache).
+
+- Picks cache invalidation was a silent no-op: keys stored as
+  "proactive_picks:<id>" but invalidate_prefix("proactive_picks:") built the
+  pattern "intel:proactive_picks::*" (double colon) and matched nothing, so
+  the 24h strip never refreshed after a scan.
+- xdist root cause: safe_background_task's TESTING suppression was gated by a
+  per-caller flag set at only ~3 of ~17 sites; the rest crashed workers at
+  teardown. Suppression now DEFAULTS to on under TESTING.
+- Auto-dedup ran synchronous Claude calls on the event loop (app freeze); it
+  now runs off-loop with a timeout.
+- part_equivalence classify commits per verdict (no re-paying Claude on timeout).
+- Proactive never stages a $0.00 sell price.
+
+Called by: pytest autodiscovery
+Depends on: conftest fixtures (db_session).
+"""
+
+import asyncio
+import inspect
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.conftest import engine  # noqa: F401
+
+# ── Picks cache invalidation no longer a no-op ───────────────────────────
+
+
+def test_picks_prefix_has_no_trailing_colon():
+    # invalidate_prefix appends ":*"; a trailing colon here would double it and
+    # match nothing.
+    from app.services import proactive_matching, proactive_service
+
+    assert proactive_matching.PICKS_CACHE_PREFIX == "proactive_picks"
+    assert proactive_service.PICKS_CACHE_PREFIX == "proactive_picks"
+
+
+def test_bust_picks_pattern_matches_stored_key():
+    from app.cache.intel_cache import _REDIS_PREFIX
+    from app.services.proactive_matching import PICKS_CACHE_PREFIX
+
+    stored_key = f"{_REDIS_PREFIX}{PICKS_CACHE_PREFIX}:42"  # what set_cached writes
+    pattern = f"{_REDIS_PREFIX}{PICKS_CACHE_PREFIX}:*"  # what invalidate_prefix builds
+    import fnmatch
+
+    assert fnmatch.fnmatch(stored_key, pattern), "invalidation pattern must match the stored key"
+
+
+# ── xdist root cause: unconditional TESTING suppression ──────────────────
+
+
+@pytest.mark.anyio
+async def test_safe_background_task_suppresses_under_testing_without_flag():
+    """A real coroutine (no suppress flag) must NOT run under TESTING — that was the
+    worker-crash source."""
+    from app.utils.async_helpers import safe_background_task
+
+    ran = False
+
+    async def _real_work():
+        nonlocal ran
+        ran = True
+
+    # Default suppress_in_testing=True now — the OLD default (False) would run it.
+    await safe_background_task(_real_work(), task_name="qc_probe")
+    await asyncio.sleep(0)
+    assert ran is False, "fire-and-forget task must be suppressed under TESTING regardless of the flag"
+
+
+# ── Auto-dedup runs off the event loop ───────────────────────────────────
+
+
+def test_auto_dedup_job_offloads_to_executor():
+    import app.jobs.maintenance_jobs as mj
+
+    src = inspect.getsource(mj._job_auto_dedup)
+    assert "run_in_executor" in src or "to_thread" in src, "dedup must not run on the event loop"
+    assert "wait_for" in src, "dedup must be bounded by a timeout"
+
+
+# ── classify commits per verdict ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_classify_commits_each_verdict(db_session):
+    from app.models import PartEquivalence
+    from app.services.part_equivalence import classify_new_pairs
+
+    commits = {"n": 0}
+    real_commit = db_session.commit
+
+    def counting_commit():
+        commits["n"] += 1
+        return real_commit()
+
+    with patch(
+        "app.utils.claude_client.claude_json",
+        new_callable=AsyncMock,
+        return_value={"verdict": "same", "confidence": 0.9, "reason": "pkg"},
+    ):
+        with patch.object(db_session, "commit", side_effect=counting_commit):
+            stored = await classify_new_pairs(db_session, {"gsot36c": "GSOT36C", "gsot36ce308": "GSOT36C-E3-08"})
+    assert stored == 1
+    assert commits["n"] >= 1  # committed as it went, not deferred to one end commit
+    assert db_session.query(PartEquivalence).count() == 1
+
+
+# ── never stage a $0 sell price ──────────────────────────────────────────
+
+
+def test_priceless_line_is_skipped_not_zero_priced(db_session):
+    from app.models import Offer, ProactiveMatch, Requirement, Requisition, User
+    from app.services.proactive_service import _build_line_items
+
+    user = User(email="r@x.com", name="R", role="sales", azure_id="az-qc5")
+    db_session.add(user)
+    db_session.flush()
+    req = Requisition(name="rq", status="open", created_by=user.id)
+    db_session.add(req)
+    db_session.flush()
+    requirement = Requirement(requisition_id=req.id, primary_mpn="ZEROPART", target_qty=10)
+    db_session.add(requirement)
+    db_session.flush()
+    # Offer with NO unit_price → no price basis at all.
+    offer = Offer(vendor_name="V", mpn="ZEROPART", qty_available=100, unit_price=None, status="active")
+    db_session.add(offer)
+    db_session.flush()
+    m = ProactiveMatch(
+        offer_id=offer.id,
+        requirement_id=requirement.id,
+        salesperson_id=user.id,
+        mpn="ZEROPART",
+        status="new",
+    )
+    m.offer = offer
+    m.requirement = requirement
+
+    line_items, total_sell, _ = _build_line_items([m], {})
+    assert line_items == []  # priceless line skipped, not staged at $0
+    assert total_sell == Decimal("0")
+
+
+def test_priced_line_still_builds(db_session):
+    from app.models import Offer, ProactiveMatch, Requirement, Requisition, User
+    from app.services.proactive_service import _build_line_items
+
+    user = User(email="r2@x.com", name="R2", role="sales", azure_id="az-qc5b")
+    db_session.add(user)
+    db_session.flush()
+    req = Requisition(name="rq2", status="open", created_by=user.id)
+    db_session.add(req)
+    db_session.flush()
+    requirement = Requirement(requisition_id=req.id, primary_mpn="PRICED", target_qty=10)
+    db_session.add(requirement)
+    db_session.flush()
+    offer = Offer(vendor_name="V", mpn="PRICED", qty_available=100, unit_price=Decimal("8.00"), status="active")
+    db_session.add(offer)
+    db_session.flush()
+    m = ProactiveMatch(
+        offer_id=offer.id, requirement_id=requirement.id, salesperson_id=user.id, mpn="PRICED", status="new"
+    )
+    m.offer = offer
+    m.requirement = requirement
+
+    line_items, _, _ = _build_line_items([m], {})
+    assert len(line_items) == 1
+    assert line_items[0]["sell_price"] == pytest.approx(8.0 * 1.3)  # cost x 1.3 fallback

--- a/tests/test_utils_async_helpers.py
+++ b/tests/test_utils_async_helpers.py
@@ -77,8 +77,11 @@ class TestSafeBackgroundTask:
         assert task.get_name() == "my_named_task"
         await task
 
-    async def test_default_suppress_false_runs(self):
-        """Default suppress_in_testing=False runs coro even in TESTING mode."""
+    async def test_default_suppresses_under_testing(self):
+        """QC 2026-08-08: suppress_in_testing now DEFAULTS to True, so an
+        unflagged real coroutine does NOT run under TESTING (the fix for the
+        xdist worker crashes). Callers that need it to run pass
+        suppress_in_testing=False explicitly."""
         result = []
 
         async def my_coro():
@@ -88,7 +91,7 @@ class TestSafeBackgroundTask:
         await safe_background_task(my_coro(), task_name="test")
         task = _new_task(before)
         await task
-        assert result == [1]
+        assert result == []  # suppressed by default under TESTING
 
     async def test_returns_none(self):
         """safe_background_task always returns None (fire-and-forget)."""


### PR DESCRIPTION
QC audit cluster 5 — highs + the long-standing flaky-suite root cause (findings 22–24, 13, + tooling cache/xdist).

- **Picks 24h cache never invalidated:** keys stored as `proactive_picks:<id>` but `invalidate_prefix` appends `:*`, so passing `proactive_picks:` built `intel:proactive_picks::*` (double colon) and matched nothing. Prefix drops the trailing colon; verified with fnmatch.
- **xdist flake ROOT CAUSE:** `safe_background_task`'s TESTING suppression defaulted to False and was set at only ~3 of ~17 sites — the rest ran real coroutines that opened async DB sessions and crashed xdist workers at teardown, blaming whatever test ran next. Default is now True (suppress-by-default); tests that need execution opt in.
- **Auto-dedup froze the app:** it ran sequential Claude calls on the event loop (`.result()`-block); now off-loop in an executor with a 900s timeout.
- **Classify re-paid Claude:** `part_equivalence` committed once at the end, so a mid-pass scan-job timeout discarded already-paid verdicts and re-paid them next run. Now commits per verdict.
- **$0 offers:** a missing cost made the sell price 0*1.3=0; seeded prices are honored, else cost×1.3, and a line with no price basis is skipped rather than sent priceless.

**Verification:** new regression cluster (cache pattern match, suppress-by-default, dedup off-loop, per-verdict commit, priceless-skip) + 5 async_helpers tests updated; cluster-5 affected sweep 1,407 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)