### PR TITLE
fix(qc): HTML-escape email bodies + cap attachment reads (OOM)

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -1,6 +1,7 @@
 """Email service — batch RFQ sending, inbox monitoring, AI parsing."""
 
 import asyncio
+import html
 import json
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -42,8 +43,13 @@ from .vendor_utils import normalize_vendor_name
 
 
 def _build_html_body(plain_text: str) -> str:
-    """Convert plain text to minimal HTML that looks like a normal email."""
-    html_body = plain_text.replace("\n", "<br>\n")
+    """Convert plain text to minimal HTML that looks like a normal email.
+
+    HTML-escapes first (QC 2026-08-13): every caller passes plain text, so an
+    unescaped ``<`` / ``&`` in a part number or note silently vanished from the
+    delivered RFQ/reply (the browser swallowed it as a bogus tag/entity).
+    """
+    html_body = html.escape(plain_text).replace("\n", "<br>\n")
     return f"""<html><body style="font-family: Calibri, Arial, sans-serif; font-size: 14px; color: #333;">
 {html_body}
 </body></html>"""

--- a/app/services/attachment_service.py
+++ b/app/services/attachment_service.py
@@ -74,6 +74,27 @@ def _trusted_content_type(file_name: str | None) -> str:
     return _EXT_CONTENT_TYPE.get(ext, "application/octet-stream")
 
 
+_READ_CHUNK = 64 * 1024  # 64 KB per read while capping the upload
+
+
+async def _read_capped(file: UploadFile) -> bytes:
+    """Read an UploadFile into memory, aborting the moment it exceeds the size cap.
+
+    QC 2026-08-13: the prior ``await file.read()`` buffered the ENTIRE request body
+    before ``_validate`` ever checked the size, so concurrent oversized uploads
+    could OOM the container (there is no body-size limit in front of the app).
+    """
+    buf = bytearray()
+    while True:
+        chunk = await file.read(_READ_CHUNK)
+        if not chunk:
+            break
+        buf.extend(chunk)
+        if len(buf) > MAX_ATTACHMENT_BYTES:
+            raise HTTPException(400, "File too large (max 10 MB)")
+    return bytes(buf)
+
+
 def _validate(file: UploadFile, content: bytes) -> None:
     """Raise HTTPException(400) if the file exceeds the size limit or has a disallowed
     extension."""
@@ -214,7 +235,7 @@ async def store_and_attach(
     cloud folder (e.g. "Companies") entity_id    — PK of the owning entity file —
     FastAPI UploadFile user         — authenticated User ORM object
     """
-    content = await file.read()
+    content = await _read_capped(file)
     _validate(file, content)
 
     item_id, drive_id, web_url = await _store(

--- a/tests/test_attachment_service.py
+++ b/tests/test_attachment_service.py
@@ -18,6 +18,7 @@ Depends on: conftest.py (db_session, test_user fixtures), app models, attachment
 
 from __future__ import annotations
 
+import io
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -47,7 +48,10 @@ def _make_upload_file(
     f = MagicMock()
     f.filename = filename
     f.content_type = content_type
-    f.read = AsyncMock(return_value=content)
+    # Behave like a real UploadFile: read(n) returns up to n bytes then b'' at EOF,
+    # so the chunked _read_capped loop terminates (a flat return_value would spin).
+    _buf = io.BytesIO(content)
+    f.read = AsyncMock(side_effect=lambda n=-1: _buf.read(n))
     return f
 
 

--- a/tests/test_attachments_coverage2.py
+++ b/tests/test_attachments_coverage2.py
@@ -16,6 +16,7 @@ Called by: pytest
 Depends on: conftest.py (client, db_session, test_user, test_requisition)
 """
 
+import io
 import os
 
 os.environ["TESTING"] = "1"
@@ -439,7 +440,10 @@ class TestUploadRequirementAttachmentNoFilename:
         mock_file = MagicMock(spec=FUF)
         mock_file.filename = None
         mock_file.content_type = "application/pdf"
-        mock_file.read = AsyncMock(return_value=b"small content")
+        # read(n) must honor EOF like a real UploadFile so the chunked _read_capped
+        # loop terminates (a flat return_value would spin to the size cap).
+        _buf = io.BytesIO(b"small content")
+        mock_file.read = AsyncMock(side_effect=lambda n=-1: _buf.read(n))
 
         with patch(
             "app.scheduler.get_valid_token",

--- a/tests/test_qcm_email_attachment_safety.py
+++ b/tests/test_qcm_email_attachment_safety.py
@@ -1,0 +1,61 @@
+"""test_qcm_email_attachment_safety.py — email HTML-escape + attachment OOM cap.
+
+Two 2026-08-08 QC audit findings:
+- _build_html_body did not escape, so a `<`/`&` in an RFQ/reply body vanished
+  from the delivered email.
+- store_and_attach buffered the whole request body before the size check, an
+  OOM vector under concurrent oversized uploads.
+
+Called by: pytest
+Depends on: app.email_service, app.services.attachment_service
+"""
+
+import io
+
+import pytest
+from fastapi import HTTPException
+
+from app.email_service import _build_html_body
+from app.services import attachment_service
+
+# ── Email HTML-escape ─────────────────────────────────────────────────────
+
+
+def test_build_html_body_escapes_angle_brackets_and_amp():
+    out = _build_html_body("price < 5 & part <GSOT36C>")
+    assert "&lt;" in out and "&gt;" in out and "&amp;" in out
+    assert "<GSOT36C>" not in out  # raw tag no longer survives to the client
+
+
+def test_build_html_body_preserves_newline_as_break():
+    out = _build_html_body("line one\nline two")
+    assert "<br>\n" in out
+    assert "line one" in out and "line two" in out
+
+
+# ── Attachment size cap (chunked, early abort) ────────────────────────────
+
+
+class _FakeUpload:
+    """Minimal UploadFile stand-in: only `await read(n)` is exercised."""
+
+    def __init__(self, data: bytes):
+        self._b = io.BytesIO(data)
+
+    async def read(self, n: int = -1) -> bytes:
+        return self._b.read(n)
+
+
+@pytest.mark.anyio
+async def test_read_capped_rejects_oversized(monkeypatch):
+    monkeypatch.setattr(attachment_service, "MAX_ATTACHMENT_BYTES", 100)
+    with pytest.raises(HTTPException) as exc:
+        await attachment_service._read_capped(_FakeUpload(b"x" * 201))
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_read_capped_accepts_boundary(monkeypatch):
+    monkeypatch.setattr(attachment_service, "MAX_ATTACHMENT_BYTES", 100)
+    out = await attachment_service._read_capped(_FakeUpload(b"x" * 100))
+    assert out == b"x" * 100


### PR DESCRIPTION
## QC mediums — email HTML-escape + attachment OOM cap

Two verified 2026-08-08 audit findings (Tier A, mechanical, unit-tested):

**1. Unescaped RFQ/reply email bodies** (`email_service.py::_build_html_body`) — the
function is named `_build_html_body(plain_text)` and every caller passes plain text,
but it never escaped. A `<`/`&` in a part number or note was swallowed by the mail
client and **vanished from the delivered email**. Now `html.escape()` before the
`\n`→`<br>` conversion.

**2. Attachment upload OOM** (`attachment_service.py::store_and_attach`) — read the
**entire** request body into memory before the 10MB check; concurrent oversized
uploads could OOM the container (nothing limits body size in front of the app). New
`_read_capped` reads 64KB chunks and aborts with 400 the instant the accumulator
exceeds `MAX_ATTACHMENT_BYTES`. Updated the shared test mock so `read(n)` honors EOF.

```
55 passed  test_qcm_email_attachment_safety.py + test_attachment_service.py + test_attachments.py
```

From the 2026-08-13 triage worklist (specs/qc-mediums-worklist-2026-08-13.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
