### PR TITLE
fix(qc): serialize buy-plan submit with id-only row lock

### DIFF
--- a/app/services/buyplan_workflow/buyplan_approval.py
+++ b/app/services/buyplan_workflow/buyplan_approval.py
@@ -59,6 +59,13 @@ def submit_buy_plan(
     approval regardless of value — no auto-approve (frozen scope; the old
     sub-$5K rule was removed, ``auto_approved`` column is vestigial).
     """
+    # Row lock (QC 2026-08-13): a separate id-only SELECT ... FOR UPDATE serializes
+    # concurrent submits so a double-submit can't both pass the DRAFT gate and open TWO
+    # REQUESTED approval rows (the second orphan would then be undecidable). FOR UPDATE
+    # on the joinedload(lines) query errors on PG (locking the nullable outer-join side),
+    # so lock the plan row by id first, THEN load it with its lines. (SQLite no-ops FOR UPDATE.)
+    if db.scalar(select(BuyPlan.id).where(BuyPlan.id == plan_id).with_for_update()) is None:
+        raise ValueError(f"Buy plan {plan_id} not found")
     plan = db.get(BuyPlan, plan_id, options=[joinedload(BuyPlan.lines)])
     if not plan:
         raise ValueError(f"Buy plan {plan_id} not found")

--- a/tests/test_c1_buyplan_gate.py
+++ b/tests/test_c1_buyplan_gate.py
@@ -24,6 +24,7 @@ import contextlib
 import uuid
 from datetime import UTC, datetime
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -561,3 +562,18 @@ def test_buyplan_badge_excludes_plans_with_open_engine_request(db_session: Sessi
     assert bp_source.count_for_user(db_session, approver) == 1
     # The approvals badge is unchanged by the pre-C1 plan (it has no engine request).
     assert appr_source.count_for_user(db_session, approver) == 1
+
+
+def test_double_submit_rejected_opens_no_second_request(db_session: Session) -> None:
+    """A second submit of an already-PENDING plan raises (the id-only FOR UPDATE +
+    status re-check serialize a double-submit) and opens NO second REQUESTED row."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+
+    submit_buy_plan(plan.id, "SO-DUP", approver, db_session)
+    assert plan.status == BuyPlanStatus.PENDING.value
+
+    with pytest.raises(ValueError, match="draft"):
+        submit_buy_plan(plan.id, "SO-DUP2", approver, db_session)
+
+    assert len(_open_requests(db_session, plan.id)) == 1  # no orphan second request


### PR DESCRIPTION
Prevents a double-submit opening two REQUESTED BUY_PLAN approval rows (the second an undecidable orphan). id-only SELECT...FOR UPDATE before the DRAFT gate; SQLite no-ops it, PG enforces. 16 passed; 0 new assertion-theater violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea