### PR TITLE
fix(qc): truncate oversized enrichment fields (no whole-batch DataError)

### DIFF
--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -50,6 +50,20 @@ def _vendor_ladder_source(connector_name: str) -> str:
     return f"{connector_name}_api"
 
 
+# String columns with a hard length bound — truncate on write so one oversized value
+# from a connector/web/OEM/AI source can't DataError the whole batch commit (QC 2026-08-13).
+_FIELD_MAXLEN = {"description": 1000, "datasheet_url": 1000}
+
+
+def _cap_field(field: str, value):
+    """Truncate a bounded string field to its DB column length; pass everything else
+    through."""
+    maxlen = _FIELD_MAXLEN.get(field)
+    if maxlen and isinstance(value, str) and len(value) > maxlen:
+        return value[:maxlen]
+    return value
+
+
 CORE_FIELDS = [
     "description",
     "manufacturer",
@@ -195,7 +209,7 @@ def _apply_merged_core_fields(card: MaterialCard, merged: dict, provenance: dict
             if not setter(card, value, source, confidence):
                 prov.pop(field, None)
         else:
-            setattr(card, field, value)
+            setattr(card, field, _cap_field(field, value))
     return prov
 
 
@@ -244,7 +258,7 @@ def _apply_evidence_fields(
             if not set_manufacturer(card, v, source, confidence):
                 continue
         else:
-            setattr(card, f, v)
+            setattr(card, f, _cap_field(f, v))
         prov[f] = {"source": source, "confidence": confidence, "fetched_at": fetched_at}
 
 
@@ -493,7 +507,7 @@ async def enrich_card(
         now = datetime.now(UTC)
         card.enriched_at = now
         if inf.status == "ai_inferred":
-            card.description = inf.description
+            card.description = _cap_field("description", inf.description)
             # Through the F1 ladder: an Opus inference (claude_opus_inferred, tier 40) fills
             # an empty category but can never overwrite decode/vendor/TRIO provenance, and
             # off-vocab junk is rejected instead of persisted.

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -972,3 +972,26 @@ async def test_dell_miss_is_not_found_not_catalogued(db_session):
     ):
         status = await aes.enrich_card(card, db_session, connectors=[], web_meter=WebMeter())
     assert status == MaterialEnrichmentStatus.NOT_FOUND  # dell is excluded from HIGH_PRECISION_VENDORS
+
+
+def test_apply_truncates_oversized_bounded_fields(db_session):
+    """QC 2026-08-13: an oversized description / datasheet_url is truncated to its column
+    length on apply, so one huge connector value can't DataError the whole batch commit."""
+    card = _card(db_session, "TRUNC001")
+    apply_authoritative(
+        card,
+        {"description": "X" * 1500, "datasheet_url": "http://ex.com/" + "y" * 1500},
+        {"description": _prov_entry("digikey"), "datasheet_url": _prov_entry("digikey")},
+        ["digikey"],
+    )
+    assert len(card.description) == 1000
+    assert len(card.datasheet_url) == 1000
+
+
+def test_cap_field_helper():
+    from app.services.authoritative_enrichment_service import _cap_field
+
+    assert len(_cap_field("description", "z" * 2000)) == 1000
+    assert _cap_field("description", "short") == "short"
+    assert _cap_field("category", "z" * 2000) == "z" * 2000  # unbounded field untouched
+    assert _cap_field("description", None) is None


### PR DESCRIPTION
description/datasheet_url are String(1000); an oversized connector/web/AI value DataError'd the batch commit and rolled back every card. _cap_field truncates the two bounded fields at the shared write choke points. 58 passed; 0 new assertion-theater violations. Safe half of the oversized finding; the savepoint-loop restructure is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea