### PR TITLE
fix(P3): reveal hover-only row actions on touch devices

### DIFF
--- a/app/static/htmx_mobile.css
+++ b/app/static/htmx_mobile.css
@@ -126,3 +126,28 @@
         display: none;
     }
 }
+
+
+/* ============================================================
+   N. Touch devices: reveal hover-only row actions (QC 2026-08-10 P3)
+   ------------------------------------------------------------
+   ~20 row actions use Tailwind `opacity-0 group-hover:opacity-100`
+   (hidden until the row is hovered). A touch device has NO hover, so
+   those Edit/Delete/Withdraw/etc. controls were PERMANENTLY invisible
+   and unreachable on a phone. Under `hover: none`, force every
+   hover-revealed utility to its shown state so the actions are tappable.
+   ============================================================ */
+@media (hover: none) {
+    [class*="group-hover:opacity-100"] {
+        opacity: 1 !important;
+    }
+    [class*="group-hover:flex"] {
+        display: flex !important;
+    }
+    [class*="group-hover:block"] {
+        display: block !important;
+    }
+    [class*="group-hover:inline-flex"] {
+        display: inline-flex !important;
+    }
+}

--- a/tests/test_remediation_p3.py
+++ b/tests/test_remediation_p3.py
@@ -1,0 +1,22 @@
+"""tests/test_remediation_p3.py — QC 2026-08-10 P3 (mobile touch actions).
+
+On a touch device (hover: none) there is no hover, so the ~20 row actions styled
+`opacity-0 group-hover:opacity-100` were permanently invisible and untappable on a
+phone. A `@media (hover: none)` rule in htmx_mobile.css now forces them visible. (CSS
+can only be checked structurally here; the visual result needs a browser.)
+"""
+
+from pathlib import Path
+
+CSS = Path(__file__).resolve().parents[1] / "app" / "static" / "htmx_mobile.css"
+
+
+def test_touch_reveals_hover_only_actions():
+    css = CSS.read_text()
+    assert "@media (hover: none)" in css
+    assert "group-hover:opacity-100" in css  # the utility it un-hides
+
+
+def test_mobile_css_braces_balanced():
+    css = CSS.read_text()
+    assert css.count("{") == css.count("}")


### PR DESCRIPTION
**UX review, mobile.** ~20 row actions use `opacity-0 group-hover:opacity-100` — hidden until the row is hovered. A touch device has **no hover**, so those Edit/Delete/Withdraw controls were permanently invisible and **untappable on a phone** (which is how the owner works).

Adds a `@media (hover: none)` block to `htmx_mobile.css` that forces every hover-revealed utility to its shown state — one rule covers all ~20 sites.

Tests assert the rule + un-hidden utility are present and the CSS braces balance. The visual result and the rest of the mobile findings (bottom-nav collapse, responsive splits, table overflow) need a browser-verified pass and are in the continuation backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)