### PR TITLE
fix(P4): AI-parsed offer keeps its reviewed currency (no silent USD)

### DIFF
--- a/app/services/ai_offer_service.py
+++ b/app/services/ai_offer_service.py
@@ -391,6 +391,11 @@ def parse_offer_form_rows(form, vendor_name: str) -> list[dict]:
                 "manufacturer": form.get(f"offers[{idx}].manufacturer"),
                 "qty_available": safe_int(form.get(f"offers[{idx}].qty_available")),
                 "unit_price": safe_float(form.get(f"offers[{idx}].unit_price")),
+                # QC 2026-08-10 P4 (AI provenance): collect the currency the reviewer
+                # sees/edits — it was dropped here, so save stamped every offer USD even
+                # when the vendor priced in EUR/GBP. None falls through to the o.currency
+                # or "USD" default at save, unchanged.
+                "currency": form.get(f"offers[{idx}].currency") or None,
                 "lead_time": form.get(f"offers[{idx}].lead_time"),
                 "date_code": form.get(f"offers[{idx}].date_code"),
                 "condition": form.get(f"offers[{idx}].condition", OfferCondition.NEW),
@@ -457,6 +462,7 @@ def save_form_parsed_offers(
             manufacturer=o.get("manufacturer"),
             qty_available=o.get("qty_available"),
             unit_price=o.get("unit_price"),
+            currency=o.get("currency") or "USD",  # QC 2026-08-10 P4: honor the reviewed currency, not a blanket USD
             lead_time=o.get("lead_time"),
             date_code=o.get("date_code"),
             condition=o.get("condition") or OfferCondition.NEW,

--- a/app/templates/htmx/partials/requisitions/tabs/parsed_email_results.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parsed_email_results.html
@@ -84,6 +84,14 @@
                    class="input input-sm">
           </div>
           <div>
+            {# QC 2026-08-10 P4: the reviewer can see/correct the currency the AI parsed —
+               it used to be hidden, so every save silently stamped USD. #}
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Currency</label>
+            <input type="text" name="offers[{{ loop.index0 }}].currency" maxlength="3"
+                   value="{{ q.currency or 'USD' }}"
+                   class="input input-sm uppercase">
+          </div>
+          <div>
             <label class="text-xs text-gray-600 uppercase block mb-0.5">Lead Time</label>
             <input type="text" name="offers[{{ loop.index0 }}].lead_time"
                    value="{{ q.lead_time_text or '' }}"

--- a/tests/test_remediation_p4ai.py
+++ b/tests/test_remediation_p4ai.py
@@ -1,0 +1,48 @@
+"""tests/test_remediation_p4ai.py — QC 2026-08-10 P4 (AI provenance: offer currency).
+
+The AI-parsed-offer review form never collected the currency the reviewer sees, so save
+stamped every offer USD even when the vendor priced in EUR/GBP — a wrong currency then
+flowed into customer quotes. The form now collects + persists it.
+"""
+
+from tests.conftest import engine  # noqa: F401
+
+
+def test_parse_offer_form_rows_collects_currency():
+    from app.services.ai_offer_service import parse_offer_form_rows
+
+    form = {
+        "offers[0].mpn": "LM317T",
+        "offers[0].unit_price": "0.42",
+        "offers[0].currency": "EUR",
+    }
+    rows = parse_offer_form_rows(form, "Acme")
+    assert rows[0]["currency"] == "EUR"  # was dropped before
+
+
+def test_saved_offer_keeps_reviewed_currency(db_session, test_user):
+    from app.models import Offer, Requisition
+    from app.services.ai_offer_service import save_form_parsed_offers
+
+    req = Requisition(name="REQ-CUR", status="open", created_by=test_user.id)
+    db_session.add(req)
+    db_session.flush()
+    rows = [{"mpn": "LM317T", "vendor_name": "Acme", "qty_available": 100, "unit_price": 0.42, "currency": "EUR"}]
+    save_form_parsed_offers(db_session, req.id, "Acme", rows, test_user)
+    db_session.commit()
+    offer = db_session.query(Offer).filter(Offer.mpn == "LM317T").one()
+    assert offer.currency == "EUR"  # not silently USD
+
+
+def test_missing_currency_defaults_usd(db_session, test_user):
+    from app.models import Offer, Requisition
+    from app.services.ai_offer_service import save_form_parsed_offers
+
+    req = Requisition(name="REQ-CUR2", status="open", created_by=test_user.id)
+    db_session.add(req)
+    db_session.flush()
+    rows = [{"mpn": "NE555P", "vendor_name": "Acme", "qty_available": 50, "unit_price": 0.10, "currency": None}]
+    save_form_parsed_offers(db_session, req.id, "Acme", rows, test_user)
+    db_session.commit()
+    offer = db_session.query(Offer).filter(Offer.mpn == "NE555P").one()
+    assert offer.currency == "USD"  # sane default preserved


### PR DESCRIPTION
**AI-guardrails review** (provenance at the decision point). The AI-parsed-offer review card never showed the currency, and `parse_offer_form_rows` never collected `offers[i].currency`, so `save_form_parsed_offers` stamped **every** saved offer USD — even a vendor who priced in EUR/GBP. That wrong currency then flowed into customer quotes off the reviewer's blind save.

- `parse_offer_form_rows` now collects the currency; `save_form_parsed_offers` persists it (`or "USD"` default preserved).
- The review card shows an editable **Currency** field so the reviewer sees and can correct what the AI parsed.

**Verification:** 3 tests (form collects currency; saved offer keeps EUR; missing → USD); affected sweep **1,575 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)