### PR TITLE
fix(qc): proactive send honesty (no phantom sent, no $0 price)

### DIFF
--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -532,6 +532,17 @@ async def proactive_send_offer(
             allow_all=is_manager_or_admin(user),
         )
 
+        # Honest outcome (QC 2026-08-13): send_proactive_offer swallows a Graph
+        # rejection and marks the offer + matches FAILED (persisted), returning
+        # normally. Don't show a phantom "sent" banner — surface the failure so the
+        # HTMX error toast fires, matching the prepared-send path.
+        from ...constants import ProactiveOfferStatus
+
+        if result.get("status") == ProactiveOfferStatus.FAILED:
+            raise HTTPException(
+                502, "Send failed — Microsoft rejected the message. The offer was not delivered; try again."
+            )
+
         # Success — reload matches list with success banner
         parts_count = len(result.get("line_items", []))
         contacts_count = len(result.get("recipient_emails", []))
@@ -541,6 +552,8 @@ async def proactive_send_offer(
 
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
+    except HTTPException:
+        raise  # our own 502 phantom-send guard — don't remap it to a generic 500
     except Exception as exc:
         logger.error("Proactive send failed: {}", exc)
         raise HTTPException(500, "Send failed. Please try again or contact support.") from exc

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -312,17 +312,17 @@ def _build_line_items(matches: list, sell_prices: dict) -> tuple[list, Decimal, 
         if not offer:
             continue
         cost = float(offer.unit_price) if offer.unit_price else 0
-        # QC 2026-08-08: a missing cost made the default 0*1.3=0, so a draft went
-        # out quoting the customer $0.00. A seeded sell_price (incl. an
-        # intentional 0) is honored; otherwise fall back to cost x 1.3 — and if
-        # there is NO price basis at all (no anchor, no cost) skip the line
-        # rather than stage a priceless offer. The match stays NEW and resurfaces.
+        # Never email a customer a $0.00 unit price (QC 2026-08-13, supersedes the
+        # earlier "intentional 0 honored" note): use the seeded sell price if given,
+        # else fall back to cost x 1.3, then skip the line if the resolved price is
+        # non-positive (missing basis OR a 0/negative seed). The match stays NEW and
+        # resurfaces — a proactive customer offer must carry a real price.
         sell = sell_prices.get(str(m.id))
-        if sell is None:
-            if not cost:
-                logger.warning("Proactive: skipping match {} ({}) — no price basis for a sell price", m.id, m.mpn)
-                continue
+        if sell is None and cost:
             sell = cost * 1.3
+        if not sell or float(sell) <= 0:
+            logger.warning("Proactive: skipping match {} ({}) — no positive sell price", m.id, m.mpn)
+            continue
         target = m.requirement.target_qty if m.requirement else 0
         avail = offer.qty_available or 0
         qty = min(avail, target) if target > 0 else avail

--- a/tests/test_qcm_proactive_honesty.py
+++ b/tests/test_qcm_proactive_honesty.py
@@ -1,0 +1,78 @@
+"""test_qcm_proactive_honesty.py — proactive send never lies about the outcome.
+
+Two 2026-08-08 QC audit findings:
+- send_proactive_offer swallows a Graph rejection (marks the offer FAILED) but the
+  send route still rendered a "sent" success banner — a phantom success.
+- _build_line_items honored a seeded 0 sell price, emailing a customer a $0.00
+  unit price.
+
+Called by: pytest
+Depends on: app.services.proactive_service, app.routers.htmx.proactive, conftest
+"""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+def _seeded_match(db: Session, mpn: str, unit_price: str):
+    from app.models import Offer, ProactiveMatch, Requirement, Requisition, User
+
+    user = User(email=f"{mpn}@x.com", name="R", role="sales", azure_id=f"az-{mpn}")
+    db.add(user)
+    db.flush()
+    req = Requisition(name=f"rq-{mpn}", status="open", created_by=user.id)
+    db.add(req)
+    db.flush()
+    requirement = Requirement(requisition_id=req.id, primary_mpn=mpn, target_qty=10)
+    db.add(requirement)
+    db.flush()
+    offer = Offer(vendor_name="V", mpn=mpn, qty_available=100, unit_price=Decimal(unit_price), status="active")
+    db.add(offer)
+    db.flush()
+    m = ProactiveMatch(offer_id=offer.id, requirement_id=requirement.id, salesperson_id=user.id, mpn=mpn, status="new")
+    db.add(m)
+    db.flush()
+    m.offer = offer
+    m.requirement = requirement
+    return m
+
+
+def test_build_line_items_skips_seeded_zero_price(db_session: Session):
+    """A seeded 0 sell price must NOT email a $0.00 line, even with a cost basis."""
+    from app.services.proactive_service import _build_line_items
+
+    m = _seeded_match(db_session, "ZEROSEED", "8.00")
+    lines, total_sell, _ = _build_line_items([m], {str(m.id): 0})
+    assert lines == []
+    assert total_sell == Decimal("0")
+
+
+def test_build_line_items_keeps_positive_seeded_price(db_session: Session):
+    from app.services.proactive_service import _build_line_items
+
+    m = _seeded_match(db_session, "POSSEED", "8.00")
+    lines, _, _ = _build_line_items([m], {str(m.id): 1.25})
+    assert len(lines) == 1
+    assert lines[0]["sell_price"] == 1.25
+
+
+def test_send_surfaces_failure_not_phantom_success(client: TestClient, monkeypatch):
+    """When the Graph send fails, the route raises (error toast), never a 'sent'
+    banner."""
+    from app.services import proactive_service
+
+    async def _failed(**kwargs):
+        return {"status": "failed", "line_items": [], "recipient_emails": []}
+
+    monkeypatch.setattr(proactive_service, "send_proactive_offer", _failed)
+    monkeypatch.setattr("app.scheduler.get_valid_token", AsyncMock(return_value="tok"))
+    resp = client.post(
+        "/v2/proactive/send",
+        data={"match_ids": "1", "contact_ids": "1"},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 502
+    assert "sent" not in resp.text.lower() or "not delivered" in resp.text.lower()


### PR DESCRIPTION
## QC mediums — proactive send honesty

Two verified findings (proactive outbound):

**1. Phantom "sent" banner.** `send_proactive_offer` swallows a Graph rejection — it marks the offer + matches FAILED (persisted, honest DB) and returns normally — so the send route always rendered *"Offer sent to N contacts"* even when nothing was delivered. The route now checks the returned status and raises **502** on FAILED (HTMX error toast), matching the prepared-send path. Added `except HTTPException: raise` so the guard isn't remapped to a generic 500.

**2. $0.00 customer price.** `_build_line_items` honored a seeded/derived sell price of 0, emailing a **$0.00 unit price**. Now any non-positive resolved price skips the line (match stays NEW, resurfaces). ⚠️ This **supersedes the earlier "intentional 0 honored"** note — a proactive customer offer must carry a real price. If intentional $0 giveaways are ever wanted, that should be an explicit separate feature.

```
187 passed  proactive suites  ·  0 assertion-theater violations
```

From the 2026-08-13 triage worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea
