### PR TITLE
fix(P3): mobile detail-scroll + wide-table scroll (desktop-safe)

### DIFF
--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -135,6 +135,21 @@ htmx.on('htmx:afterRequest', function(evt) {
     });
 });
 
+// ── Mobile: bring a just-loaded detail pane into view (QC 2026-08-10 P3) ──────
+// On a phone the master/detail workspaces stack vertically, so selecting a row
+// swaps the detail BELOW the fold — the tap looked DEAD because nothing visibly
+// changed (a UX-review blocker). After a swap settles into a detail pane, scroll
+// it into view on narrow viewports only. Desktop (>=768px, side-by-side) is
+// untouched by construction.
+document.body.addEventListener('htmx:afterSettle', function(evt) {
+    if (window.innerWidth >= 768) return;
+    var t = evt.detail && evt.detail.target;
+    if (!t || !t.id) return;
+    if (t.id === 'aw-pane' || t.id === 'sightings-detail' || /(^|[-_])detail([-_]|$)/.test(t.id)) {
+        try { t.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (_e) { t.scrollIntoView(); }
+    }
+});
+
 // ── Trouble-ticket capture & reporting ───────────────────────
 // Recent HTMX-pushed URLs — a breadcrumb trail for bug repro. Capped at 8.
 window._ttNavHistory = [];

--- a/app/static/htmx_mobile.css
+++ b/app/static/htmx_mobile.css
@@ -151,3 +151,20 @@
         display: inline-flex !important;
     }
 }
+
+
+/* ============================================================
+   N+1. Wide compact tables scroll instead of overflowing the page
+   (QC 2026-08-10 P3) — the resell lines/offers tables use
+   `compact-table min-w-full`, so on a phone their many columns
+   pushed the whole page sideways. `display:block; overflow-x:auto`
+   contains the scroll to the table's own box. Mobile-only; desktop
+   (table layout) is untouched.
+   ============================================================ */
+@media (max-width: 768px) {
+    .compact-table {
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}

--- a/tests/test_p3_mobile_complete.py
+++ b/tests/test_p3_mobile_complete.py
@@ -1,0 +1,34 @@
+"""tests/test_p3_mobile_complete.py — QC 2026-08-10 P3 (mobile), wave 2.
+
+Desktop-safe, mobile-scoped fixes (CSS visual result still wants a browser pass):
+- A just-loaded detail pane scrolls into view on narrow viewports (the master/
+  detail workspaces stack on mobile, so a row tap swapped the detail below the
+  fold and looked dead).
+- Wide `compact-table`s (resell) scroll within their own box on mobile instead
+  of pushing the whole page sideways.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+JS = ROOT / "app" / "static" / "htmx_app.js"
+CSS = ROOT / "app" / "static" / "htmx_mobile.css"
+
+
+def test_detail_pane_scrolls_into_view_on_mobile():
+    js = JS.read_text()
+    assert "htmx:afterSettle" in js
+    assert "scrollIntoView" in js
+    assert "window.innerWidth >= 768" in js  # desktop is excluded by construction
+
+
+def test_compact_tables_scroll_on_mobile():
+    css = CSS.read_text()
+    assert ".compact-table" in css
+    # inside a max-width media query (mobile-only), never touching desktop
+    idx = css.index(".compact-table")
+    assert "@media (max-width: 768px)" in css[:idx]
+
+
+def test_mobile_css_braces_balanced():
+    assert CSS.read_text().count("{") == CSS.read_text().count("}")


### PR DESCRIPTION
Second mobile wave (after #845's hover:none reveal). Both changes are scoped to narrow viewports by construction — desktop layout untouched.

- **Detail scrolls into view on mobile:** the master/detail workspaces stack on a phone, so selecting a row swapped the detail *below the fold* and the tap looked dead. An `htmx:afterSettle` handler scrolls a settled detail pane into view when `innerWidth < 768`.
- **Wide compact tables scroll in their box:** the resell lines/offers tables pushed the whole page sideways on a phone. A `max-width:768px` rule gives `.compact-table` `display:block; overflow-x:auto`.

Tests assert both (handler + viewport guard; rule inside a mobile media query; braces balance).

Remaining P3 (bottom-nav collapse, fixed-width-layout responsiveness, URL-truth canonical push) restructure desktop-visible layout — in the continuation backlog for a browser-verified pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)