### PR TITLE
fix(P4): bound quantity inputs to PG INT4 (no unhandled 500s)

### DIFF
--- a/app/schemas/requisitions.py
+++ b/app/schemas/requisitions.py
@@ -18,6 +18,7 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.constants import PG_INT4_MAX
 from app.utils.normalization import normalize_condition, normalize_mpn, normalize_packaging
 
 
@@ -101,7 +102,7 @@ class RequisitionUpdate(BaseModel):
 class RequirementCreate(BaseModel):
     primary_mpn: str
     manufacturer: str
-    target_qty: int = Field(default=1, ge=1)
+    target_qty: int = Field(default=1, ge=1, le=PG_INT4_MAX)
     target_price: float | None = Field(default=None, ge=0)
     brand: str | None = None
     substitutes: list[str] = Field(default_factory=list, max_length=20)
@@ -154,7 +155,7 @@ class RequirementCreate(BaseModel):
 class RequirementUpdate(BaseModel):
     primary_mpn: str | None = None
     manufacturer: str | None = None
-    target_qty: int | None = Field(default=None, ge=1)
+    target_qty: int | None = Field(default=None, ge=1, le=PG_INT4_MAX)
     target_price: float | None = Field(default=None, ge=0)
     brand: str | None = None
     substitutes: list[str] | None = None

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -20,7 +20,7 @@ from loguru import logger
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session, joinedload
 
-from ...constants import OfferStatus, UserRole
+from ...constants import PG_INT4_MAX, OfferStatus, UserRole
 from ...models import Offer, Requirement, User
 from ...models.buy_plan import BuyPlan, BuyPlanLine, BuyPlanLineStatus, BuyPlanStatus
 from ..buyplan_scoring import assign_buyer, score_offer
@@ -422,14 +422,18 @@ def _require_int_quantity(value: object) -> int:
     if isinstance(value, bool):
         raise ValueError("Quantity must be a whole number.")
     if isinstance(value, int):
-        return value
-    try:
-        as_float = float(value)
-    except (TypeError, ValueError) as e:
-        raise ValueError("Quantity must be a whole number.") from e
-    if not as_float.is_integer():
-        raise ValueError("Quantity must be a whole number.")
-    return int(as_float)
+        result = value
+    else:
+        try:
+            as_float = float(value)
+        except (TypeError, ValueError) as e:
+            raise ValueError("Quantity must be a whole number.") from e
+        if not as_float.is_integer():
+            raise ValueError("Quantity must be a whole number.")
+        result = int(as_float)
+    if result > PG_INT4_MAX:
+        raise ValueError(f"Quantity is too large (max {PG_INT4_MAX:,}).")
+    return result
 
 
 def _coerce_known_line_ids(known_line_ids: list[int] | None) -> set[int] | None:

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -1752,6 +1752,8 @@ def add_line(
         raise HTTPException(400, "Part number is required")
     if quantity is None or quantity <= 0:
         raise HTTPException(400, "Quantity must be a positive whole number")
+    if quantity > PG_INT4_MAX:
+        raise HTTPException(400, f"Quantity is too large (max {PG_INT4_MAX:,}).")
 
     item = ExcessLineItem(
         excess_list_id=el.id,
@@ -1817,6 +1819,8 @@ def update_line(
         raise HTTPException(404, f"Line {line_id} not found on list {list_id}")
     if quantity is None or quantity <= 0:
         raise HTTPException(400, "Quantity must be a positive whole number")
+    if quantity > PG_INT4_MAX:
+        raise HTTPException(400, f"Quantity is too large (max {PG_INT4_MAX:,}).")
 
     identity_changed = (part_number or "").strip() != (line.part_number or "") or (manufacturer or None) != (
         line.manufacturer or None

--- a/tests/test_p4_int4_qty_ceilings.py
+++ b/tests/test_p4_int4_qty_ceilings.py
@@ -1,0 +1,91 @@
+"""test_p4_int4_qty_ceilings.py — quantity inputs are bounded to PG INT4.
+
+Every quantity that reaches a PostgreSQL INTEGER column must be rejected with a
+clean 400/validation error before the insert, not blow up as an unhandled
+psycopg DataError 500. This covers the three intake layers the 2026-08-08 QC
+audit flagged as unbounded: the requisition/requirement schema, the buy-plan
+line quantity coercer, and the resell add/update-line service paths.
+
+Called by: pytest
+Depends on: app.constants.PG_INT4_MAX, app.schemas.requisitions,
+    app.services.buyplan_workflow.buyplan_lines, app.services.excess_service
+"""
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.constants import PG_INT4_MAX
+from app.models import Company, User
+from app.services.excess_service import add_line, create_excess_list, update_line
+from tests.conftest import engine
+
+_ = engine  # ensure test DB tables exist
+
+OVER = PG_INT4_MAX + 1
+
+
+# ── Requisition/requirement schema ────────────────────────────────────────
+
+
+def test_requirement_create_rejects_over_int4_qty():
+    from app.schemas.requisitions import RequirementCreate
+
+    with pytest.raises(ValidationError):
+        RequirementCreate(primary_mpn="LM317T", manufacturer="TI", target_qty=OVER)
+    # boundary value is still accepted
+    ok = RequirementCreate(primary_mpn="LM317T", manufacturer="TI", target_qty=PG_INT4_MAX)
+    assert ok.target_qty == PG_INT4_MAX
+
+
+def test_requirement_update_rejects_over_int4_qty():
+    from app.schemas.requisitions import RequirementUpdate
+
+    with pytest.raises(ValidationError):
+        RequirementUpdate(target_qty=OVER)
+    assert RequirementUpdate(target_qty=PG_INT4_MAX).target_qty == PG_INT4_MAX
+
+
+# ── Buy-plan line quantity coercer ────────────────────────────────────────
+
+
+def test_buyplan_require_int_quantity_rejects_over_int4():
+    from app.services.buyplan_workflow.buyplan_lines import _require_int_quantity
+
+    assert _require_int_quantity(PG_INT4_MAX) == PG_INT4_MAX  # boundary ok
+    with pytest.raises(ValueError):
+        _require_int_quantity(OVER)
+    with pytest.raises(ValueError):
+        _require_int_quantity(float(OVER))  # float form also rejected pre-insert
+
+
+# ── Resell add/update line service paths ──────────────────────────────────
+
+
+def _draft(db):
+    co = Company(name="Seller Corp")
+    db.add(co)
+    db.commit()
+    user = User(email="t@x.com", name="T", role="trader", azure_id="az-t")
+    db.add(user)
+    db.commit()
+    el = create_excess_list(db, title="Excess", company_id=co.id, owner_id=user.id)
+    return el, user
+
+
+def test_resell_add_line_rejects_over_int4_qty(db_session):
+    el, user = _draft(db_session)
+    with pytest.raises(HTTPException) as exc:
+        add_line(db_session, el.id, user, part_number="LM317T", quantity=OVER)
+    assert exc.value.status_code == 400
+
+
+def test_resell_update_line_rejects_over_int4_qty(db_session):
+    from app.models.excess import ExcessLineItem
+
+    el, user = _draft(db_session)
+    add_line(db_session, el.id, user, part_number="LM317T", quantity=100)
+    line = db_session.query(ExcessLineItem).filter(ExcessLineItem.excess_list_id == el.id).first()
+    with pytest.raises(HTTPException) as exc:
+        update_line(db_session, el.id, line.id, user, part_number="LM317T", quantity=OVER)
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## P4 (code-QC mediums) — bound quantity inputs to PG INT4

Three quantity intake layers accepted values above PostgreSQL `INTEGER` range and
let a raw psycopg `DataError` surface as an **unhandled 500**. The SQLite test
harness could never catch it — SQLite has no INT4 ceiling. Now bounded at the
edge, so an over-range quantity is a clean 400 / validation error:

| Layer | Before | After |
|---|---|---|
| `schemas/requisitions.py` — `RequirementCreate/Update.target_qty` | `ge=1` only | `ge=1, le=PG_INT4_MAX` |
| `buyplan_workflow/buyplan_lines.py` — `_require_int_quantity` | int fast-path returned before any ceiling | rejects `> PG_INT4_MAX` on **both** int and float-coerced paths |
| `excess_service.py` — resell `add_line` / `update_line` | `quantity <= 0` only | also rejects `> PG_INT4_MAX` (import path was already bounded) |

New tests (`tests/test_p4_int4_qty_ceilings.py`) assert boundary-accepts +
over-range-rejects on all three layers:

```
5 passed  tests/test_p4_int4_qty_ceilings.py
36 passed + test_excess_crud.py + test_integration_requisitions.py
```

Flagged by multiple reviewers in the 2026-08-08 QC audit; P4 tranche of the
2026-08-10 remediation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
