### PR TITLE
fix(P4): contact merge preserves do_not_contact / is_archived

### DIFF
--- a/app/services/contact_merge_service.py
+++ b/app/services/contact_merge_service.py
@@ -84,8 +84,13 @@ def merge_contacts(keep_id: int, remove_id: int, db: Session) -> dict:
         sep = f"\n\n--- Merged from {remove.full_name} ---\n"
         keep.notes = (keep.notes or "") + sep + remove.notes
 
-    # 4. Boolean merge (OR semantics for is_priority; explicit states preserved)
+    # 4. Boolean merge — OR semantics across all three disposition flags (they are
+    #    documented peers on the model). do_not_contact and is_archived are
+    #    suppression signals: dropping the loser's TRUE silently re-enabled outreach
+    #    to a contact someone had marked do-not-contact / archived.
     keep.is_priority = bool(keep.is_priority) or bool(remove.is_priority)
+    keep.do_not_contact = bool(keep.do_not_contact) or bool(remove.do_not_contact)
+    keep.is_archived = bool(keep.is_archived) or bool(remove.is_archived)
 
     # 5. Expire the loser's attachments relationship so ORM cascade doesn't
     #    delete the rows we just reassigned.

--- a/tests/test_contact_merge_move.py
+++ b/tests/test_contact_merge_move.py
@@ -176,6 +176,27 @@ class TestMergeContactsService:
         assert result["kept"] == keeper.id
         assert result["removed"] == loser.id
 
+    def test_dnc_and_archived_preserved_from_loser(self, db_session: Session, keeper: SiteContact, loser: SiteContact):
+        """Loser's do_not_contact / is_archived survive the merge (OR semantics).
+
+        Regression: merging a do-not-contact loser into an active keeper used to
+        drop the flag, silently re-enabling outreach to a contact someone had
+        marked do-not-contact.
+        """
+        keeper.do_not_contact = False
+        keeper.is_archived = False
+        loser.do_not_contact = True
+        loser.is_archived = True
+        db_session.commit()
+
+        from app.services.contact_merge_service import merge_contacts
+
+        merge_contacts(keeper.id, loser.id, db_session)
+        db_session.commit()
+        db_session.refresh(keeper)
+        assert keeper.do_not_contact is True
+        assert keeper.is_archived is True
+
     def test_loser_deleted(self, db_session: Session, keeper: SiteContact, loser: SiteContact):
         """Loser row is deleted after merge."""
         loser_id = loser.id


### PR DESCRIPTION
## P4 (code-QC mediums) — contact merge preserves do_not_contact / is_archived

`merge_contacts` applied OR semantics to `is_priority` only, silently dropping the
loser's `do_not_contact` and `is_archived`. `do_not_contact` is a suppression /
consent signal — merging a do-not-contact loser into an active keeper **re-enabled
outreach to a contact someone had explicitly marked do-not-contact**. `is_archived`
is its documented peer on the model ("Both mirror do_not_contact exactly").

All three disposition flags now OR-merge, so a `True` on either side survives.

```python
keep.is_priority    = bool(keep.is_priority)    or bool(remove.is_priority)
keep.do_not_contact = bool(keep.do_not_contact) or bool(remove.do_not_contact)   # new
keep.is_archived    = bool(keep.is_archived)    or bool(remove.is_archived)       # new
```

Test: do-not-contact + archived loser merged into an active keeper ⇒ keeper ends up
`do_not_contact` and `is_archived`.

```
25 passed  tests/test_contact_merge_move.py
```

Flagged in the 2026-08-08 QC audit (CRM/quotes group); P4 tranche of the 2026-08-10
remediation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
