### PR TITLE
fix(P2/D5): a won quote now closes the deal + records revenue

### DIFF
--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -4,8 +4,6 @@ reopen) and pricing history.
 Extracted from routers/crm.py.
 """
 
-from datetime import UTC, datetime
-
 from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
 from sqlalchemy import select
@@ -14,7 +12,7 @@ from sqlalchemy.orm import Session, joinedload
 from ...constants import RESTRICTED_ROLES, QuoteStatus, RequisitionStatus
 from ...database import get_db
 from ...dependencies import require_user
-from ...models import ActivityLog, CustomerSite, Offer, Quote, Requisition, User
+from ...models import CustomerSite, Offer, Quote, Requisition, User
 from ...schemas.crm import QuoteCreate, QuoteReopen, QuoteResult, QuoteSendOverride, QuoteUpdate
 from ...schemas.responses import QuoteDetailResponse
 from ...services.status_machine import require_valid_transition
@@ -479,51 +477,13 @@ async def quote_result(
     quote = get_quote_for_user(db, user, quote_id)
     if not quote:
         raise HTTPException(404, "Quote not found")
-    quote.result = payload.result
-    quote.result_reason = payload.reason
-    quote.result_notes = payload.notes
-    quote.result_at = datetime.now(UTC)
-    require_valid_transition("quote", quote.status, payload.result)
-    quote.status = payload.result
-    if payload.result == QuoteStatus.WON:
-        quote.won_revenue = quote.subtotal
+    # QC 2026-08-10 P2 (process-review D5): both quote-result routes now share
+    # one service so they can't diverge again (the HTMX workspace twin had
+    # stopped closing the requisition + recording won_revenue).
+    from ...services.quote_requisitions import apply_quote_result
+
+    apply_quote_result(db, quote, result=payload.result, reason=payload.reason, notes=payload.notes)
     req = db.get(Requisition, quote.requisition_id)
-    if req:
-        req.status = payload.result
-
-    # Notify requisition creator about quote outcome
-    notify_user_id = req.created_by if req else None
-    if notify_user_id and payload.result in ("won", "lost"):
-        customer = req.customer_name or (req.name if req else "") or ""
-        if payload.result == "won":
-            subj = f"Quote won: {customer} — ${quote.subtotal or 0:,.0f}"
-        else:
-            subj = f"Quote lost: {customer} — {payload.reason or 'no reason'}"
-        # Resolve company_id for activity tracking
-        quote_company_id = None
-        if req and req.customer_site_id:
-            _site = db.get(CustomerSite, req.customer_site_id)
-            if _site:
-                quote_company_id = _site.company_id
-
-        db.add(
-            ActivityLog(
-                user_id=notify_user_id,
-                activity_type=f"quote_{payload.result}",
-                channel="system",
-                requisition_id=req.id if req else None,
-                quote_id=quote.id,
-                contact_name=customer,
-                subject=subj,
-                company_id=quote_company_id,
-            )
-        )
-
-        if quote_company_id:
-            from app.services.activity_service import _update_last_activity
-
-            _update_last_activity({"type": "company", "id": quote_company_id}, db)
-
     db.commit()
     return {
         "ok": True,

--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -579,11 +579,13 @@ async def quote_result_htmx(
     result = form.get("result", "")
     if result not in ("won", "lost"):
         raise HTTPException(400, "Result must be 'won' or 'lost'")
-    quote.result = result
-    require_valid_transition("quote", quote.status, result)
-    quote.status = result
-    quote.result_at = datetime.now(UTC)
-    quote.result_reason = form.get("result_reason", "")
+    # QC 2026-08-10 P2 (process-review D5): use the shared service so a won quote
+    # ALSO closes every contributing requisition + records won_revenue + the
+    # outcome activity — the workspace path used to set only the quote's status,
+    # so the owner's win metrics never recorded the win.
+    from ...services.quote_requisitions import apply_quote_result
+
+    apply_quote_result(db, quote, result=result, reason=form.get("result_reason") or None)
     db.commit()
     logger.info("Quote {} marked as {} by {}", quote.quote_number, result, user.email)
     return await quote_detail_partial(request, quote_id, user, db)

--- a/app/services/quote_requisitions.py
+++ b/app/services/quote_requisitions.py
@@ -175,3 +175,70 @@ def quotes_for_requisition(db: Session, req_id: int) -> Query:
         .join(QuoteRequisition, QuoteRequisition.quote_id == Quote.id)
         .filter(QuoteRequisition.requisition_id == req_id)
     )
+
+
+def apply_quote_result(db: Session, quote, *, result: str, reason: str | None = None, notes: str | None = None) -> None:
+    """Record a won/lost outcome on a quote AND every contributing requisition.
+
+    The SINGLE source of truth for both quote-result routes (the HTMX Approvals
+    workspace and the JSON API). They had diverged: the workspace path set only the
+    quote's status, leaving the requisition open and won_revenue unset — so the owner's
+    win metrics never recorded the win (process-review D5). This also transitions EVERY
+    contributing requisition (combined quotes span several), never clobbering one
+    already WON/LOST, and writes the outcome ActivityLog the JSON twin did.
+
+    Caller commits.
+    """
+    from datetime import UTC, datetime
+
+    from app.constants import QuoteStatus, RequisitionStatus
+    from app.models import ActivityLog, CustomerSite, Requisition
+    from app.services.status_machine import require_valid_transition
+
+    if result not in (QuoteStatus.WON, QuoteStatus.LOST):
+        raise ValueError("Result must be 'won' or 'lost'")
+
+    require_valid_transition("quote", quote.status, result)
+    quote.result = result
+    quote.result_reason = reason
+    quote.result_notes = notes
+    quote.result_at = datetime.now(UTC)
+    quote.status = result
+    if result == QuoteStatus.WON:
+        quote.won_revenue = quote.subtotal
+
+    # Every contributing requisition — combined quotes span 2+. Never clobber one
+    # already terminal.
+    for rid in requisition_ids_for_quote(db, quote.id) or [quote.requisition_id]:
+        req = db.get(Requisition, rid)
+        if req and req.status not in (RequisitionStatus.WON, RequisitionStatus.LOST):
+            req.status = result
+
+    # Outcome notification on the PRIMARY requisition's creator (one row).
+    primary = db.get(Requisition, quote.requisition_id)
+    if primary and primary.created_by:
+        customer = primary.customer_name or primary.name or ""
+        if result == QuoteStatus.WON:
+            subj = f"Quote won: {customer} — ${quote.subtotal or 0:,.0f}"
+        else:
+            subj = f"Quote lost: {customer} — {reason or 'no reason'}"
+        company_id = None
+        if primary.customer_site_id:
+            site = db.get(CustomerSite, primary.customer_site_id)
+            company_id = site.company_id if site else None
+        db.add(
+            ActivityLog(
+                user_id=primary.created_by,
+                activity_type=f"quote_{result}",
+                channel="system",
+                requisition_id=primary.id,
+                quote_id=quote.id,
+                contact_name=customer,
+                subject=subj,
+                company_id=company_id,
+            )
+        )
+        if company_id:
+            from app.services.activity_service import _update_last_activity
+
+            _update_last_activity({"type": "company", "id": company_id}, db)

--- a/tests/test_remediation_p2.py
+++ b/tests/test_remediation_p2.py
@@ -1,0 +1,98 @@
+"""tests/test_remediation_p2.py — QC 2026-08-10 P2 (dead-end states) regressions.
+
+- D5: marking a quote WON closes every contributing requisition AND records
+  won_revenue (the HTMX workspace path used to set only the quote status, so the
+  owner's win metrics never recorded the win). Both quote-result routes now
+  share app.services.quote_requisitions.apply_quote_result.
+
+Called by: pytest autodiscovery
+Depends on: conftest fixtures (db_session, test_user).
+"""
+
+from decimal import Decimal
+
+from tests.conftest import engine  # noqa: F401
+
+
+def _won_quote_setup(db, test_user, *, combined=False):
+    from app.models import CustomerSite, Quote, Requisition
+    from app.models.crm import Company
+
+    company = Company(name="WonCo", is_active=True)
+    db.add(company)
+    db.flush()
+    site = CustomerSite(company_id=company.id, site_name="HQ")
+    db.add(site)
+    db.flush()
+    req = Requisition(
+        name="REQ-WON", customer_name="WonCo", status="quoted", created_by=test_user.id, customer_site_id=site.id
+    )
+    db.add(req)
+    db.flush()
+    quote = Quote(
+        requisition_id=req.id,
+        customer_site_id=site.id,
+        quote_number="Q-WON-1",
+        status="sent",
+        line_items=[],
+        subtotal=Decimal("52500.00"),
+    )
+    db.add(quote)
+    db.flush()
+    extra = None
+    if combined:
+        from app.services.quote_requisitions import link_quote_to_requisitions
+
+        extra = Requisition(name="REQ-WON-2", customer_name="WonCo", status="quoted", created_by=test_user.id)
+        db.add(extra)
+        db.flush()
+        link_quote_to_requisitions(db, quote.id, [req.id, extra.id])
+    return quote, req, extra
+
+
+def test_won_quote_closes_requisition_and_records_revenue(db_session, test_user):
+    from app.constants import QuoteStatus, RequisitionStatus
+    from app.services.quote_requisitions import apply_quote_result
+
+    quote, req, _ = _won_quote_setup(db_session, test_user)
+    apply_quote_result(db_session, quote, result="won", reason=None)
+    db_session.commit()
+
+    db_session.refresh(quote)
+    db_session.refresh(req)
+    assert quote.status == QuoteStatus.WON
+    assert quote.won_revenue == Decimal("52500.00")  # win metric now records
+    assert req.status == RequisitionStatus.WON  # requisition closed, not stranded in QUOTED
+
+
+def test_won_quote_closes_every_contributing_requisition(db_session, test_user):
+    from app.constants import RequisitionStatus
+    from app.services.quote_requisitions import apply_quote_result
+
+    quote, req, extra = _won_quote_setup(db_session, test_user, combined=True)
+    apply_quote_result(db_session, quote, result="won", reason=None)
+    db_session.commit()
+
+    db_session.refresh(req)
+    db_session.refresh(extra)
+    assert req.status == RequisitionStatus.WON
+    assert extra.status == RequisitionStatus.WON  # combined quote closes BOTH
+
+
+def test_lost_quote_records_reason_and_closes_requisition(db_session, test_user):
+    from app.constants import QuoteStatus, RequisitionStatus
+    from app.models import ActivityLog
+    from app.services.quote_requisitions import apply_quote_result
+
+    quote, req, _ = _won_quote_setup(db_session, test_user)
+    apply_quote_result(db_session, quote, result="lost", reason="price too high")
+    db_session.commit()
+
+    db_session.refresh(quote)
+    db_session.refresh(req)
+    assert quote.status == QuoteStatus.LOST
+    assert quote.result_reason == "price too high"
+    assert quote.won_revenue is None  # lost never books revenue
+    assert req.status == RequisitionStatus.LOST
+    act = db_session.query(ActivityLog).filter(ActivityLog.quote_id == quote.id).one()
+    assert act.activity_type == "quote_lost"


### PR DESCRIPTION
**P2 / process-review D5** — a dead-end where a record was silently lost. The HTMX Approvals-workspace quote-result path set **only the quote's status**: it never closed the requisition or set `won_revenue`. So a won deal left its requisition stranded in QUOTED and **the owner's win metrics never recorded the win**. Its JSON twin did the right thing; the two had diverged.

New shared `app.services.quote_requisitions.apply_quote_result` is the single source of truth for both routes: sets result/`won_revenue`, transitions **every** contributing requisition (combined quotes span 2+, never clobbering one already terminal), and writes the outcome ActivityLog + company last-activity touch. Both routers call it, so they can't diverge again.

**Verification:** 3 D5 regression tests (won closes requisition + books revenue; combined quote closes both; lost records reason + no revenue); affected sweep **838 passed**.

The related revision-convention unification (customer-facing quote numbers across 3 implementations) is deferred to its own careful fix. D1 (Testing/Comps manual-complete) and D4 (resell auto-close) are held pending business-rule decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)