### PR TITLE
fix(P4): human 'different' verdict is a hard kill-switch, even transitively

### DIFF
--- a/app/services/part_equivalence.py
+++ b/app/services/part_equivalence.py
@@ -127,6 +127,12 @@ def expand_parts(db: Session, parts: set[str]) -> dict[str, dict]:
         state[p] = {"keys": {base}, "ai_variants": {}}
         frontier.add(base)
 
+    # Human 'different' verdicts are a HARD kill-switch (QC 2026-08-10 P4): a key
+    # may never join a class that already contains a key a human ruled it different
+    # from — NOT EVEN transitively. The bug: A≠B (human), but A~C and C~B (AI 'same')
+    # pooled A and B anyway, silently overriding the human's "not the same part".
+    blocked: set[tuple[str, str]] = set()
+
     # Verdicts form a tiny graph; walk 'same' edges (a variant of a variant
     # pools too), loading each round's edges for EVERY part in one query.
     for _ in range(3):  # bounded — ordering-code chains are short
@@ -135,6 +141,8 @@ def expand_parts(db: Session, parts: set[str]) -> dict[str, dict]:
             break
         best: dict[tuple[str, str], PartEquivalence] = {}
         for r in rows:
+            if r.verdict == "different" and r.source == "human":
+                blocked.add((r.key_a, r.key_b))  # stored key_a<key_b, matches _ordered()
             pair = (r.key_a, r.key_b)
             cur = best.get(pair)
             if cur is None or (r.source == "human" and cur.source != "human"):
@@ -150,6 +158,10 @@ def expand_parts(db: Session, parts: set[str]) -> dict[str, dict]:
                 elif r.key_b in keys and r.key_a not in keys:
                     other = r.key_a
                 else:
+                    continue
+                # Kill-switch: refuse the pool if a human ruled `other` different from
+                # ANY key already in this class (direct or transitive).
+                if any(_ordered(other, k) in blocked for k in keys):
                     continue
                 keys.add(other)
                 info["ai_variants"][other] = r.reason or "AI: same part, ordering-code variant"

--- a/tests/test_part_equivalence.py
+++ b/tests/test_part_equivalence.py
@@ -271,3 +271,33 @@ def test_verdict_endpoint(db_session):
         assert row.source == "human"
     finally:
         app.dependency_overrides.clear()
+
+
+# ── QC 2026-08-10 P4: human 'different' is a HARD kill-switch, even transitively ──
+
+
+def test_human_different_blocks_transitive_repool(db_session):
+    """A~C and C~B via AI 'same', but A vs B is human 'different'.
+
+    A must NOT pool B transitively (the kill-switch bug: the human override was silently
+    bypassed).
+    """
+    from app.services.part_equivalence import expand_part, norm_key, record_human_verdict
+
+    # AI says A~C and C~B (a chain).
+    _eq(db_session, "LM317T", "LM317TX", "same", source="ai")
+    _eq(db_session, "LM317TX", "LM317TY", "same", source="ai")
+    # A human ruled A ('LM317T') != B ('LM317TY').
+    from app.models import User
+
+    user = User(email="h@x.com", name="H", role="admin", azure_id="az-h")
+    db_session.add(user)
+    db_session.flush()
+    record_human_verdict(db_session, user, "LM317T", "LM317TY", "different")
+    db_session.commit()  # fixture is autoflush=False — the verdict must be visible to _load_verdicts
+
+    eq = expand_part(db_session, "LM317T")
+    keys = set(eq["keys"])
+    assert norm_key("LM317TX") in keys  # the AI 'same' variant still pools
+    assert norm_key("LM317TY") not in keys  # but NOT the human-'different' one, transitively
+    assert norm_key("LM317T") in keys


### PR DESCRIPTION
## P4 (AI provenance) — human "different" is a hard kill-switch, even transitively

**Bug.** A human "not the same part" verdict is supposed to permanently outrank
the AI. It did — but only directly. When a human ruled **A ≠ B**, yet the AI had
said **A ~ C** and **C ~ B** ("same"), `expand_parts` still pooled A and B
transitively through C — silently reversing the human's override and letting one
part's supply/demand match a part it was explicitly ruled apart from.

**Fix.** `expand_parts` now tracks a `blocked` set of every human-`different`
key pair encountered while walking the verdict graph, and refuses to add a key
to a class if a human ruled it different from **any** key already in that class —
direct or transitive.

**Test.** `test_human_different_blocks_transitive_repool`: AI-same A~C, AI-same
C~B, human-different A–B ⇒ `expand_part(A)` pools C's variant but **not** B's.

```
15 passed  tests/test_part_equivalence.py
61 passed  + tests/test_proactive_matching.py
```

Part of the 2026-08-10 remediation plan, **P4 tranche (AI provenance)**. Sibling
pieces: offer-currency preserved end-to-end shipped in #846; the "hotlist
amber-chip" finding was verified already covered — the supply-side
`has_ai_variants` rollup keys on `m.mpn` for hotlist and requirement matches
alike, so hotlist matches already render the amber verify chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
