### PR TITLE
fix(P4): tagging job no longer closes its DB session under a running thread at shutdown

### DIFF
--- a/app/jobs/tagging_jobs.py
+++ b/app/jobs/tagging_jobs.py
@@ -23,14 +23,24 @@ async def _run_threaded_db_job(label, fn):
     from ..database import SessionLocal
 
     db = SessionLocal()
+    # QC 2026-08-10 P4: CancelledError is a BaseException, so `except Exception`
+    # missed it — on scheduler shutdown the finally then closed the session while
+    # the asyncio.to_thread WORKER was still using it (Sentry AVAILAI-TH). On
+    # cancellation, don't close under the running thread; the pool is torn down at
+    # process exit anyway.
+    cancelled = False
     try:
         result = await asyncio.to_thread(fn, db)
         logger.info(f"{label}: {result}")
+    except asyncio.CancelledError:
+        cancelled = True
+        raise
     except Exception:
         db.rollback()
         raise
     finally:
-        db.close()
+        if not cancelled:
+            db.close()
 
 
 def register_tagging_jobs(scheduler, settings):

--- a/tests/test_remediation_p4med.py
+++ b/tests/test_remediation_p4med.py
@@ -1,0 +1,58 @@
+"""tests/test_remediation_p4med.py — QC 2026-08-10 P4 (code-QC medium: tagging job).
+
+CancelledError is a BaseException, not Exception, so `_run_threaded_db_job`'s
+`except Exception` missed it — on scheduler shutdown the finally closed the DB
+session while the asyncio.to_thread worker was still using it. On cancellation we
+now skip the close (the pool tears down at process exit).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import engine  # noqa: F401
+
+
+@pytest.mark.anyio
+async def test_cancelled_shutdown_does_not_close_session_under_the_thread():
+    from app.jobs import tagging_jobs
+
+    fake_db = MagicMock()
+    with (
+        patch("app.database.SessionLocal", return_value=fake_db),
+        patch("app.jobs.tagging_jobs.asyncio.to_thread", new=AsyncMock(side_effect=asyncio.CancelledError())),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await tagging_jobs._run_threaded_db_job("test", lambda db: None)
+    # The session must NOT be closed out from under the still-running worker thread.
+    fake_db.close.assert_not_called()
+    fake_db.rollback.assert_not_called()  # rollback would also touch the busy session
+
+
+@pytest.mark.anyio
+async def test_normal_completion_still_closes_session():
+    from app.jobs import tagging_jobs
+
+    fake_db = MagicMock()
+    with (
+        patch("app.database.SessionLocal", return_value=fake_db),
+        patch("app.jobs.tagging_jobs.asyncio.to_thread", new=AsyncMock(return_value="ok")),
+    ):
+        await tagging_jobs._run_threaded_db_job("test", lambda db: "ok")
+    fake_db.close.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_real_error_rolls_back_and_closes():
+    from app.jobs import tagging_jobs
+
+    fake_db = MagicMock()
+    with (
+        patch("app.database.SessionLocal", return_value=fake_db),
+        patch("app.jobs.tagging_jobs.asyncio.to_thread", new=AsyncMock(side_effect=ValueError("boom"))),
+    ):
+        with pytest.raises(ValueError):
+            await tagging_jobs._run_threaded_db_job("test", lambda db: None)
+    fake_db.rollback.assert_called_once()
+    fake_db.close.assert_called_once()


### PR DESCRIPTION
**Code-QC medium — Sentry AVAILAI-TH, a live production error.** `asyncio.CancelledError` is a `BaseException`, not `Exception`, so `_run_threaded_db_job`'s `except Exception` never caught it. On scheduler shutdown the job was cancelled mid-`await asyncio.to_thread(fn, db)`; the `finally: db.close()` then closed the session while the worker thread was **still running** `fn(db)`.

On cancellation we now skip the close (the worker keeps running; the pool tears down at process exit). Normal completion and real exceptions close/roll back exactly as before.

**Verification:** 3 tests (cancelled → no close/rollback; normal → close; error → rollback+close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)