### PR TITLE
fix(qc): stock-list re-ingest ignores soft-deleted MaterialCards

### DIFF
--- a/app/services/stock_list_ingest.py
+++ b/app/services/stock_list_ingest.py
@@ -170,7 +170,14 @@ def ingest_stock_list(
             )
             continue
 
-        card = db.query(MaterialCard).filter_by(normalized_mpn=norm).first()
+        # Only ACTIVE cards match: prod runs a PARTIAL unique index (WHERE deleted_at
+        # IS NULL), so a soft-deleted twin must not capture the ingest — a new active
+        # card is created instead (the partial unique allows the coexisting dead row).
+        card = (
+            db.query(MaterialCard)
+            .filter(MaterialCard.normalized_mpn == norm, MaterialCard.deleted_at.is_(None))
+            .first()
+        )
         if not card:
             card = MaterialCard(
                 normalized_mpn=norm,
@@ -182,7 +189,11 @@ def ingest_stock_list(
                 db.flush()
             except IntegrityError:
                 db.rollback()
-                card = db.query(MaterialCard).filter_by(normalized_mpn=norm).first()
+                card = (
+                    db.query(MaterialCard)
+                    .filter(MaterialCard.normalized_mpn == norm, MaterialCard.deleted_at.is_(None))
+                    .first()
+                )
                 if not card:
                     result.skipped_rows += 1
                     result.warnings.append(

--- a/tests/test_materials_router_coverage.py
+++ b/tests/test_materials_router_coverage.py
@@ -2464,7 +2464,7 @@ class TestImportStockDirectIntegrityErrors:
                     from unittest.mock import MagicMock as _MM
 
                     mock_q = _MM()
-                    mock_q.filter_by.return_value.first.return_value = None
+                    mock_q.filter.return_value.first.return_value = None
                     return mock_q
             return q
 
@@ -2522,7 +2522,7 @@ class TestImportStockDirectIntegrityErrors:
                 from unittest.mock import MagicMock as _MM
 
                 mock_q = _MM()
-                mock_q.filter_by.return_value.first.return_value = None
+                mock_q.filter.return_value.first.return_value = None
                 return mock_q
             return q
 

--- a/tests/test_vendor_stock_upload.py
+++ b/tests/test_vendor_stock_upload.py
@@ -12,6 +12,7 @@ Depends on: routers/htmx_views.py, routers/materials.py, services/stock_list_ing
 """
 
 import io
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -156,6 +157,56 @@ def test_ingest_service_existing_vendor_reused(db_session):
     )
     assert result.new_vendor is False
     assert db_session.query(VendorCard).filter_by(normalized_name=norm).count() == 1
+
+
+def test_ingest_does_not_reuse_soft_deleted_card(db_session):
+    """A soft-deleted MaterialCard must NOT capture a re-ingest of the same MPN.
+
+    Prod runs a partial unique index (WHERE deleted_at IS NULL), so the card lookup must
+    match only ACTIVE cards — the dead twin keeps its own rows and the re-ingest
+    bypasses it (a fresh active card is created on PG). Before the fix, the lookup
+    matched the soft-deleted row and linked new vendor history to the dead card.
+    """
+    # 1) First ingest creates one active card for the MPN.
+    ingest_stock_list(
+        db_session,
+        filename="stock.csv",
+        content=b"mpn,qty,price\nDEADCARD1,10,1.00",
+        vendor_name="Alpha Vendor",
+    )
+    dead = db_session.query(MaterialCard).filter_by(normalized_mpn="deadcard1").one()
+    dead_id = dead.id
+
+    # 2) Soft-delete that card; pre-create the second vendor (committed, so the
+    #    service never rolls back a pending new-vendor row on the SQLite retry path).
+    dead.deleted_at = datetime.now(UTC)
+    norm_bravo = normalize_vendor_name("Bravo Vendor")
+    db_session.add(VendorCard(normalized_name=norm_bravo, display_name="Bravo Vendor", emails=[], phones=[]))
+    db_session.commit()
+
+    # 3) Re-ingest the SAME MPN from the second vendor.
+    ingest_stock_list(
+        db_session,
+        filename="stock.csv",
+        content=b"mpn,qty,price\nDEADCARD1,20,2.00",
+        vendor_name="Bravo Vendor",
+    )
+
+    # The dead card captured NONE of the re-ingest: no vendor history for the new
+    # vendor was ever attached to it.
+    assert (
+        db_session.query(MaterialVendorHistory).filter_by(material_card_id=dead_id, vendor_name=norm_bravo).count() == 0
+    )
+    # It is never the ACTIVE match for the MPN. (On PG a fresh active card exists; on
+    # SQLite the full unique index blocks a twin, so no active row exists — either way
+    # the dead card id is never returned by the active-only lookup.)
+    active = (
+        db_session.query(MaterialCard)
+        .filter(MaterialCard.normalized_mpn == "deadcard1", MaterialCard.deleted_at.is_(None))
+        .first()
+    )
+    if active is not None:
+        assert active.id != dead_id
 
 
 # ── Removals: old vendor-import route + CRM "Find by Part" sub-tab ─────────


### PR DESCRIPTION
From the 2026-08-13 QC-mediums worklist (parallel-implemented, reviewed). Local: tests pass + 0 new assertion-theater violations. Fix key: normalized-mpn-filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea