### PR TITLE
fix(qc): auto-attribution AI pass fires (run in worker thread)

### DIFF
--- a/app/jobs/maintenance_jobs.py
+++ b/app/jobs/maintenance_jobs.py
@@ -66,12 +66,15 @@ async def _job_cache_cleanup():
 @_traced_job
 async def _job_auto_attribute_activities():
     """Auto-attribute unmatched activities using rule-based + AI matching."""
-    from ..database import SessionLocal
-    from ..services.auto_attribution_service import run_auto_attribution
+    from ..services.auto_attribution_service import run_auto_attribution_threadsafe
 
-    db = SessionLocal()
+    # Run in a worker thread (QC 2026-08-14): run_auto_attribution's AI pass skips when
+    # a running event loop is present (this job always has one), so it was dead in prod;
+    # the executor thread has no loop, so the AI pass fires. The wrapper owns its own
+    # Session inside that thread (never shared across the loop boundary).
+    loop = asyncio.get_running_loop()
     try:
-        stats = run_auto_attribution(db)
+        stats = await loop.run_in_executor(None, run_auto_attribution_threadsafe)
         total = stats["rule_matched"] + stats["ai_matched"]
         if total:
             logger.info(
@@ -81,11 +84,10 @@ async def _job_auto_attribute_activities():
                 stats["auto_dismissed"],
             )
     except Exception:
+        # The worker-thread Session is created + closed inside run_auto_attribution_threadsafe;
+        # nothing to roll back or close here.
         logger.exception("Auto-attribution job failed")
-        db.rollback()
         raise
-    finally:
-        db.close()
 
 
 @_traced_job

--- a/app/services/auto_attribution_service.py
+++ b/app/services/auto_attribution_service.py
@@ -25,6 +25,24 @@ def _as_utc(dt: datetime) -> datetime:
     return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
 
 
+def run_auto_attribution_threadsafe() -> dict:
+    """Run auto-attribution in a thread that owns its own Session (QC 2026-08-14).
+
+    Called via ``loop.run_in_executor`` from the async maintenance job so that (a) the
+    AI matching pass actually FIRES — ``run_auto_attribution`` skips it when it detects a
+    running event loop, which the async job always has, so the pass was dead in prod; and
+    (b) the Session is created, used, and closed entirely inside THIS worker thread,
+    never shared across the loop boundary (a SQLAlchemy Session is not thread-safe).
+    """
+    from ..database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        return run_auto_attribution(db)
+    finally:
+        db.close()
+
+
 def run_auto_attribution(db: Session) -> dict:
     """Process unmatched activities with rule-based and AI matching.
 

--- a/tests/test_auto_attribution_service.py
+++ b/tests/test_auto_attribution_service.py
@@ -481,3 +481,40 @@ class TestCallClaudeForMatching:
         assert len(result) == 2
         assert result[1]["entity_type"] == "company"
         assert result[2]["entity_type"] == "vendor"
+
+
+# ── QC 2026-08-14: AI pass fires (was dead under the async job's running loop) ──
+
+
+def test_threadsafe_wrapper_owns_and_closes_its_session():
+    """run_auto_attribution_threadsafe creates its own Session, runs, and closes it — so
+    it can be handed to run_in_executor without sharing a Session across threads."""
+    from unittest.mock import MagicMock, patch
+
+    from app.services import auto_attribution_service as aas
+
+    fake_db = MagicMock()
+    stats = {"rule_matched": 1, "ai_matched": 2, "auto_dismissed": 0, "skipped": 0}
+    with (
+        patch("app.database.SessionLocal", return_value=fake_db),
+        patch.object(aas, "run_auto_attribution", return_value=stats) as mock_run,
+    ):
+        out = aas.run_auto_attribution_threadsafe()
+    mock_run.assert_called_once_with(fake_db)
+    fake_db.close.assert_called_once()  # session lifecycle owned by this thread
+    assert out["ai_matched"] == 2
+
+
+@pytest.mark.anyio
+async def test_job_runs_attribution_in_executor_so_ai_pass_fires():
+    """The async maintenance job offloads to a worker thread (no running loop), so
+    run_auto_attribution's AI pass — which skips when a loop is present — actually
+    runs."""
+    from unittest.mock import patch
+
+    from app.jobs import maintenance_jobs
+
+    stats = {"rule_matched": 0, "ai_matched": 0, "auto_dismissed": 0, "skipped": 0}
+    with patch("app.services.auto_attribution_service.run_auto_attribution_threadsafe", return_value=stats) as mock_ts:
+        await maintenance_jobs._job_auto_attribute_activities()
+    mock_ts.assert_called_once()


### PR DESCRIPTION
run_auto_attribution's Claude pass skipped whenever a running event loop was present; the async job always had one, so the AI pass was dead in prod (only rule-matching ran). Now offloaded via run_in_executor (worker thread has no loop); the wrapper owns its Session in-thread (also the correct cross-thread-session pattern). Enables live Claude spend on this job (owner-authorized 'do all'; 20 activities/batch, Haiku-tier). 36 passed; 0 new assertion-theater violations.

Generated with Claude Code — https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea