### PR TITLE
fix(qc): money-path concurrency locks + honest approval-email failures

### DIFF
--- a/app/services/approvals/notifications.py
+++ b/app/services/approvals/notifications.py
@@ -40,13 +40,15 @@ except Exception:  # pragma: no cover
 async def send_email(user, subject: str, html_body: str, db: Session) -> None:
     """Send a single approval notification email via Graph API.
 
-    Silently skips when token fetch returns nothing (user not authenticated). On any
-    other error, re-raises so the dispatcher can record it.
+    Raises when token fetch returns nothing (user not authenticated) — like any other
+    send error — so the outbox dispatcher records a failure (fail_count/last_error →
+    retry, then dead-letter) instead of stamping ``sent_at`` on an email that never
+    went out. Previously it returned silently and the dispatcher marked the row sent,
+    losing the requester's only notice of the decision (QC 2026-08-13).
     """
     token = await get_valid_token(user, db)
     if not token:
-        logger.warning("approval email skipped — no token for {}", user.email)
-        return
+        raise RuntimeError(f"approval email not sent — no Graph token for {user.email}")
     gc = GraphClient(token)
     await gc.post_json(
         "/me/sendMail",

--- a/app/services/buyplan_workflow/buyplan_approval.py
+++ b/app/services/buyplan_workflow/buyplan_approval.py
@@ -315,6 +315,11 @@ def _cancel_open_prepayment_requests_for_plan(
     )
     if line_ids is not None:
         stmt = stmt.where(Prepayment.buy_plan_line_id.in_(line_ids))
+    # Row lock (QC 2026-08-13): serialize the teardown sweep against a concurrent
+    # approve/mark-paid on the same prepayment, so it can't leave an APPROVED
+    # prepayment with a live pay link on a torn-down plan. FOR UPDATE re-checks the
+    # status WHERE against the latest committed row. (SQLite no-ops FOR UPDATE.)
+    stmt = stmt.with_for_update()
     open_requests = db.execute(stmt).scalars().all()
     for ar in open_requests:
         ar.status = ApprovalRequestStatus.CANCELLED
@@ -328,6 +333,7 @@ def _cancel_open_prepayment_requests_for_plan(
     )
     if line_ids is not None:
         pp_stmt = pp_stmt.where(Prepayment.buy_plan_line_id.in_(line_ids))
+    pp_stmt = pp_stmt.with_for_update()  # lock the approved prepayments before voiding (QC 2026-08-13)
     approved_prepayments = db.execute(pp_stmt).scalars().all()
     for pp in approved_prepayments:
         pp.status = PrepaymentStatus.VOID.value

--- a/app/services/prepayment_service.py
+++ b/app/services/prepayment_service.py
@@ -280,6 +280,15 @@ def mark_prepayment_paid(
         schedule_prepayment_notify,
     )
 
+    # Row lock (QC 2026-08-13): re-fetch under FOR UPDATE so two concurrent
+    # confirmations (a double-submit, or the accounting email link racing the in-app
+    # fallback) serialize. The second blocks until the first commits PAID, then the
+    # guard below fires — instead of both fanning out the paid notice and the second
+    # overwriting wire_reference / paid_amount / confirmer. (SQLite no-ops FOR UPDATE.)
+    locked = db.query(Prepayment).filter(Prepayment.id == prepayment.id).with_for_update().one_or_none()
+    if locked is not None:
+        prepayment = locked
+
     if prepayment.status != PrepaymentStatus.APPROVED.value:
         raise ValueError("Only an approved prepayment can be marked paid.")
 

--- a/tests/test_approval_outbox.py
+++ b/tests/test_approval_outbox.py
@@ -383,3 +383,29 @@ async def test_email_dispatch_path_committing_session_does_not_abort_batch(db_se
 
     notifs = db_session.execute(select(Notification).where(Notification.user_id == other.id)).scalars().all()
     assert len(notifs) == 1, "the in_app sibling's Notification must be written"
+
+
+@pytest.mark.asyncio
+async def test_email_channel_no_token_is_failure_not_sent(db_session):
+    """No Graph token → the row is a FAILURE (fail_count++, sent_at NULL), not a silent
+    'sent'.
+
+    The requester's only notice of the decision must not be lost.
+    """
+    from app.jobs.approval_outbox import dispatch_pending
+
+    user = _make_user(db_session, "notok@example.com")
+    req = _make_request(db_session, user)
+    row = _pending_outbox(db_session, req, user, channel="email")
+    db_session.commit()
+
+    with patch(
+        "app.services.approvals.notifications.get_valid_token",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await dispatch_pending(db_session)
+
+    db_session.refresh(row)
+    assert row.sent_at is None, "no-token email must NOT be marked sent"
+    assert row.fail_count == 1, "fail_count must increment so retry/dead-letter engages"

--- a/tests/test_prepayment_mark_paid.py
+++ b/tests/test_prepayment_mark_paid.py
@@ -252,3 +252,16 @@ def test_unmark_paid_manager_only(db_session: Session):
     assert r.status_code == 403
     db_session.refresh(pp)
     assert pp.status == PrepaymentStatus.PAID.value  # still paid
+
+
+def test_mark_paid_twice_is_rejected(db_session: Session, approved_prepay: Prepayment):
+    """A second mark-paid on a now-PAID prepayment raises (the FOR UPDATE re-fetch +
+    status re-check serialize a double-submit, so the paid fan-out never double-fires
+    and wire_reference / confirmer aren't overwritten)."""
+    pp = approved_prepay
+    mark_prepayment_paid(db_session, pp, wire_reference="WIRE-1", paid_amount=Decimal("20002.38"), paid_via="in_app")
+    with pytest.raises(ValueError):
+        mark_prepayment_paid(
+            db_session, pp, wire_reference="WIRE-2", paid_amount=Decimal("20002.38"), paid_via="in_app"
+        )
+    assert pp.wire_reference == "WIRE-1"  # the second call never overwrote it


### PR DESCRIPTION
See commit. Prepayment mark-paid + teardown FOR UPDATE locks (SQLite no-ops; PG-real), and approval email raises on no-token so the outbox retries/dead-letters instead of a phantom 'sent'. 453 passed across prepayment/approval/teardown suites; 0 assertion-theater violations. From the 2026-08-13 triage worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea