### PR TITLE
fix(P2): resell dead-ends — withdraw-line writer (D4b) + close a stranded bid_out list (D4)

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -1789,6 +1789,43 @@ async def resell_close_without_bid(
     return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
 
+@router.post("/api/resell/{list_id}/close-bid-out", response_class=HTMLResponse)
+async def resell_close_bid_out(
+    request: Request,
+    list_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Close a stranded ``bid_out`` list into the terminal ``closed`` state (owner-
+    only).
+
+    QC 2026-08-10 P2/D4: a bid_out list (e.g. after a rejected customer bid) had no
+    exit. The service enforces owner-only + the bid_out guard and refuses while a live
+    offer is still winnable (409).
+    """
+    el = excess_service.close_bid_out_list(db, list_id, user)
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
+@router.post("/api/resell/{list_id}/lines/{line_id}/withdraw", response_class=HTMLResponse)
+async def resell_withdraw_line(
+    request: Request,
+    list_id: int,
+    line_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """Withdraw a posted line (owner or manager/admin) so a partially-sold list can
+    resolve.
+
+    QC 2026-08-10 P2/D4b: ``WITHDRAWN`` had no writer. The service enforces the
+    owner/manager gate and refuses an already-awarded line (409).
+    """
+    excess_service.withdraw_line(db, line_id, user)
+    el = excess_service.get_excess_list(db, list_id)
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
 @router.post("/api/resell/{list_id}/offers", response_class=HTMLResponse)
 async def resell_submit_offer(
     request: Request,

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -1966,6 +1966,89 @@ def close_list_without_bid(db: Session, list_id: int, owner: User) -> ExcessList
     return _end_posting_window(db, list_id, owner, target_status=ExcessListStatus.CLOSED)
 
 
+def withdraw_line(db: Session, line_id: int, user: User) -> ExcessLineItem:
+    """Withdraw a posted resell line — the missing WITHDRAWN writer (QC 2026-08-10
+    P2/D4b).
+
+    ``ExcessLineItemStatus.WITHDRAWN`` existed but nothing ever wrote it, so a line that
+    would never sell could not be taken off the table — and a list only flips to
+    ``awarded`` once EVERY line is decided (awarded or withdrawn), so a partially-sold
+    list stranded in ``bid_out`` forever. Per the owner's decision the LIST OWNER or a
+    manager/admin may withdraw a line. Mirrors ``award_offer``: lock the list, refuse an
+    already-awarded line (unaward first), set WITHDRAWN, recompute the rollup, retire the
+    line from the Sighting live-mirror, then re-derive the list status. Idempotent on an
+    already-withdrawn line. Commits.
+    """
+    from ..dependencies import is_manager_or_admin
+
+    line = db.get(ExcessLineItem, line_id)
+    if not line:
+        raise HTTPException(404, f"ExcessLineItem {line_id} not found")
+    excess_list = get_excess_list(db, line.excess_list_id)
+    if not (excess_list.owner_id == user.id or is_manager_or_admin(user)):
+        raise HTTPException(403, "Only the list owner or a manager can withdraw a line")
+
+    _lock_list_and_lines(db, excess_list.id)
+    if line.status == ExcessLineItemStatus.WITHDRAWN:
+        return line  # idempotent
+    if line.status == ExcessLineItemStatus.AWARDED:
+        raise HTTPException(409, f"Line '{line.part_number}' is awarded — unaward it first")
+
+    line.status = ExcessLineItemStatus.WITHDRAWN
+    db.flush()
+    recompute_line_rollup(db, line.id)
+
+    from . import excess_mirror
+
+    excess_mirror.sync_list_mirror(db, excess_list)
+    _apply_award_list_status(excess_list)
+    _safe_commit(db, entity="excess line withdraw")
+    db.refresh(line)
+    logger.info("Withdrew ExcessLineItem id={} (list={}) by user={}", line_id, excess_list.id, user.id)
+    return line
+
+
+def close_bid_out_list(db: Session, list_id: int, owner: User) -> ExcessList:
+    """Close a ``bid_out`` list into the terminal ``closed`` state (QC 2026-08-10
+    P2/D4).
+
+    A list whose customer bid was rejected (or that otherwise won't resolve) stranded in
+    ``bid_out`` with no exit — the posting-window close only accepts open/collecting. Per
+    the owner's decision the owner is PROMPTED to close or re-bid; this is the manual
+    close. Owner-only. Refuses anything but ``bid_out`` (404/409), and refuses while an
+    offer is still awardable-and-undecided so a live award is never orphaned. ``closed``
+    is terminal (no reopen, not swept by expiry); retires the Sighting mirror. Commits.
+    """
+    excess_list = get_excess_list(db, list_id)
+    if excess_list.owner_id != owner.id:
+        raise HTTPException(403, "Only the list owner can close it")
+    _lock_list_and_lines(db, list_id)
+    if excess_list.status != ExcessListStatus.BID_OUT.value:
+        raise HTTPException(409, "Only a bid-out list is closed from here.")
+    # Don't strand a still-winnable offer: if any line is still undecided AND an actionable
+    # offer covers it, the owner should award/withdraw first (or unaward), not force-close.
+    if any(it.status not in _DECIDED_LINE_STATUSES for it in excess_list.line_items):
+        undecided_has_live_offer = any(
+            o.status in {st.value for st in _ACTIONABLE_OFFER_STATUSES} for o in excess_list.offers
+        )
+        if undecided_has_live_offer:
+            raise HTTPException(
+                409, "Some lines still have live offers — award or withdraw them (or unaward) before closing."
+            )
+
+    excess_list.status = ExcessListStatus.CLOSED.value
+    excess_list.close_at = excess_list.close_at or datetime.now(UTC)
+    db.flush()
+
+    from . import excess_mirror
+
+    excess_mirror.sync_list_mirror(db, excess_list)
+    _safe_commit(db, entity="excess list close from bid_out")
+    db.refresh(excess_list)
+    logger.info("Closed bid_out ExcessList id={} -> closed by owner={}", list_id, owner.id)
+    return excess_list
+
+
 # List statuses that are still "in flight" (the posting window has not resolved) and so
 # are eligible for auto-expiry once past ``close_at`` (M5 nightly job).
 _UNRESOLVED_LIST_STATUSES = (ExcessListStatus.OPEN, ExcessListStatus.COLLECTING)

--- a/app/templates/htmx/partials/resell/_lines.html
+++ b/app/templates/htmx/partials/resell/_lines.html
@@ -65,6 +65,20 @@
   </div>
 {% endmacro %}
 
+{# QC 2026-08-10 P2/D4b: withdraw a posted, still-undecided line so a partially-sold
+   list can finally resolve (WITHDRAWN previously had no writer). Owner/manager; the
+   service enforces the gate. #}
+{% macro _line_withdraw_action(el, item) %}
+  {% if item.status not in ('awarded', 'withdrawn') %}
+  <button hx-post="/api/resell/{{ el.id }}/lines/{{ item.id }}/withdraw"
+          hx-target="[data-resell-detail-root]"
+          hx-swap="outerHTML"
+          hx-confirm="Withdraw this line? It stops advertising as available and can't be offered on."
+          data-loading-disable
+          class="btn-ghost btn-sm text-gray-500 hover:text-gray-700">Withdraw</button>
+  {% endif %}
+{% endmacro %}
+
 <div class="space-y-4">
 
   {# ── Easy entry (owner, draft only — lines lock on post) ──────── #}
@@ -120,6 +134,7 @@
       <div class="inline-flex items-center gap-1.5 flex-shrink-0">
         {{ _status_pill(item) }}
         {{ _line_offer_badge(el, item, is_owner) }}
+        {% if is_owner and not is_draft %}{{ _line_withdraw_action(el, item) }}{% endif %}
       </div>
     </div>
     {% if is_owner and is_draft %}
@@ -221,6 +236,7 @@
               <div class="inline-flex items-center gap-1.5">
                 {{ _status_pill(item) }}
                 {{ _line_offer_badge(el, item, is_owner) }}
+                {% if is_owner and not is_draft %}{{ _line_withdraw_action(el, item) }}{% endif %}
               </div>
             </td>
             {% if is_owner and is_draft %}<td class="text-right">{{ _line_edit_actions(el, item) }}</td>{% endif %}

--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -103,6 +103,18 @@
           Close (no bid)
         </button>
         {% endif %}
+        {# QC 2026-08-10 P2/D4: a bid_out list (e.g. the customer bid was rejected) had no
+           exit and stranded here. The owner closes it to the terminal CLOSED state. #}
+        {% if can_see_customer and el.status == 'bid_out' %}
+        <button hx-post="/api/resell/{{ el.id }}/close-bid-out"
+                hx-target="closest [data-resell-detail-root]"
+                hx-swap="outerHTML"
+                hx-confirm="Close this list? The bid is resolved and the list ends for good (no reopen)."
+                data-loading-disable
+                class="btn-secondary btn-sm">
+          Close list
+        </button>
+        {% endif %}
         {% if can_offer %}
         <button @click="$dispatch('open-modal')"
                 hx-get="/v2/partials/resell/{{ el.id }}/offer-form"

--- a/tests/test_remediation_p2c.py
+++ b/tests/test_remediation_p2c.py
@@ -1,0 +1,104 @@
+"""tests/test_remediation_p2c.py — QC 2026-08-10 P2 (resell dead-ends, D4/D4b).
+
+- D4b: withdraw_line is the missing WITHDRAWN writer — a line that won't sell can
+  be taken off the table, letting a partially-sold list finally resolve.
+- D4: close_bid_out_list gives a BID_OUT list (e.g. after a rejected customer bid)
+  a terminal exit; before, it stranded with no way to close.
+
+Called by: pytest autodiscovery
+Depends on: conftest fixtures (db_session, test_user).
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from tests.conftest import engine  # noqa: F401
+
+
+def _owner(db, email="resell-owner@trioscs.com", role="trader"):
+    from app.models import User
+
+    u = User(email=email, name="Owner", role=role, azure_id="az-" + email[:8], is_active=True)
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _list_with_line(db, owner):
+    from app.models import Company
+    from app.models.excess import ExcessLineItem
+    from app.services.excess_service import create_excess_list
+
+    company = Company(name="ExcessCo", is_active=True)
+    db.add(company)
+    db.flush()
+    el = create_excess_list(db, title="Resolve me", company_id=company.id, owner_id=owner.id)
+    line = ExcessLineItem(excess_list_id=el.id, part_number="GRM188R", quantity=500, asking_price=Decimal("1.00"))
+    db.add(line)
+    db.commit()
+    return el, line
+
+
+def test_owner_withdraws_a_line(db_session):
+    from app.constants import ExcessLineItemStatus
+    from app.services.excess_service import withdraw_line
+
+    owner = _owner(db_session)
+    el, line = _list_with_line(db_session, owner)
+    withdraw_line(db_session, line.id, owner)
+    db_session.refresh(line)
+    assert line.status == ExcessLineItemStatus.WITHDRAWN  # the writer that never existed
+
+
+def test_manager_can_withdraw_a_line(db_session):
+    from app.constants import ExcessLineItemStatus
+    from app.services.excess_service import withdraw_line
+
+    owner = _owner(db_session)
+    mgr = _owner(db_session, email="resell-mgr@trioscs.com", role="manager")
+    el, line = _list_with_line(db_session, owner)
+    withdraw_line(db_session, line.id, mgr)  # owner + manager/admin, per the owner's rule
+    db_session.refresh(line)
+    assert line.status == ExcessLineItemStatus.WITHDRAWN
+
+
+def test_non_owner_non_manager_cannot_withdraw(db_session):
+    from fastapi import HTTPException
+
+    from app.services.excess_service import withdraw_line
+
+    owner = _owner(db_session)
+    rando = _owner(db_session, email="rando-trader@trioscs.com", role="trader")
+    el, line = _list_with_line(db_session, owner)
+    with pytest.raises(HTTPException) as exc:
+        withdraw_line(db_session, line.id, rando)
+    assert exc.value.status_code == 403
+
+
+def test_close_bid_out_list_terminal(db_session):
+    from app.constants import ExcessListStatus
+    from app.services.excess_service import close_bid_out_list
+
+    owner = _owner(db_session)
+    el, _line = _list_with_line(db_session, owner)
+    el.status = ExcessListStatus.BID_OUT.value  # simulate bids sent, customer rejected
+    db_session.commit()
+    close_bid_out_list(db_session, el.id, owner)
+    db_session.refresh(el)
+    assert el.status == ExcessListStatus.CLOSED.value  # terminal exit, no longer stranded
+
+
+def test_cannot_close_non_bid_out_list_from_here(db_session):
+    from fastapi import HTTPException
+
+    from app.constants import ExcessListStatus
+    from app.services.excess_service import close_bid_out_list
+
+    owner = _owner(db_session)
+    el, _line = _list_with_line(db_session, owner)
+    el.status = ExcessListStatus.OPEN.value
+    db_session.commit()
+    with pytest.raises(HTTPException) as exc:
+        close_bid_out_list(db_session, el.id, owner)
+    assert exc.value.status_code == 409  # open/collecting close through the posting-window path


### PR DESCRIPTION
**P2 resell dead-ends** — a list stranded in `bid_out` with no exit.

**D4b (withdraw_line):** `ExcessLineItemStatus.WITHDRAWN` existed but **nothing ever wrote it**. A list only flips to `awarded` once every line is decided (awarded or withdrawn), so a line that would never sell couldn't be taken off the table — a partially-sold list stranded forever. New `withdraw_line` service + route + per-line **Withdraw** control; the **owner or a manager/admin** may withdraw (your rule). Mirrors `award_offer` (lock, recompute rollup, retire the Sighting mirror, re-derive list status); refuses an already-awarded line, idempotent otherwise.

**D4 (close_bid_out_list):** a `bid_out` list — e.g. after the customer bid was rejected — had no exit. New service + route + **Close list** button flips it to the terminal `closed` state (owner-only), refusing while a line still has a live winnable offer so no award is orphaned. Per your rule, the owner is prompted to close-or-rebid; this is the manual close.

**Verification:** 5 regression tests (owner + manager withdraw, non-owner 403, close bid_out→closed, non-bid_out refused); affected sweep **997 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)