### PR TITLE
fix(qc): enrichment merges provenance (preserves manual edits, no not-found wipe)

### DIFF
--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -199,6 +199,20 @@ def _apply_merged_core_fields(card: MaterialCard, merged: dict, provenance: dict
     return prov
 
 
+def _merge_provenance(card: MaterialCard, new_prov: dict) -> dict:
+    """Merge this run's per-field provenance into the card's existing provenance instead
+    of replacing it wholesale (QC 2026-08-13).
+
+    A blanket reassignment discarded the provenance of fields NOT touched this run —
+    including manual edits — so the audit trail lied about who last set them. Fields
+    written this run overwrite their entry; everything else (a prior
+    manual/authoritative entry) is preserved.
+    """
+    merged = dict(card.enrichment_provenance or {})
+    merged.update(new_prov or {})
+    return merged
+
+
 def apply_authoritative(
     card: MaterialCard,
     merged: dict,
@@ -211,7 +225,7 @@ def apply_authoritative(
     ``_apply_merged_core_fields`` (ladder-rejected writes are dropped from the persisted
     provenance).
     """
-    card.enrichment_provenance = _apply_merged_core_fields(card, merged, provenance)
+    card.enrichment_provenance = _merge_provenance(card, _apply_merged_core_fields(card, merged, provenance))
     card.enrichment_source = contributors[0] if contributors else card.enrichment_source
     card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
     card.enriched_at = datetime.now(UTC)
@@ -283,7 +297,7 @@ def apply_web_sourced(card: MaterialCard, result: WebExtractResult) -> None:
     )
     card.enrichment_source = "web_search"
     card.enrichment_status = MaterialEnrichmentStatus.WEB_SOURCED
-    card.enrichment_provenance = prov
+    card.enrichment_provenance = _merge_provenance(card, prov)
     card.enriched_at = now
 
 
@@ -319,7 +333,7 @@ def apply_cross_ref_verified(
         "confirmed_by": confirmer,
         "confidence": xr.confidence,
     }
-    card.enrichment_provenance = prov
+    card.enrichment_provenance = _merge_provenance(card, prov)
     card.enrichment_source = confirmer or "cross_ref"
     card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
     card.enriched_at = now
@@ -359,7 +373,7 @@ def apply_oem_sourced(card: MaterialCard, result: OemExtractResult) -> None:
     )
     card.enrichment_source = "oem_official"
     card.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
-    card.enrichment_provenance = prov
+    card.enrichment_provenance = _merge_provenance(card, prov)
     card.enriched_at = now
 
 
@@ -523,8 +537,12 @@ async def enrich_card(
         if (vendor in HIGH_PRECISION_VENDORS and oem_attempted)
         else MaterialEnrichmentStatus.NOT_FOUND
     )
-    card.enrichment_source = None
-    card.enrichment_provenance = None
+    # Don't erase a prior manual/authoritative enrichment on a not_found run (QC
+    # 2026-08-13): only clear the summary fields when there's nothing worth keeping.
+    # A re-enrichment that finds no NEW authoritative data must not wipe a human's edit.
+    if not card.enrichment_provenance:
+        card.enrichment_source = None
+        card.enrichment_provenance = None
     return card.enrichment_status
 
 

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -972,3 +972,22 @@ async def test_dell_miss_is_not_found_not_catalogued(db_session):
     ):
         status = await aes.enrich_card(card, db_session, connectors=[], web_meter=WebMeter())
     assert status == MaterialEnrichmentStatus.NOT_FOUND  # dell is excluded from HIGH_PRECISION_VENDORS
+
+
+def test_apply_authoritative_merges_provenance_not_replaces(db_session):
+    """QC 2026-08-13: applying enrichment MERGES per-field provenance into the card's
+    existing provenance — a prior manual entry for a field NOT touched this run is
+    preserved, not wiped by the wholesale reassignment."""
+    card = _card(db_session, "PROVMERGE001")
+    # A human previously set package_type by hand (a non-core field the run below
+    # doesn't touch); its provenance must survive.
+    card.enrichment_provenance = {"package_type": {"source": "manual", "confidence": 1.0}}
+
+    apply_authoritative(
+        card, {"description": "New authoritative desc"}, {"description": _prov_entry("digikey")}, ["digikey"]
+    )
+
+    prov = card.enrichment_provenance
+    assert prov["package_type"]["source"] == "manual"  # PRESERVED (was wiped before the fix)
+    assert prov["description"]["source"] == "digikey"  # this run's entry added
+    assert card.description == "New authoritative desc"


### PR DESCRIPTION
Enrichment apply paths reassigned card.enrichment_provenance wholesale (discarding untouched fields' entries incl. manual) and NULLed on not_found. New _merge_provenance folds this run's entries into existing provenance; not_found only clears when nothing worth keeping. F1 ladder already protected the values — this fixes the JSONB audit trail. Backward-compatible. 147 passed; 0 new assertion-theater violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea