### PR TITLE
fix(qc): quote-builder revise anti-hijack (require full req set)

### DIFF
--- a/app/services/quote_builder_service.py
+++ b/app/services/quote_builder_service.py
@@ -477,7 +477,11 @@ def _save_quote_from_builder_core(
     from app.constants import QuoteStatus, RequisitionStatus
     from app.models import Quote, QuoteLine, Requisition
     from app.services.crm_service import next_quote_number
-    from app.services.quote_requisitions import link_quote_to_requisitions, validate_same_customer
+    from app.services.quote_requisitions import (
+        link_quote_to_requisitions,
+        requisition_ids_for_quote,
+        validate_same_customer,
+    )
     from app.services.requisition_state import transition as req_transition
 
     if not req_ids:
@@ -521,6 +525,14 @@ def _save_quote_from_builder_core(
     revision = 1
     old_quote = db.get(Quote, payload.quote_id) if payload.quote_id else None
     if old_quote:
+        # Authz + integrity guard (QC 2026-08-13): you may only revise a quote whose
+        # requisitions are all within the set you're re-quoting (req_ids is already
+        # access-checked upstream). Without this, any quote_id could be passed to
+        # revise a quote on another rep's requisition (hijack), or a combined quote
+        # could be revised from a partial req set, silently stranding its siblings.
+        old_req_ids = set(requisition_ids_for_quote(db, old_quote.id))
+        if old_req_ids and not old_req_ids.issubset(set(req_ids)):
+            raise ValueError("This revision must include all of the original quote's requisitions.")
         old_revision = old_quote.revision or 1
         quote_number = old_quote.quote_number
         revision = old_revision + 1

--- a/tests/test_build_quote_multi_req.py
+++ b/tests/test_build_quote_multi_req.py
@@ -422,3 +422,33 @@ class TestBuyPlanGuard:
 
 def _payload(lines: list[dict]) -> QuoteBuilderSaveRequest:
     return QuoteBuilderSaveRequest(lines=lines)
+
+
+# ── QC 2026-08-13: revise-hijack / combined-quote-collapse guard ──────────────
+
+
+def test_revise_rejects_partial_req_set(db_session: Session, test_user: User, combo):
+    """Revising a combined quote from a PARTIAL req set is rejected — otherwise a caller
+    could hijack another rep's quote by id, or strand a combined quote's sibling
+    requisitions."""
+    from app.schemas.quote_builder import QuoteBuilderSaveRequest
+    from app.services.quote_builder_service import save_quote_from_builder_multi
+
+    r1, i1, o1 = combo["r1"]
+    r2, i2, o2 = combo["r2"]
+
+    created = save_quote_from_builder_multi(
+        db_session,
+        [r1.id, r2.id],
+        QuoteBuilderSaveRequest(lines=[_line(i1, o1, "LM317T", 0.60, 0.40), _line(i2, o2, "NE555P", 0.30, 0.20)]),
+        test_user,
+    )
+    qid = created["quote_id"]
+
+    with pytest.raises(ValueError, match="all of the original quote"):
+        save_quote_from_builder_multi(
+            db_session,
+            [r1.id],  # missing r2 — would strand it / is a hijack of the combined quote
+            QuoteBuilderSaveRequest(lines=[_line(i1, o1, "LM317T", 0.65, 0.40)], quote_id=qid),
+            test_user,
+        )


### PR DESCRIPTION
## QC mediums — quote-builder revise anti-hijack

`_save_quote_from_builder_core` loaded the quote-to-revise via `db.get(Quote, payload.quote_id)` with **no ownership or requisition check**. So any `quote_id` could be passed to "revise" a quote on **another rep's requisition** (hijack), or a combined quote could be revised from a **partial** req set — silently stranding its sibling requisitions on the superseded quote.

**Guard:** the old quote's requisitions must all be within `req_ids` (which is already access-checked upstream); otherwise `ValueError` → user-facing error. Legitimate single- and multi-req revisions are unaffected.

```
15 passed  test_build_quote_multi_req.py — creating a combined quote across r1+r2
           then revising it with only r1 is now rejected; all legit flows still pass
```

Includes the merge of #855 (CI pip pin). From the 2026-08-13 triage worklist (the sibling HTMX quote path was already guarded; this closes the builder path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
