### PR TITLE
fix(qc): 8x8 CDR fetch failure holds the watermark (no call-record loss)

### DIFF
--- a/app/jobs/eight_by_eight_jobs.py
+++ b/app/jobs/eight_by_eight_jobs.py
@@ -91,6 +91,7 @@ async def _process_cdrs(db, settings) -> dict:
     from ..models.config import SystemConfig
     from ..services.activity_service import log_call_activity, match_phone_to_entity
     from ..services.eight_by_eight_service import (
+        CdrFetchError,
         get_access_token,
         get_cdrs,
         normalize_cdr,
@@ -114,7 +115,13 @@ async def _process_cdrs(db, settings) -> dict:
         logger.error(f"8x8 auth failed, skipping poll: {e}")
         return {"processed": 0, "matched": 0, "skipped": 0}
 
-    cdrs = await get_cdrs(token, settings, since, until)
+    try:
+        cdrs = await get_cdrs(token, settings, since, until)
+    except CdrFetchError as e:
+        # Fetch failed (QC 2026-08-13): do NOT advance the watermark, or the window's
+        # unfetched call records are lost forever. Retry the same window next poll.
+        logger.warning("8x8 CDR fetch failed — leaving watermark at {} for retry: {}", since, e)
+        return {"processed": 0, "matched": 0, "skipped": 0}
     if not cdrs:
         _update_watermark(db, watermark_row, until)
         return {"processed": 0, "matched": 0, "skipped": 0}

--- a/app/services/eight_by_eight_service.py
+++ b/app/services/eight_by_eight_service.py
@@ -25,6 +25,16 @@ from app.http_client import http
 
 BASE_URL = "https://api.8x8.com/analytics/work/v1"
 
+
+class CdrFetchError(Exception):
+    """A CDR fetch failed (HTTP error / non-200).
+
+    Raised so the poll caller can tell a failed fetch from a clean empty window and NOT
+    advance its watermark past unfetched records (which would lose those call records
+    forever). QC 2026-08-13.
+    """
+
+
 # Module-level OAuth token cache.
 # _token_cache["token"] is reused until _token_cache["expires_at"] - 60s.
 
@@ -118,7 +128,9 @@ async def get_cdrs(token: str, settings, since: datetime, until: datetime) -> li
     """Fetch Call Detail Records from the 8x8 Analytics API.
 
     GET /v1/cdr with pbxId=allpbxes, isCallRecord=true, time window, and timezone.
-    Paginates via scrollId. Returns empty list on any error — never crashes.
+    Paginates via scrollId. Raises ``CdrFetchError`` on an HTTP error / non-200 so the
+    caller does NOT advance its watermark past unfetched records (QC 2026-08-13) — a
+    genuinely-empty window still returns ``[]``.
 
     Async — uses the shared pooled http client so it never blocks the event loop and
     reuses connections across calls.
@@ -148,11 +160,11 @@ async def get_cdrs(token: str, settings, since: datetime, until: datetime) -> li
             resp = await http.get(url, headers=headers, params=params, timeout=30)
         except httpx.HTTPError as e:
             logger.error(f"8x8 CDR fetch failed: {e}")
-            return all_records
+            raise CdrFetchError(str(e)) from e
 
         if resp.status_code != 200:
             logger.error(f"8x8 CDR fetch error: HTTP {resp.status_code} — {resp.text[:200]}")
-            return all_records
+            raise CdrFetchError(f"HTTP {resp.status_code}")
 
         body = resp.json()
         records = body.get("data", [])

--- a/tests/test_8x8_jobs.py
+++ b/tests/test_8x8_jobs.py
@@ -186,3 +186,27 @@ class TestProcessCdrsIntegration:
         assert kwargs["user_id"] == 1
         assert kwargs["direction"] == "outbound"
         assert kwargs["phone"] == "+15551234567"
+
+
+class TestProcessCdrsFetchFailure:
+    """A failed CDR fetch must NOT advance the watermark (QC 2026-08-13)."""
+
+    @patch("app.jobs.eight_by_eight_jobs._update_watermark")
+    @patch("app.services.eight_by_eight_service.get_cdrs", new_callable=AsyncMock)
+    @patch("app.services.eight_by_eight_service.get_access_token", new_callable=AsyncMock)
+    async def test_fetch_failure_holds_watermark(self, mock_auth, mock_fetch, mock_update_wm):
+        from app.jobs.eight_by_eight_jobs import _process_cdrs
+        from app.services.eight_by_eight_service import CdrFetchError
+
+        mock_auth.return_value = "token"
+        mock_fetch.side_effect = CdrFetchError("HTTP 500")
+
+        db = MagicMock()
+        wm_query = MagicMock()
+        wm_query.filter.return_value.first.return_value = None
+        db.query.return_value = wm_query
+
+        result = await _process_cdrs(db, ENABLED_SETTINGS)
+
+        assert result["processed"] == 0
+        mock_update_wm.assert_not_called()  # watermark held so records aren't lost

--- a/tests/test_8x8_service.py
+++ b/tests/test_8x8_service.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.services.eight_by_eight_service import get_access_token, get_cdrs, normalize_cdr
+from app.services.eight_by_eight_service import CdrFetchError, get_access_token, get_cdrs, normalize_cdr
 
 FAKE_SETTINGS = SimpleNamespace(
     eight_by_eight_api_key="test-key",
@@ -75,15 +75,16 @@ class TestGetAccessToken:
 
 
 class TestGetCdrs:
-    async def test_returns_empty_on_api_error(self):
+    async def test_raises_on_api_error(self):
+        """A non-200 raises CdrFetchError so the poll caller holds its watermark."""
         mock_resp = MagicMock()
         mock_resp.status_code = 500
         mock_resp.text = "Internal Server Error"
         factory = _mock_async_client(get=mock_resp)
 
         with patch("app.services.eight_by_eight_service.http", factory):
-            result = await get_cdrs("token", FAKE_SETTINGS, SINCE, UNTIL)
-        assert result == []
+            with pytest.raises(CdrFetchError):
+                await get_cdrs("token", FAKE_SETTINGS, SINCE, UNTIL)
 
     async def test_returns_records_from_data_key(self):
         mock_resp = MagicMock()

--- a/tests/test_eight_by_eight_coverage.py
+++ b/tests/test_eight_by_eight_coverage.py
@@ -20,6 +20,7 @@ import httpx
 import pytest
 
 from app.services.eight_by_eight_service import (
+    CdrFetchError,
     _token_cache,
     get_access_token,
     get_cdrs,
@@ -161,13 +162,13 @@ class TestGetAccessToken:
 
 
 class TestGetCdrs:
-    async def test_returns_empty_on_http_error(self):
+    async def test_raises_on_http_error(self):
         factory = _mock_async_client(get=httpx.HTTPError("connection refused"))
         since = datetime(2026, 3, 1, tzinfo=UTC)
         until = datetime(2026, 3, 2, tzinfo=UTC)
         with patch("app.services.eight_by_eight_service.http", factory):
-            result = await get_cdrs("token", FAKE_SETTINGS, since, until)
-        assert result == []
+            with pytest.raises(CdrFetchError):
+                await get_cdrs("token", FAKE_SETTINGS, since, until)
 
     async def test_stops_when_all_records_fetched(self):
         """Stops paginating when all records are already in all_records."""


### PR DESCRIPTION
get_cdrs returned a partial list on any error, so the poll couldn't distinguish a failed fetch from an empty window and advanced its watermark past unfetched records — losing those call records forever (48 polls/day). get_cdrs now raises CdrFetchError on HTTP-error/non-200; _process_cdrs catches it and does NOT advance the watermark (retries the window next poll). Kept the list return type (raise, not a tuple) so ~15 get_cdrs->list test mocks are untouched; only 2 error-path unit tests changed. 80 passed across 8x8 + call-reconcile suites; 0 NEW assertion-theater violations. From the 2026-08-13 triage worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea