### PR TITLE
fix(P2): RFQ success-theater — no green "sent" when nothing was emailed

### DIFF
--- a/app/routers/htmx/offers/rfq.py
+++ b/app/routers/htmx/offers/rfq.py
@@ -210,6 +210,7 @@ async def rfq_send(
 
     sent = []
     failed = []
+    not_sent = []  # QC P2: real no-token run — recorded but NOT emailed
 
     if token and not is_testing:
         # Real email send via Graph API
@@ -268,7 +269,12 @@ async def rfq_send(
                     sent.append({"vendor": name, "email": email, "status": "draft"})
                 db.commit()
     else:
-        # Test mode or no token — create Contact records without sending
+        # QC 2026-08-10 P2 (success-theater): a MISSING Graph token means these RFQs
+        # were NOT emailed — recording them SENT + showing a green "sent" banner was a
+        # lie (the vendors never got them). Only TESTING mode records SENT (the harness
+        # skips the real POST but the send is otherwise real); a real no-token run stamps
+        # PENDING and reports them as "not sent — reconnect Microsoft 365".
+        status_val = ContactStatus.SENT if is_testing else ContactStatus.PENDING
         for name, email in zip(vendor_names, vendor_emails):
             if not email:
                 continue
@@ -281,11 +287,12 @@ async def rfq_send(
                 vendor_contact=email,
                 parts_included=parts_text,
                 subject=subject,
-                status=ContactStatus.SENT,
+                status=status_val,
                 status_updated_at=datetime.now(UTC),
             )
             db.add(contact)
-            sent.append({"vendor": name, "email": email, "status": "sent"})
+            entry = {"vendor": name, "email": email, "status": "sent" if is_testing else "not_sent"}
+            (sent if is_testing else not_sent).append(entry)
         db.commit()
 
     logger.info("RFQ: {} sent, {} failed for req {} by {}", len(sent), len(failed), req_id, user.email)
@@ -296,6 +303,8 @@ async def rfq_send(
     ctx["failed_results"] = failed
     ctx["total_sent"] = len(sent)
     ctx["total_failed"] = len(failed)
+    ctx["not_sent_results"] = not_sent
+    ctx["total_not_sent"] = len(not_sent)
     return template_response("htmx/partials/requisitions/rfq_results.html", ctx)
 
 

--- a/app/templates/htmx/partials/requisitions/rfq_results.html
+++ b/app/templates/htmx/partials/requisitions/rfq_results.html
@@ -5,7 +5,9 @@
 #}
 <div class="space-y-4">
 
-  {# ── Success Banner ────────────────────────────────────── #}
+  {# ── Outcome banner (QC 2026-08-10 P2): honest sent / not-sent / failed, never a
+       green "sent" when a missing Microsoft 365 token meant nothing was emailed. #}
+  {% if total_sent %}
   <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4 flex items-start gap-3">
     <svg class="h-5 w-5 text-emerald-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
@@ -15,6 +17,29 @@
       <p class="text-xs text-emerald-600 mt-0.5">Contact records created. Check the Activity tab for status updates.</p>
     </div>
   </div>
+  {% endif %}
+  {% if total_not_sent %}
+  <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 flex items-start gap-3">
+    <svg class="h-5 w-5 text-amber-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    <div>
+      <p class="text-sm font-medium text-amber-800">{{ total_not_sent }} RFQ(s) NOT sent — Microsoft 365 not connected</p>
+      <p class="text-xs text-amber-600 mt-0.5">The contacts were saved but no email went out. Reconnect Microsoft 365, then re-send from the Activity tab.</p>
+    </div>
+  </div>
+  {% endif %}
+  {% if total_failed %}
+  <div class="bg-rose-50 border border-rose-200 rounded-lg p-4 flex items-start gap-3">
+    <svg class="h-5 w-5 text-rose-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+    </svg>
+    <div>
+      <p class="text-sm font-medium text-rose-800">{{ total_failed }} RFQ(s) failed to send</p>
+      <p class="text-xs text-rose-600 mt-0.5">Microsoft rejected these — check the addresses and try again.</p>
+    </div>
+  </div>
+  {% endif %}
 
   {# ── Results Table ─────────────────────────────────────── #}
   {% if sent_results %}

--- a/tests/test_remediation_st.py
+++ b/tests/test_remediation_st.py
@@ -1,0 +1,45 @@
+"""tests/test_remediation_st.py — QC 2026-08-10 P2 success-theater (RFQ honesty).
+
+The RFQ results screen must NOT show a green "sent" banner when a missing Microsoft 365
+token meant nothing was actually emailed — it shows an amber "NOT sent — reconnect
+Microsoft 365" banner instead. (The route can't be exercised for the no-token path under
+TESTING, which forces the send branch, so this asserts the template renders each outcome
+honestly.)
+"""
+
+from tests.conftest import engine  # noqa: F401
+
+
+def _render(**ctx):
+    from app.template_env import templates
+
+    base = {
+        "total_sent": 0,
+        "total_not_sent": 0,
+        "total_failed": 0,
+        "sent_results": [],
+        "not_sent_results": [],
+        "failed_results": [],
+        "req": None,
+        "request": None,
+    }
+    base.update(ctx)
+    return templates.env.get_template("htmx/partials/requisitions/rfq_results.html").render(**base)
+
+
+def test_no_token_shows_not_sent_not_a_green_sent_banner():
+    html = _render(total_not_sent=2, not_sent_results=[{"vendor": "Acme", "email": "a@x.com", "status": "not_sent"}])
+    assert "NOT sent" in html
+    assert "Microsoft 365 not connected" in html
+    assert "RFQ sent to" not in html  # the lie is gone — no green "sent" banner
+
+
+def test_real_send_still_shows_sent_banner():
+    html = _render(total_sent=3, sent_results=[{"vendor": "Acme", "email": "a@x.com", "status": "sent"}])
+    assert "RFQ sent to 3 vendor(s)" in html
+    assert "NOT sent" not in html
+
+
+def test_failed_sends_show_a_failure_banner():
+    html = _render(total_failed=1, failed_results=[{"vendor": "Bad", "email": "b@x.com", "status": "failed"}])
+    assert "failed to send" in html


### PR DESCRIPTION
**UX review, success-theater theme.** The RFQ results screen always showed a green "RFQ sent to N vendor(s)" banner — but when the user's Microsoft 365 token was missing, the send branch recorded every contact as SENT and showed that green banner even though **no email went out** (the vendors never got the RFQ).

- **Route** (`offers/rfq.py`): a real no-token run now stamps contacts `PENDING` (not SENT) and collects them into `not_sent`, distinct from TESTING mode (which keeps the SENT convenience since the harness skips only the real POST).
- **Template** (`rfq_results.html`): renders each outcome honestly — green only for actual sends, an amber **"NOT sent — reconnect Microsoft 365"** banner for the no-token case, red for Graph failures.

**Verification:** 3 render tests (no-token → amber + no green; real send → green; failures → red); affected sweep **263 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)