### PR TITLE
fix(qc): resell concurrency + idempotency (publish lock, retry card, dup offer)

### DIFF
--- a/app/services/excess_mirror.py
+++ b/app/services/excess_mirror.py
@@ -508,9 +508,14 @@ def publish_list(db: Session, list_id: int, user) -> ExcessList:
     then runs ``sync_list_mirror`` so the posted lines surface to the matcher. Commits.
     Returns the refreshed list.
     """
-    from .excess_service import get_excess_list
+    from .excess_service import _lock_list_row, get_excess_list
 
     excess_list = get_excess_list(db, list_id)
+    # M9 row lock (QC 2026-08-13): every other status writer takes it; publish did not,
+    # so two concurrent publishes both passed the DRAFT check and each created scratch
+    # requisitions + mirror Sightings that are never retired. populate_existing refreshes
+    # excess_list's status so the second caller sees OPEN and 409s.
+    _lock_list_row(db, list_id)
     if excess_list.status != ExcessListStatus.DRAFT:
         raise HTTPException(409, "Only a draft list can be published")
     now = datetime.now(UTC)

--- a/app/services/resell_outreach_service.py
+++ b/app/services/resell_outreach_service.py
@@ -567,8 +567,8 @@ async def _finalize_outreach_send(
 ) -> list[ExcessOutreach]:
     """Send the emails, stamp graph ids, and advance each ``sending`` row to its final
     status. Shared by :func:`submit_outreach_email` (inline) and
-    :func:`run_outreach_email_send` (background) — the ONE place the send + lookup
-    logic lives.
+    :func:`run_outreach_email_send` (background) — the ONE place the send + lookup logic
+    lives.
 
     Reuses the RFQ send engine in its no-requisition mode (email out, no Contact rows;
     the live RFQ tracking path is untouched). Graph ids do NOT come back in
@@ -923,8 +923,8 @@ async def retry_outreach_send(
     token: str,
     session_factory=None,
 ) -> None:
-    """Retry a ``failed`` / ``interrupted`` outreach row — reconcile-first, only
-    resend if the original never actually went out (the double-send guard).
+    """Retry a ``failed`` / ``interrupted`` outreach row — reconcile-first, only resend
+    if the original never actually went out (the double-send guard).
 
     Opens its OWN session (a background job, mirroring :func:`run_outreach_email_send`). A
     row not in a retryable state is skipped (idempotent). The buyer email is resolved, then
@@ -1037,7 +1037,10 @@ async def retry_outreach_send(
         row.recipient_email = row.recipient_email or email  # backfill a legacy NULL row
         db.commit()
         parts = [p.get("part_number") for p in (row.parts_included or []) if p.get("part_number")]
-        plan = [{"card_id": card.id, "email": email, "row_ids": [row.id], "parts": parts}]
+        # Use the stored FK, not card.id (QC 2026-08-13): a merge-nulled card leaves
+        # card=None while recipient_email is still set, so card.id AttributeError'd
+        # AFTER the row was committed to SENDING — cycling it sending->interrupted forever.
+        plan = [{"card_id": row.target_vendor_card_id, "email": email, "row_ids": [row.id], "parts": parts}]
         await _finalize_outreach_send(
             db, excess_list=excess_list, owner=owner, subject=guard_subject, body=resend_body, token=token, plan=plan
         )
@@ -1163,12 +1166,17 @@ def record_response(
         new_status = ExcessOutreachStatus.RESPONDED
 
     _terminal = {ExcessOutreachStatus.BID, ExcessOutreachStatus.DECLINED}
+    # Snapshot BEFORE the loop flips statuses (QC 2026-08-13): gate the offer link on
+    # the SAME terminal check as record_manual_response, so a replayed email response
+    # on an already-BID row does not mint a SECOND ExcessOffer (inflating offer_count /
+    # best_offer_id with no row-level idempotency).
+    already_terminal = rows[0].status in _terminal
     for row in rows:
         if row.status in _terminal:
             continue  # never regress a buyer who already bid / declined
         row.status = new_status
 
-    if has_offer:
+    if has_offer and not already_terminal:
         _link_inbound_offer(db, rows[0], offer_lines or [], offer_notes)
 
     if commit:
@@ -1283,8 +1291,7 @@ def _match_outreach(
     conversation_id: str | None,
     message_id: str | None,
 ) -> list[ExcessOutreach]:
-    """Match a reply to outreach rows — conversation id (whole thread), then message
-    id.
+    """Match a reply to outreach rows — conversation id (whole thread), then message id.
 
     Conversation id is the preferred key (matches all rows on the thread, like RFQ
     Tier-1 fan-out); message id is the exact-touch fallback. Vendor-scoped by

--- a/tests/test_resell_outreach_service.py
+++ b/tests/test_resell_outreach_service.py
@@ -750,3 +750,56 @@ class TestRecordResponse:
         offers = db_session.query(ExcessOffer).filter(ExcessOffer.excess_list_id == excess_list.id).all()
         assert len(offers) == 1
         assert offers[0].id is not None
+
+
+# ── QC 2026-08-13: resell concurrency / idempotency fixes ─────────────────
+
+
+class TestResellQCMediums:
+    def _make_outreach(self, db, excess_list, buyer_card, trader, status="sent"):
+        o = ExcessOutreach(
+            excess_list_id=excess_list.id,
+            target_vendor_card_id=buyer_card.id,
+            submitted_by=trader.id,
+            channel="email",
+            status=status,
+            graph_message_id="msg-1",
+            graph_conversation_id="conv-1",
+        )
+        db.add(o)
+        db.commit()
+        db.refresh(o)
+        return o
+
+    def test_replayed_reply_with_offer_makes_no_duplicate(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        line_item: ExcessLineItem,
+        buyer_card: VendorCard,
+        trader: User,
+    ):
+        """A second inbound reply carrying a bid on an already-BID row must NOT mint a
+        second ExcessOffer (record_response now gates the link on the terminal
+        snapshot)."""
+        self._make_outreach(db_session, excess_list, buyer_card, trader)
+        lines = [{"mpn_raw": "LM358N", "quantity": 500, "unit_price": "1.25"}]
+        svc.record_response(db_session, conversation_id="conv-1", has_offer=True, offer_lines=lines)
+        svc.record_response(db_session, conversation_id="conv-1", has_offer=True, offer_lines=lines)
+        offers = db_session.query(ExcessOffer).filter(ExcessOffer.excess_list_id == excess_list.id).all()
+        assert len(offers) == 1  # was 2 before the fix
+
+    def test_publish_takes_the_list_lock(self, db_session: Session, excess_list: ExcessList, trader: User):
+        """publish_list now takes the M9 row lock (like every other status writer)."""
+        from unittest.mock import patch
+
+        from app.services import excess_mirror, excess_service
+
+        excess_list.status = ExcessListStatus.DRAFT
+        db_session.commit()
+
+        # publish_list does `from .excess_service import _lock_list_row`, so patch the
+        # source module where the name is resolved at call time.
+        with patch.object(excess_service, "_lock_list_row") as lock:
+            excess_mirror.publish_list(db_session, excess_list.id, trader)
+        lock.assert_called_once_with(db_session, excess_list.id)


### PR DESCRIPTION
## QC mediums — resell concurrency + idempotency

Three verified 2026-08-08 resell findings:

**1. `publish_list` took no row lock** (`excess_mirror.py`). Every other status writer
takes the M9 lock; publish didn't, so two concurrent publishes both passed the DRAFT
check and each created scratch requisitions + mirror Sightings that are never retired.
Now takes `_lock_list_row` (`populate_existing` refreshes status so the loser 409s).

**2. Retry crashed on a merge-nulled card** (`resell_outreach_service.retry_outreach_send`).
Built the send plan with `card.id`, which `AttributeError`'d when `card=None` (merged
away) but `recipient_email` was still set — **after** the row was committed to SENDING,
cycling it `sending`↔`interrupted` forever. Now uses the None-safe FK
`row.target_vendor_card_id`.

**3. Replayed reply minted a duplicate offer** (`record_response`). Linked the inbound
`ExcessOffer` without checking whether `rows[0]` was already terminal, so a second reply
on an already-BID row created a **second** offer (inflating `offer_count`/`best_offer_id`).
Now gated on the same terminal snapshot as `record_manual_response`.

```
32 passed  test_resell_outreach_service.py (incl. new dup-offer + publish-lock tests)
```

Note: the publish lock's true concurrency behavior needs PostgreSQL (SQLite no-ops
`FOR UPDATE`); the test asserts the lock is taken. From the 2026-08-13 triage worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
