### PR TITLE
fix(qc): Graph sent-lookup $search query + resell retry time floor

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -464,7 +464,27 @@ class SentMessageLookupError(RuntimeError):
     """
 
 
-async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None:
+def _sent_at_or_after(raw: str | None, floor: datetime) -> bool:
+    """True if the message's sentDateTime is at/after ``floor`` (or unparseable/absent,
+    in which case we don't exclude it).
+
+    Used to ignore a prior campaign's message that shares a subject+recipient with the
+    one we're looking for (QC 2026-08-13).
+    """
+    if not raw:
+        return True
+    try:
+        ts = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    if floor.tzinfo is None:
+        floor = floor.replace(tzinfo=UTC)  # SQLite returns naive datetimes
+    return ts >= floor
+
+
+async def _find_sent_message(gc, subject: str, vendor_email: str, sent_after: datetime | None = None) -> dict | None:
     """Find the just-sent message in Sent Items to get its ID and conversationId.
 
     Vendor-discriminating (F1): every vendor group in a batch shares an IDENTICAL tagged
@@ -498,13 +518,18 @@ async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None
                 params={
                     "$top": "50",
                     "$orderby": "sentDateTime desc",
-                    "$select": "id,conversationId,subject,toRecipients",
+                    "$select": "id,conversationId,subject,toRecipients,sentDateTime",
                 },
             )
             msgs: list[dict] = data.get("value", []) if data else []  # Graph JSON boundary
             scanned = len(msgs)
             for m in msgs:
                 if m.get("subject", "").strip() != subject.strip():
+                    continue
+                # Time floor (QC 2026-08-13): a retry must not match a PRIOR campaign's
+                # message that happens to share this subject+recipient. RFQ callers pass
+                # sent_after=None (no floor); the resell retry passes its row's send time.
+                if sent_after is not None and not _sent_at_or_after(m.get("sentDateTime"), sent_after):
                     continue
                 recipients = {
                     (r.get("emailAddress", {}).get("address") or "").lower() for r in m.get("toRecipients", [])

--- a/app/services/resell_outreach_service.py
+++ b/app/services/resell_outreach_service.py
@@ -988,7 +988,13 @@ async def retry_outreach_send(
         # row may have actually delivered, so never assume the send did not happen.
         gc = GraphClient(token)
         try:
-            sent_msg = await email_service._find_sent_message(gc, guard_subject, email)
+            # Time floor (QC 2026-08-13): only THIS row's send counts. Without it, a
+            # prior campaign to the same buyer with the same tagged subject could be
+            # matched and this failed row falsely marked delivered. row.created_at here
+            # is still the original send-attempt time (the resend branch refreshes it
+            # later); a 10-min tolerance absorbs Graph/app clock skew.
+            floor = (row.created_at or datetime.now(UTC)) - timedelta(minutes=10)
+            sent_msg = await email_service._find_sent_message(gc, guard_subject, email, sent_after=floor)
         except Exception:
             # A lookup FAILURE is the UNKNOWN case, never proof of not-sent — the original
             # may have delivered while the Sent-folder query is transiently failing.

--- a/app/utils/graph_client.py
+++ b/app/utils/graph_client.py
@@ -148,16 +148,20 @@ class GraphClient:
         """
         base = f"/users/{user_id}" if user_id else "/me"
         path = f"{base}/mailFolders/SentItems/messages"
-        # Escape single quotes per OData convention to prevent filter injection
-        safe_query = query.replace("'", "''")
+        # QC 2026-08-13: the old query was Graph-invalid on two counts — contains() is
+        # not allowed on body/content, and $filter+$orderby on sentDateTime is rejected
+        # — so PO sent-detection errored on every call. Use $search (spans subject+body)
+        # with no $orderby, then sort newest-first in Python. Strip double-quotes from
+        # the term so it can't break out of the quoted KQL search string.
+        safe_query = query.replace('"', " ")
         params = {
-            "$filter": f"contains(subject,'{safe_query}') or contains(body/content,'{safe_query}')",
+            "$search": f'"{safe_query}"',
             "$select": "id,subject,toRecipients,sentDateTime",
             "$top": str(max_results),
-            "$orderby": "sentDateTime desc",
         }
         data = await self.get_json(path, params=params)  # raises GraphAPIError on failure
         messages: list[dict] = data.get("value", [])  # Graph JSON boundary
+        messages.sort(key=lambda m: m.get("sentDateTime", ""), reverse=True)
         return messages
 
     # ── H8: Delta Query ─────────────────────────────────────────────

--- a/tests/test_nightly_coverage_gaps.py
+++ b/tests/test_nightly_coverage_gaps.py
@@ -92,14 +92,17 @@ class TestGraphClientSearchSentMessages:
 
     @pytest.mark.asyncio
     @patch("app.utils.graph_client.http")
-    async def test_escapes_single_quotes(self, mock_http):
+    async def test_uses_search_no_invalid_filter_orderby(self, mock_http):
         from app.utils.graph_client import GraphClient
 
         mock_http.get = AsyncMock(return_value=MagicMock(status_code=200, json=lambda: {"value": []}))
         gc = GraphClient("token-abc")
         await gc.search_sent_messages("O'Brien's Query")
         call_params = mock_http.get.call_args[1]["params"]
-        assert "O''Brien''s Query" in call_params["$filter"]
+        # $search wraps the term in double quotes (single quotes are fine inside KQL);
+        # the Graph-invalid contains()+$orderby pair is gone (QC 2026-08-13).
+        assert call_params["$search"] == "\"O'Brien's Query\""
+        assert "$filter" not in call_params and "$orderby" not in call_params
 
 
 class TestGraphClientPatchRetry:

--- a/tests/test_qcm_graph_sent_lookup.py
+++ b/tests/test_qcm_graph_sent_lookup.py
@@ -1,0 +1,72 @@
+"""test_qcm_graph_sent_lookup.py — Graph sent-message lookup fixes.
+
+Two 2026-08-08 QC findings (Graph behavior is always mocked in CI — these assert
+query CONSTRUCTION + Python-side filtering, not live Graph):
+- search_sent_messages built a Graph-invalid OData query (contains() on body/content
+  + $filter combined with $orderby) so PO sent-detection errored every call.
+- _find_sent_message had no time floor, so a retry could match a PRIOR campaign's
+  message sharing the subject+recipient.
+
+Called by: pytest
+Depends on: app.utils.graph_client, app.email_service
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_search_sent_messages_uses_search_not_filter_orderby():
+    from app.utils.graph_client import GraphClient
+
+    gc = GraphClient("tok")
+    captured: dict = {}
+
+    async def _get(path, params=None):
+        captured["params"] = params
+        return {
+            "value": [
+                {"id": "a", "sentDateTime": "2026-08-10T00:00:00Z"},
+                {"id": "b", "sentDateTime": "2026-08-13T00:00:00Z"},
+            ]
+        }
+
+    gc.get_json = _get
+    out = await gc.search_sent_messages("PO-123")
+    p = captured["params"]
+    assert p["$search"] == '"PO-123"'
+    assert "$filter" not in p and "$orderby" not in p  # the Graph-invalid pair is gone
+    assert [m["id"] for m in out] == ["b", "a"]  # sorted newest-first in Python
+
+
+def _msg(mid, when, subj="RFQ X", addr="v@x.com"):
+    return {"id": mid, "subject": subj, "sentDateTime": when, "toRecipients": [{"emailAddress": {"address": addr}}]}
+
+
+@pytest.mark.anyio
+async def test_find_sent_message_time_floor_excludes_prior_campaign():
+    from app import email_service
+
+    gc = AsyncMock()
+    gc.get_json = AsyncMock(
+        return_value={"value": [_msg("old", "2026-08-01T12:00:00Z"), _msg("new", "2026-08-13T12:00:00Z")]}
+    )
+    floor = datetime(2026, 8, 10, tzinfo=UTC)
+    with patch("app.email_service.asyncio.sleep", new=AsyncMock()):
+        with_floor = await email_service._find_sent_message(gc, "RFQ X", "v@x.com", sent_after=floor)
+        no_floor = await email_service._find_sent_message(gc, "RFQ X", "v@x.com")
+    assert with_floor["id"] == "new"  # the pre-floor "old" is skipped
+    assert no_floor["id"] == "old"  # default: first match wins → proves the floor changed behavior
+
+
+def test_sent_at_or_after_helper():
+    from app.email_service import _sent_at_or_after
+
+    floor = datetime(2026, 8, 10, tzinfo=UTC)
+    assert _sent_at_or_after("2026-08-13T00:00:00Z", floor) is True
+    assert _sent_at_or_after("2026-08-01T00:00:00Z", floor) is False
+    assert _sent_at_or_after(None, floor) is True  # unknown → don't exclude
+    assert _sent_at_or_after("garbage", floor) is True
+    assert _sent_at_or_after("2026-08-13T00:00:00Z", datetime(2026, 8, 10)) is True  # naive floor coerced

--- a/tests/test_resell_outreach_async.py
+++ b/tests/test_resell_outreach_async.py
@@ -558,7 +558,7 @@ class TestRunOutreachEmailSend:
         )
         row_id = rows[0].id
 
-        async def _found(_gc, _subject, _email):
+        async def _found(_gc, _subject, _email, sent_after=None):
             return {"id": "m1", "conversationId": "c1"}
 
         real_commit = db_session.commit
@@ -816,7 +816,7 @@ class TestRunOutreachEmailSend:
                 {"vendor_email": "ops@secondbuyer.com", "status": "sent"},
             ]
 
-        async def _lookup(_gc, _subject, _email):
+        async def _lookup(_gc, _subject, _email, sent_after=None):
             return {"id": f"m-{_email}", "conversationId": f"c-{_email}"}
 
         with (
@@ -870,7 +870,7 @@ class TestCommitAfterSendAndActivityGating:
         )
         row_id = rows[0].id
 
-        async def _lookup(_gc, _subject, _email):
+        async def _lookup(_gc, _subject, _email, sent_after=None):
             return {"id": "msg-bk-1", "conversationId": "conv-bk-1"}
 
         def _explode_bookkeeping(*_args, **_kwargs):
@@ -920,7 +920,7 @@ class TestCommitAfterSendAndActivityGating:
             body="surplus",
         )
 
-        async def _lookup(_gc, _subject, _email):
+        async def _lookup(_gc, _subject, _email, sent_after=None):
             return {"id": "m", "conversationId": "c"}
 
         with (
@@ -1025,7 +1025,7 @@ class TestRetryOutreachSend:
 
         send_mock = AsyncMock()
 
-        async def _found(_gc, _subject, _email):
+        async def _found(_gc, _subject, _email, sent_after=None):
             return {"id": "already-sent-1", "conversationId": "conv-already-1"}
 
         with (
@@ -1066,7 +1066,7 @@ class TestRetryOutreachSend:
         send_mock = AsyncMock(return_value=[{"vendor_email": "sales@asyncbuyer.com", "status": "sent"}])
         calls: list[int] = []
 
-        async def _lookup(_gc, _subject, _email):
+        async def _lookup(_gc, _subject, _email, sent_after=None):
             # 1st call = the pre-send reconcile guard (not delivered → None);
             # 2nd call = the post-send stamp inside _finalize_outreach_send.
             calls.append(1)
@@ -1125,7 +1125,7 @@ class TestRetryOutreachSend:
         send_mock = AsyncMock()
         seen_subjects: list[str] = []
 
-        async def _found(_gc, subject, _email):
+        async def _found(_gc, subject, _email, sent_after=None):
             seen_subjects.append(subject)
             # Only the REAL (customized) subject matches the delivered message.
             return {"id": "already-1", "conversationId": "conv-1"} if subject == custom_subject else None
@@ -1193,7 +1193,7 @@ class TestRetryOutreachSend:
 
         seen_emails: list[str] = []
 
-        async def _found(_gc, _subject, email):
+        async def _found(_gc, _subject, email, sent_after=None):
             seen_emails.append(email)
             return {"id": "already-2", "conversationId": "conv-already-2"}
 
@@ -1237,7 +1237,7 @@ class TestRetryOutreachSend:
 
         seen_emails: list[str] = []
 
-        async def _found(_gc, _subject, email):
+        async def _found(_gc, _subject, email, sent_after=None):
             seen_emails.append(email)
             return {"id": "legacy-1", "conversationId": "conv-legacy-1"}
 

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -172,23 +172,26 @@ class TestEncryptedTypeFailOpen:
 # ── Fix 2: OData Filter Injection ──────────────────────────────────
 
 
-class TestODataFilterInjection:
-    """search_sent_messages must escape single quotes in query."""
+class TestODataSearchInjection:
+    """search_sent_messages now uses $search (QC 2026-08-13, the old contains()+$orderby
+    $filter was Graph-invalid): a double-quote in the query is stripped so it can't
+    break out of the quoted KQL search string.
+
+    Single quotes are harmless inside $search.
+    """
 
     @pytest.mark.asyncio
-    async def test_single_quotes_escaped_in_odata_filter(self):
+    async def test_double_quote_stripped_from_search(self):
         from unittest.mock import AsyncMock
 
         from app.utils.graph_client import GraphClient
 
         gc = GraphClient("fake-token")
-        mock_response = {"value": []}
-        with patch.object(gc, "get_json", new_callable=AsyncMock, return_value=mock_response) as mock_get:
-            await gc.search_sent_messages("test'injection")
-            call_args = mock_get.call_args
-            params = call_args.kwargs.get("params") or call_args[1]["params"]
-            assert "test''injection" in params["$filter"]
-            assert "test'injection" not in params["$filter"]
+        with patch.object(gc, "get_json", new_callable=AsyncMock, return_value={"value": []}) as mock_get:
+            await gc.search_sent_messages('test"injection')
+            params = mock_get.call_args.kwargs.get("params") or mock_get.call_args[1]["params"]
+            assert params["$search"] == '"test injection"'  # stray double-quote neutralized
+            assert "$filter" not in params
 
     @pytest.mark.asyncio
     async def test_query_without_quotes_unchanged(self):
@@ -197,12 +200,10 @@ class TestODataFilterInjection:
         from app.utils.graph_client import GraphClient
 
         gc = GraphClient("fake-token")
-        mock_response = {"value": []}
-        with patch.object(gc, "get_json", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+        with patch.object(gc, "get_json", new_callable=AsyncMock, return_value={"value": []}) as mock_get:
             await gc.search_sent_messages("PO12345")
-            call_args = mock_get.call_args
-            params = call_args.kwargs.get("params") or call_args[1]["params"]
-            assert "PO12345" in params["$filter"]
+            params = mock_get.call_args.kwargs.get("params") or mock_get.call_args[1]["params"]
+            assert params["$search"] == '"PO12345"'
 
 
 # ── Fix 4: Screenshot Path Traversal ──────────────────────────────


### PR DESCRIPTION
search_sent_messages used a Graph-invalid contains()+$orderby query (PO sent-detection errored every call) → now $search + Python sort. _find_sent_message gains a sent_after floor so a resell retry can't match a prior campaign's same-subject message. 298 passed; 0 new assertion-theater violations. NOTE: Graph is CI-mocked — live-mailbox verify of the $search query is yours to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea