### PR TITLE
fix(qc): proactive authz + single-site guard + scorecard accuracy

### DIFF
--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -597,8 +597,22 @@ async def proactive_scorecard(
         from ...services.proactive_service import get_scorecard
 
         stats = get_scorecard(db, user.id)
-    except (ImportError, RuntimeError, Exception):
-        stats = {"total_sent": 0, "total_converted": 0, "conversion_rate": 0, "total_revenue": 0}
+    except Exception:
+        # QC 2026-08-13: was a silent all-zeros swallow whose keys didn't even
+        # match the template (total_revenue is unused; converted_revenue /
+        # gross_profit / anticipated_revenue / total_quoted / total_po are what
+        # scorecard.html reads). Log it, and mirror get_scorecard's real keys.
+        logger.exception("Proactive scorecard failed for user {}", user.id)
+        stats = {
+            "total_sent": 0,
+            "total_converted": 0,
+            "total_quoted": 0,
+            "total_po": 0,
+            "conversion_rate": 0,
+            "anticipated_revenue": 0,
+            "converted_revenue": 0,
+            "gross_profit": 0,
+        }
 
     return template_response(
         "htmx/partials/proactive/scorecard.html",

--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -110,7 +110,7 @@ async def proactive_list_partial(
 @router.post("/v2/partials/proactive/refresh", response_class=HTMLResponse)
 async def proactive_refresh(
     request: Request,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Trigger a proactive scan then return the matches list partial."""
@@ -130,7 +130,7 @@ async def proactive_refresh(
 @router.post("/v2/partials/proactive/batch-dismiss", response_class=HTMLResponse)
 async def proactive_batch_dismiss(
     request: Request,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Batch dismiss selected proactive matches and reload the list."""
@@ -161,7 +161,7 @@ async def proactive_batch_dismiss(
 async def proactive_prepare_page(
     site_id: int,
     request: Request,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Full-page prepare/send workflow for proactive offers."""
@@ -278,7 +278,7 @@ async def proactive_add_contact(
     full_name: str = Form(""),
     email: str = Form(""),
     title: str = Form(""),
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Add a SiteContact from the Prepare page, then re-render the contact picker.
@@ -353,7 +353,7 @@ async def proactive_add_contact(
 @router.post("/v2/partials/proactive/draft", response_class=HTMLResponse)
 async def proactive_draft_for_prepare(
     request: Request,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """AI-draft a proactive offer email for the prepare page."""
@@ -473,7 +473,7 @@ async def proactive_draft_for_prepare(
 @router.post("/v2/proactive/send", response_class=HTMLResponse)
 async def proactive_send_offer(
     request: Request,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Send a proactive offer email from the prepare page."""
@@ -556,7 +556,7 @@ async def proactive_send_offer(
 async def proactive_convert(
     request: Request,
     offer_id: int,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Convert a won proactive offer into req+quote+buyplan."""
@@ -631,7 +631,7 @@ async def proactive_badge(
 @router.post("/v2/partials/proactive/do-not-offer", response_class=HTMLResponse)
 async def proactive_do_not_offer(
     request: Request,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
     db: Session = Depends(get_db),
 ):
     """Add an MPN+customer combo to the do-not-offer list (with dedup check)."""

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -433,6 +433,13 @@ async def send_proactive_offer(
     if not matches:
         raise ValueError("No valid matches found")
 
+    # Confidentiality guard (QC 2026-08-13): every selected match must belong to
+    # ONE customer site. A mixed match_ids selection would build one email body
+    # from all matches, then send it (and file the throttle) under matches[0]'s
+    # site — leaking one customer's parts/prices to another.
+    if len({m.customer_site_id for m in matches}) > 1:
+        raise ValueError("All selected matches must be for a single customer site")
+
     site_id = matches[0].customer_site_id
     site = db.get(CustomerSite, site_id)
     company = site.company if site else None

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -1076,6 +1076,10 @@ def get_scorecard(db: Session, salesperson_id: int | None = None) -> dict:
                 _summed_when(ProactiveOfferStatus.SENT, ProactiveOffer.total_sell).label("pending"),
                 func.count(ProactiveOffer.converted_quote_id).label("quoted"),
             )
+            # Same base_filter as the top-line query (QC 2026-08-13): without it the
+            # per-rep 'sent' counts included staged DRAFTs and FAILED sends, so the
+            # breakdown didn't reconcile with the headline total.
+            .filter(*base_filter)
             .group_by(ProactiveOffer.salesperson_id)
             .all()
         )

--- a/tests/test_qcm_proactive_authz_site.py
+++ b/tests/test_qcm_proactive_authz_site.py
@@ -72,3 +72,37 @@ async def test_send_proactive_offer_rejects_mixed_sites(
 
     with pytest.raises(ValueError, match="single customer site"):
         await send_proactive_offer(db_session, test_user, "tok", [m1.id, m2.id], [], {})
+
+
+# ── Scorecard accuracy + resilience ───────────────────────────────────────
+
+
+def test_scorecard_breakdown_excludes_draft_and_failed(db_session: Session, test_user, test_customer_site):
+    """The per-rep breakdown must exclude DRAFT + FAILED, matching the headline."""
+    from app.constants import ProactiveOfferStatus
+    from app.models.intelligence import ProactiveOffer
+    from app.services.proactive_service import get_scorecard
+
+    for st in (ProactiveOfferStatus.SENT, ProactiveOfferStatus.DRAFT, ProactiveOfferStatus.FAILED):
+        db_session.add(
+            ProactiveOffer(
+                customer_site_id=test_customer_site.id, salesperson_id=test_user.id, status=st, line_items=[]
+            )
+        )
+    db_session.commit()
+
+    result = get_scorecard(db_session, None)  # admin/all view builds the breakdown
+    mine = [b for b in result["breakdown"] if b["salesperson_id"] == test_user.id]
+    assert mine and mine[0]["sent"] == 1  # only the SENT one counts
+
+
+def test_scorecard_route_survives_service_error(client: TestClient, monkeypatch):
+    """A get_scorecard error renders a zeroed fallback (200), never a 500."""
+    from app.services import proactive_service
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(proactive_service, "get_scorecard", _boom)
+    resp = client.get("/v2/partials/proactive/scorecard", headers={"HX-Request": "true"})
+    assert resp.status_code == 200

--- a/tests/test_qcm_proactive_authz_site.py
+++ b/tests/test_qcm_proactive_authz_site.py
@@ -1,0 +1,74 @@
+"""test_qcm_proactive_authz_site.py — proactive outbound authz + single-site guard.
+
+Two 2026-08-08 QC audit findings:
+- Mutating proactive routes gated on require_user, not PROACTIVE access — a user
+  with proactive revoked could still run the whole outbound flow.
+- send_proactive_offer never asserted all selected matches share one customer
+  site, so a mixed match_ids selection leaked one customer's parts/prices to
+  another (built the body from all matches, sent under matches[0]'s site).
+
+Called by: pytest
+Depends on: conftest fixtures (client, db_session, test_user, test_offer,
+    test_customer_site, test_requisition)
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import AccessKey
+from app.models import User
+from app.models.crm import CustomerSite
+from app.models.intelligence import ProactiveMatch
+
+# ── Authz: revoked PROACTIVE blocks a mutating route ──────────────────────
+
+
+def test_revoked_proactive_blocks_mutating_route(client: TestClient, db_session: Session, test_user: User):
+    """A user with PROACTIVE explicitly denied gets 403 on a mutating route that
+    previously only required a logged-in user."""
+    test_user.access_overrides = {AccessKey.PROACTIVE.value: False}
+    db_session.commit()
+    resp = client.post(
+        "/v2/partials/proactive/draft",
+        data={"match_ids": "1"},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 403
+
+
+# ── Confidentiality: mixed-site selection is rejected pre-send ─────────────
+
+
+@pytest.mark.anyio
+async def test_send_proactive_offer_rejects_mixed_sites(
+    db_session: Session, test_user, test_offer, test_customer_site, test_requisition
+):
+    from app.services.proactive_service import send_proactive_offer
+
+    site_b = CustomerSite(company_id=test_customer_site.company_id, site_name="Other Site", is_active=True)
+    db_session.add(site_b)
+    db_session.commit()
+
+    def _match(site_id):
+        m = ProactiveMatch(
+            offer_id=test_offer.id,
+            requisition_id=test_requisition.id,
+            customer_site_id=site_id,
+            salesperson_id=test_user.id,
+            mpn="LM317T",
+            status="new",
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(m)
+        db_session.commit()
+        db_session.refresh(m)
+        return m
+
+    m1 = _match(test_customer_site.id)
+    m2 = _match(site_b.id)
+
+    with pytest.raises(ValueError, match="single customer site"):
+        await send_proactive_offer(db_session, test_user, "tok", [m1.id, m2.id], [], {})

--- a/tests/test_qcm_proactive_authz_site.py
+++ b/tests/test_qcm_proactive_authz_site.py
@@ -106,3 +106,7 @@ def test_scorecard_route_survives_service_error(client: TestClient, monkeypatch)
     monkeypatch.setattr(proactive_service, "get_scorecard", _boom)
     resp = client.get("/v2/partials/proactive/scorecard", headers={"HX-Request": "true"})
     assert resp.status_code == 200
+    # The zeroed fallback still renders the real scorecard panel (not a 500/error),
+    # and its keys match the template so the values render as 0, not blanks.
+    assert "Proactive Scorecard" in resp.text
+    assert "Gross Profit" in resp.text


### PR DESCRIPTION
## QC mediums — proactive authz + single-site send guard

Two verified 2026-08-08 audit findings (authz + confidentiality):

**1. Mutating proactive routes gated on `require_user`, not PROACTIVE access.** The
newer Process routes already use `Depends(require_access(AccessKey.PROACTIVE))`, but
the outbound mutating routes (refresh, batch-dismiss, prepare, prepare/add-contact,
draft, send, convert, do-not-offer) still let any logged-in user run the whole flow.
Swapped all 8. `do-not-offer` keeps its extra `can_manage_account` check; the two
read-only GETs (scorecard, badge) stay `require_user`.

**2. `send_proactive_offer` never asserted one customer site.** A mixed `match_ids`
selection built one email body from all matches and sent it (and filed the throttle)
under `matches[0]`'s site — **leaking one customer's parts/prices to another**. Added
a pre-send guard: >1 distinct `customer_site_id` → `ValueError`. (The draft path is
anchored to one site at creation and its email is already sent by the time its matches
reload, so the guard belongs on the caller-supplied send path.)

```
114 passed  proactive router suites + new authz/confidentiality tests
```

From the 2026-08-13 triage worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
