### PR TITLE
fix(qc): Teams push watermark advances contiguously (no skipped matches)

### DIFF
--- a/app/services/proactive_teams_push.py
+++ b/app/services/proactive_teams_push.py
@@ -95,10 +95,15 @@ async def push_new_matches_to_teams(db: Session) -> dict[str, int]:
     Returns ``{"pushed": <count>}`` — 0 when there is nothing new.
     """
     last_id = _get_last_id(db)
+    # Window by id ASC (QC 2026-08-13), NOT by score: the watermark advances to this
+    # page's max id, so the page must be CONTIGUOUS in id — otherwise a NEW match with
+    # an id below the page's max but outside a top-by-score slice would be jumped over
+    # and never pushed (matches are only ever deduped by this watermark; the push does
+    # not flip their status). The digest card is score-sorted below for display.
     matches: list[ProactiveMatch] = (
         db.query(ProactiveMatch)
         .filter(ProactiveMatch.status == ProactiveMatchStatus.NEW, ProactiveMatch.id > last_id)
-        .order_by(ProactiveMatch.match_score.desc(), ProactiveMatch.id.asc())
+        .order_by(ProactiveMatch.id.asc())
         .limit(_SCAN_CAP)
         .all()
     )
@@ -112,9 +117,12 @@ async def push_new_matches_to_teams(db: Session) -> dict[str, int]:
             names[cid] = cname
 
     total = len(matches)
-    await post_teams_channel_card(_build_card(matches, names, total))
+    # Card shows the highest-score matches first (the query is id-ordered only so the
+    # watermark stays safe); _build_card slices the top _CARD_ROWS of what it's given.
+    card_matches = sorted(matches, key=lambda m: m.match_score or 0, reverse=True)
+    await post_teams_channel_card(_build_card(card_matches, names, total))
 
-    max_id = max(m.id for m in matches)
+    max_id = max(m.id for m in matches)  # = last id of the contiguous window → safe to advance
     _set_last_id(db, max_id)
     logger.info(f"Proactive Teams push: sent digest of {total} new match(es), watermark now {max_id}")
     return {"pushed": total}

--- a/tests/test_proactive_teams_push.py
+++ b/tests/test_proactive_teams_push.py
@@ -137,3 +137,34 @@ class TestPushJobRegistration:
 
     def test_absent_when_flag_off(self):
         assert "proactive_teams_push" not in self._register(push_enabled=False)
+
+
+async def test_watermark_advances_contiguously_no_skip(db_session: Session, monkeypatch):
+    """With more NEW matches than the scan cap, the watermark advances by ID (a
+    contiguous window), so lower-scored lower-id matches are NOT skipped forever — a
+    second run picks up the remainder with no overlap.
+
+    (Regression: the old score-ordered window jumped the watermark to the top-by-score
+    max id.)
+    """
+    import app.services.proactive_teams_push as tp
+
+    monkeypatch.setattr(tp, "_SCAN_CAP", 3)
+    ctx = _scaffold(db_session)
+    # Scores ASCEND with id, so top-by-score = the HIGHEST ids. The buggy window would
+    # push ids {3,4,5} and jump the watermark to id5, orphaning ids {1,2}.
+    ms = [_add_match(db_session, ctx, f"MPN{i}", score=10 * i) for i in range(1, 6)]
+
+    with patch(_PUSH_PATH, new=AsyncMock()) as mock_post:
+        first = await tp.push_new_matches_to_teams(db_session)
+    assert first == {"pushed": 3}
+    row = db_session.query(SystemConfig).filter(SystemConfig.key == _WATERMARK_KEY).first()
+    assert int(row.value) == ms[2].id  # contiguous: 3rd id, NOT ms[4].id (top score)
+    # Card is still score-sorted for display (highest score of the window first).
+    facts = mock_post.call_args.args[0]["body"][1]["facts"]
+    assert "MPN3" in facts[0]["title"]
+
+    with patch(_PUSH_PATH, new=AsyncMock()) as mock_post2:
+        second = await tp.push_new_matches_to_teams(db_session)
+    assert second == {"pushed": 2}  # ids 4,5 — the remainder, none re-pushed
+    assert int(db_session.query(SystemConfig).filter(SystemConfig.key == _WATERMARK_KEY).first().value) == ms[4].id


### PR DESCRIPTION
Correct fix for teams-watermark (the parallel-batch agent's 'hold on full page' attempt was rejected — it would re-push every run since matches aren't status-flipped). Windows by id ASC so the watermark advances safely; card score-sorted for display. 7 passed; 0 new assertion-theater violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea