### PR TITLE
perf(qc): offload O(n^2) part-equivalence candidate scan off the event loop

### DIFF
--- a/app/services/part_equivalence.py
+++ b/app/services/part_equivalence.py
@@ -23,6 +23,7 @@ Depends on: models (PartEquivalence, Offer, Requirement), utils/claude_client,
     utils/normalization.
 """
 
+import asyncio
 from datetime import UTC, datetime
 
 from loguru import logger
@@ -211,7 +212,10 @@ async def classify_new_pairs(db: Session, spellings_by_key: dict[str, str], *, l
     """
     from ..utils.claude_client import claude_json
 
-    pairs = find_candidate_pairs(spellings_by_key)
+    # find_candidate_pairs is O(n^2) in the number of distinct keys; running it
+    # inline would block the event loop when the window is large. Offload it to a
+    # worker thread so the loop stays responsive — same pairs, same verdicts.
+    pairs = await asyncio.get_running_loop().run_in_executor(None, find_candidate_pairs, spellings_by_key)
     if not pairs:
         return 0
     existing = {

--- a/tests/test_part_equivalence.py
+++ b/tests/test_part_equivalence.py
@@ -109,6 +109,29 @@ async def test_classify_bad_verdict_becomes_uncertain(db_session):
     assert db_session.query(PartEquivalence).one().verdict == "uncertain"
 
 
+@pytest.mark.anyio
+async def test_classify_offloads_candidate_scan_but_keeps_verdicts(db_session):
+    """find_candidate_pairs now runs in an executor (perf); verdicts are unchanged.
+
+    A modest multi-key window yields one suffix candidate pair; the stored verdict and
+    reason must match the model's reply exactly — proof the thread offload did not alter
+    classification outputs.
+    """
+    spellings = {"ltc1234": "LTC1234", "ltc1234e3": "LTC1234-E3", "unrelated9": "UNRELATED9"}
+    with patch(
+        "app.utils.claude_client.claude_json",
+        new_callable=AsyncMock,
+        return_value={"verdict": "same", "confidence": 0.9, "reason": "LTC -E3 = lead-free packaging code"},
+    ):
+        stored = await classify_new_pairs(db_session, spellings)
+    assert stored == 1
+    row = db_session.query(PartEquivalence).one()
+    assert (row.key_a, row.key_b) == ("ltc1234", "ltc1234e3")
+    assert row.verdict == "same"
+    assert row.source == "ai"
+    assert row.reason == "LTC -E3 = lead-free packaging code"
+
+
 # ── Class expansion ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
From the 2026-08-13 QC-mediums worklist (parallel-implemented, reviewed). Local: tests pass + 0 new assertion-theater violations. Fix key: part-equiv-perf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea