### PR TITLE
ci: pin pip < 26.2 for lockfile recompile (pip 26.2 removed stdlib_pkgs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
         # Keeps installs reproducible.
         if: matrix.shard == 0
         run: |
+          # pip 26.2 removed pip._internal.utils.compat.stdlib_pkgs, which pip-tools
+          # 7.6.x still imports at compile time -> ImportError breaks pip-compile on
+          # every PR. Pin pip below 26.2 for the recompile until pip-tools ships a
+          # fix; the runner's ambient pip auto-updated into 26.2 (QC 2026-08-13).
+          python -m pip install --quiet "pip<26.2"
           pip-compile --no-header --no-strip-extras --quiet requirements.in
           pip-compile --no-header --no-strip-extras --quiet requirements-dev.in
           if ! git diff --exit-code requirements.txt requirements-dev.txt; then


### PR DESCRIPTION
## CI fix — pin pip < 26.2 for the lockfile recompile

**pip 26.2 (released today, 2026-08-13) removed `pip._internal.utils.compat.stdlib_pkgs`**, which pip-tools 7.6.x still imports at compile time:

```
ImportError: cannot import name 'stdlib_pkgs' from 'pip._internal.utils.compat'
```

The GitHub runner's ambient pip auto-updated into 26.2, so the shard-0 **"Verify requirements lockfiles are in sync"** step now fails on **every open PR** (#849–851 passed hours ago on the older pip). The pytest suites are unaffected — test shard 1 stays green throughout.

Fix: pin pip `< 26.2` for the recompile step until pip-tools ships a compatible release. Verified locally that pip 26.1.2 still exposes `stdlib_pkgs` and pip-tools 7.6.1 imports it cleanly.

This unblocks the merge-gate for all in-flight PRs; the other branches pick it up by merging main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
