### PR TITLE
fix(qc): background-job correctness (bid-due cap + 8x8 CDR scan bound)

### DIFF
--- a/app/jobs/eight_by_eight_jobs.py
+++ b/app/jobs/eight_by_eight_jobs.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime, timedelta
 
 from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
+from sqlalchemy import and_, or_
 
 from ..constants import MEANINGFUL_CALL_OUTCOMES, CallOutcome, RequisitionStatus
 from ..scheduler import _traced_job
@@ -274,7 +275,13 @@ def _find_optimistic_row(db, user_id, direction, external_phone, cdr_occurred_at
     window_start = cdr_occurred_at - window
     window_end = cdr_occurred_at + window
 
-    # Fetch candidate rows: unreconciled, matching user+direction+channel+type
+    # Fetch candidate rows: unreconciled, matching user+direction+channel+type.
+    # Time-bound the scan (QC 2026-08-13): never-reconciled manual call logs keep
+    # external_id NULL forever, so without a bound this full-table scan grew without
+    # limit (48 polls/day). Match on occurred_at (the call time) inside the window;
+    # for rows with no occurred_at, fall back to a generous created_at floor. The
+    # precise ±10min reconciliation still happens in the Python loop below.
+    created_floor = cdr_occurred_at - timedelta(days=2)
     candidates = (
         db.query(ActivityLog)
         .filter(
@@ -283,6 +290,10 @@ def _find_optimistic_row(db, user_id, direction, external_phone, cdr_occurred_at
             ActivityLog.external_id.is_(None),
             ActivityLog.user_id == user_id,
             ActivityLog.direction == direction,
+            or_(
+                ActivityLog.occurred_at.between(window_start, window_end),
+                and_(ActivityLog.occurred_at.is_(None), ActivityLog.created_at >= created_floor),
+            ),
         )
         .all()
     )

--- a/app/jobs/task_jobs.py
+++ b/app/jobs/task_jobs.py
@@ -69,6 +69,10 @@ async def _job_bid_due_alerts():
                 Requisition.deadline != "",
                 Requisition.deadline != "ASAP",
             )
+            # Order by nearest deadline (QC 2026-08-13): without ORDER BY the LIMIT
+            # returned an arbitrary slice, so a genuinely-due req outside that slice
+            # was never alerted. String deadlines sort correctly for ISO dates.
+            .order_by(Requisition.deadline.asc())
             .limit(_BID_DUE_CAP * 3)  # Fetch extra; many may not parse or be in range
             .all()
         )

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -751,8 +751,13 @@ def on_buy_plan_assigned(
 
 
 def on_bid_due_soon(db: Session, requisition_id: int, deadline: str, req_name: str):
-    """Auto-generate 'Bid due' alert task for a requisition approaching deadline."""
-    auto_create_task(
+    """Auto-generate 'Bid due' alert task for a requisition approaching deadline.
+
+    Returns the task (QC 2026-08-13): the caller counts non-None results to honor the
+    per-run cap and log how many it created — without the return it was always None, so
+    the cap and success logging were dead code.
+    """
+    return auto_create_task(
         db,
         requisition_id=requisition_id,
         title=f"Bid due {deadline} — {req_name}",

--- a/tests/test_jobs_coverage.py
+++ b/tests/test_jobs_coverage.py
@@ -131,7 +131,8 @@ def _make_req_mock(id_, deadline, req_name):
 def _db_returning_reqs(mock_db, reqs):
     """Wire mock_db.query so the bid-due-alerts query returns ``reqs``."""
     mock_query = MagicMock()
-    mock_query.filter.return_value.limit.return_value.all.return_value = reqs
+    # Chain mirrors the real query: filter().order_by().limit().all()
+    mock_query.filter.return_value.order_by.return_value.limit.return_value.all.return_value = reqs
     mock_db.query.return_value = mock_query
 
 

--- a/tests/test_qcm_job_correctness.py
+++ b/tests/test_qcm_job_correctness.py
@@ -1,0 +1,62 @@
+"""test_qcm_job_correctness.py — background-job correctness fixes.
+
+Two 2026-08-08 QC audit findings:
+- on_bid_due_soon returned None, so the bid-due job's per-run cap and success
+  logging were dead (it counts non-None results).
+- _find_optimistic_row scanned ALL unreconciled call logs with no time bound, so
+  never-reconciled manual logs grew into an ever-larger full-table scan.
+
+Called by: pytest
+Depends on: app.services.task_service, app.jobs.eight_by_eight_jobs, conftest
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.constants import ActivityType, Channel
+from app.models import ActivityLog
+
+
+def test_on_bid_due_soon_returns_the_task(db_session: Session, test_requisition):
+    """The task is returned so the job can count it against its cap + log it."""
+    from app.services.task_service import on_bid_due_soon
+
+    task = on_bid_due_soon(db_session, test_requisition.id, "2026-09-01", test_requisition.name or "R")
+    assert task is not None
+    assert task.id is not None
+
+
+def test_find_optimistic_row_matches_in_window_with_old_decoy(db_session: Session, test_user):
+    """A valid in-window unreconciled call log still matches even with the new scan
+    bound in place; an old no-occurred_at decoy (below the created_at floor) does
+    not."""
+    from app.jobs.eight_by_eight_jobs import _find_optimistic_row
+
+    now = datetime.now(UTC)
+    phone = "+14155551212"
+    good = ActivityLog(
+        activity_type=ActivityType.CALL_LOGGED,
+        channel=Channel.PHONE,
+        external_id=None,
+        user_id=test_user.id,
+        direction="outbound",
+        contact_phone=phone,
+        occurred_at=now,
+    )
+    decoy = ActivityLog(
+        activity_type=ActivityType.CALL_LOGGED,
+        channel=Channel.PHONE,
+        external_id=None,
+        user_id=test_user.id,
+        direction="outbound",
+        contact_phone=phone,
+        occurred_at=None,
+        created_at=now - timedelta(days=10),
+    )
+    db_session.add_all([good, decoy])
+    db_session.commit()
+
+    match = _find_optimistic_row(db_session, test_user.id, "outbound", phone, now)
+    assert match is not None
+    assert match.id == good.id


### PR DESCRIPTION
## QC mediums — background-job correctness

Three verified 2026-08-08 job findings:

**1. Bid-due job cap + logging were dead** (`task_service.on_bid_due_soon`). It returned
`None`, so the job's `if task: created += 1` never incremented — the per-run cap (20) and
the success log never worked. Now returns the created task.

**2. Bid-due query had no `ORDER BY`** (`task_jobs.py`). `LIMIT(cap*3)` took an arbitrary
slice, so a genuinely-due requisition outside it was never alerted. Added `ORDER BY deadline
ASC` (ISO date strings sort correctly).

**3. 8x8 CDR reconcile scanned unboundedly** (`eight_by_eight_jobs._find_optimistic_row`).
Never-reconciled manual call logs keep `external_id` NULL forever, so the candidate query
grew into an ever-larger full-table scan (48 polls/day). Bounded on `occurred_at` within the
±10min window, with a generous `created_at` floor fallback for rows lacking `occurred_at`;
the precise reconciliation still happens in the Python loop.

```
48 passed  test_8x8_service.py + test_eight_by_eight_coverage.py + new job-correctness tests
```

Includes the merge of #855 (CI pip pin). From the 2026-08-13 triage worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
