### PR TITLE
fix(qc): proactive-matching job owns its Session in-thread (no cross-thread teardown)

### DIFF
--- a/app/jobs/offers_jobs.py
+++ b/app/jobs/offers_jobs.py
@@ -114,55 +114,59 @@ async def _job_proactive_matching():
     """Scan new offers for proactive matching (requirement history + hotlists)."""
     from ..database import SessionLocal
 
-    db = SessionLocal()
-    try:
+    def _run_all_matching() -> tuple[dict, int, int]:
+        """All DB work in ONE worker thread with ONE Session it fully owns (QC
+        2026-08-14).
+
+        Previously the job created the Session and handed it to run_in_executor, then
+        rolled back / closed it in the timeout & except branches — while the executor
+        thread was STILL mid-query on it (a ``wait_for`` timeout cancels the await but
+        cannot stop the running thread). Owning the Session inside the thread removes
+        that cross-thread corruption; the outer timeout simply abandons the future and
+        the thread cleans up its own Session in ``finally``.
+        """
         from ..models import ProactiveMatch
+        from ..services.part_equivalence import classify_new_pairs, windowed_spellings_by_key
         from ..services.proactive_matching import expire_old_matches, run_proactive_scan
 
-        loop = asyncio.get_running_loop()
-
-        # Classify any new part-equivalence candidate pairs FIRST so this
-        # scan already pools freshly-judged variants (verdicts are cached
-        # forever; a pass with nothing new is a no-op).
+        db = SessionLocal()
         try:
-            from ..services.part_equivalence import classify_new_pairs, windowed_spellings_by_key
+            # Classify new part-equivalence candidate pairs FIRST so the scan pools
+            # freshly-judged variants (verdicts cached forever; empty pass = no-op).
+            try:
+                spellings = windowed_spellings_by_key(db)
+                asyncio.run(asyncio.wait_for(classify_new_pairs(db, spellings), timeout=120))
+            except Exception as eq_exc:  # classifier down ≠ matching broken (same thread → safe rollback)
+                logger.warning("Part-equivalence classification pass failed: {}", eq_exc)
+                db.rollback()
 
-            spellings = await loop.run_in_executor(None, windowed_spellings_by_key, db)
-            await asyncio.wait_for(classify_new_pairs(db, spellings), timeout=120)
-        except Exception as eq_exc:  # classifier down ≠ matching broken
-            logger.warning("Part-equivalence classification pass failed: {}", eq_exc)
-            db.rollback()
+            scan_result = run_proactive_scan(db)
+            expired = expire_old_matches(db)
+            total_pending = db.query(ProactiveMatch).filter(ProactiveMatch.status == ProactiveMatchStatus.NEW).count()
+            return scan_result, expired, total_pending
+        finally:
+            db.close()
 
-        # Requirement-history + hotlist scan over new live offers
-        scan_result = await asyncio.wait_for(
-            loop.run_in_executor(None, run_proactive_scan, db),
-            timeout=300,
+    loop = asyncio.get_running_loop()
+    try:
+        scan_result, expired, total_pending = await asyncio.wait_for(
+            loop.run_in_executor(None, _run_all_matching), timeout=300
         )
-        if scan_result.get("matches_created"):
-            logger.info(
-                f"Proactive matching: {scan_result['matches_created']} new matches "
-                f"from {scan_result['scanned_offers']} offers"
-            )
-
-        # Expire stale matches
-        expired = await loop.run_in_executor(None, expire_old_matches, db)
-        if expired:
-            logger.info(f"Proactive matching: expired {expired} old matches")
-
-        # Summary log with total pending
-        new_matches = scan_result.get("matches_created", 0)
-        total_pending = db.query(ProactiveMatch).filter(ProactiveMatch.status == ProactiveMatchStatus.NEW).count()
-        logger.info(f"Proactive scan complete: {new_matches} new matches, {total_pending} pending")
     except TimeoutError:
+        # The worker thread owns + closes its own Session — nothing to roll back/close here.
         logger.error("Proactive matching timed out after 300s")
-        db.rollback()
         raise
-    except Exception as e:
-        logger.exception(f"Proactive matching error: {e}")
-        db.rollback()
-        raise
-    finally:
-        db.close()
+
+    if scan_result.get("matches_created"):
+        logger.info(
+            f"Proactive matching: {scan_result['matches_created']} new matches "
+            f"from {scan_result['scanned_offers']} offers"
+        )
+    if expired:
+        logger.info(f"Proactive matching: expired {expired} old matches")
+    logger.info(
+        f"Proactive scan complete: {scan_result.get('matches_created', 0)} new matches, {total_pending} pending"
+    )
 
 
 @_traced_job

--- a/tests/test_jobs_coverage_2.py
+++ b/tests/test_jobs_coverage_2.py
@@ -109,70 +109,68 @@ class TestJobProactiveMatching:
 
     @patch("app.jobs.offers_jobs.logger")
     def test_happy_path(self, mock_logger):
+        """All DB work runs in the executor fn, which owns + closes its own Session."""
         from app.jobs.offers_jobs import _job_proactive_matching
 
         mock_db = _mock_db()
         mock_db.query.return_value.filter.return_value.count.return_value = 5
 
-        scan_result = {"matches_created": 3, "scanned_offers": 10}
-        expired_count = 2
+        with (
+            patch(
+                "app.services.proactive_matching.run_proactive_scan",
+                return_value={"matches_created": 3, "scanned_offers": 10},
+            ) as mock_scan,
+            patch("app.services.proactive_matching.expire_old_matches", return_value=2),
+            patch("app.services.part_equivalence.windowed_spellings_by_key", return_value={}),
+            patch("app.services.part_equivalence.classify_new_pairs", new=AsyncMock(return_value=0)),
+            patch("app.database.SessionLocal", return_value=mock_db),
+        ):
+            _run(_job_proactive_matching.__wrapped__())
 
-        # run_in_executor is called twice: first result goes via wait_for, second awaited directly
-        run_exec_mock = AsyncMock(side_effect=[MagicMock(), expired_count])
+        mock_scan.assert_called_once()
+        mock_db.close.assert_called_once()  # session lifecycle owned by the executor fn
 
+    @patch("app.jobs.offers_jobs.logger")
+    def test_timeout_does_no_cross_thread_session_op(self, mock_logger):
+        """QC 2026-08-14: on a wait_for timeout the job must NOT roll back / close a
+        Session — the worker thread owns it; the job holds none."""
+        from app.jobs.offers_jobs import _job_proactive_matching
+
+        mock_db = _mock_db()
         with patch("app.jobs.offers_jobs.asyncio.get_running_loop") as mock_loop_fn:
             mock_loop = MagicMock()
             mock_loop_fn.return_value = mock_loop
-            mock_loop.run_in_executor = run_exec_mock
+            mock_loop.run_in_executor.return_value = MagicMock()  # dummy future; the fn never runs
 
-            with patch(
-                "app.jobs.offers_jobs.asyncio.wait_for",
-                new=AsyncMock(return_value=scan_result),
+            with (
+                patch("app.jobs.offers_jobs.asyncio.wait_for", side_effect=asyncio.TimeoutError),
+                patch("app.database.SessionLocal", return_value=mock_db),
             ):
-                with patch("app.database.SessionLocal", return_value=mock_db):
+                with pytest.raises(asyncio.TimeoutError):
                     _run(_job_proactive_matching.__wrapped__())
 
-        mock_db.close.assert_called_once()
+        mock_db.rollback.assert_not_called()  # the fix — no cross-thread rollback
+        mock_db.close.assert_not_called()
 
     @patch("app.jobs.offers_jobs.logger")
-    def test_timeout_error(self, mock_logger):
+    def test_generic_exception_propagates_no_session_op(self, mock_logger):
         from app.jobs.offers_jobs import _job_proactive_matching
 
         mock_db = _mock_db()
-
         with patch("app.jobs.offers_jobs.asyncio.get_running_loop") as mock_loop_fn:
             mock_loop = MagicMock()
             mock_loop_fn.return_value = mock_loop
+            mock_loop.run_in_executor.return_value = MagicMock()
 
-            future = asyncio.Future()
-            future.set_result({"matches_created": 0, "scanned_offers": 0})
-            mock_loop.run_in_executor.return_value = future
+            with (
+                patch("app.jobs.offers_jobs.asyncio.wait_for", side_effect=RuntimeError("boom")),
+                patch("app.database.SessionLocal", return_value=mock_db),
+            ):
+                with pytest.raises(RuntimeError, match="boom"):
+                    _run(_job_proactive_matching.__wrapped__())
 
-            with patch("app.jobs.offers_jobs.asyncio.wait_for", side_effect=asyncio.TimeoutError):
-                with patch("app.database.SessionLocal", return_value=mock_db):
-                    with pytest.raises(asyncio.TimeoutError):
-                        _run(_job_proactive_matching.__wrapped__())
-
-        mock_db.rollback.assert_called()  # classification pass may add a guarded rollback
-        mock_db.close.assert_called_once()
-
-    @patch("app.jobs.offers_jobs.logger")
-    def test_generic_exception(self, mock_logger):
-        from app.jobs.offers_jobs import _job_proactive_matching
-
-        mock_db = _mock_db()
-
-        with patch("app.jobs.offers_jobs.asyncio.get_running_loop") as mock_loop_fn:
-            mock_loop = MagicMock()
-            mock_loop_fn.return_value = mock_loop
-
-            with patch("app.jobs.offers_jobs.asyncio.wait_for", side_effect=RuntimeError("boom")):
-                with patch("app.database.SessionLocal", return_value=mock_db):
-                    with pytest.raises(RuntimeError, match="boom"):
-                        _run(_job_proactive_matching.__wrapped__())
-
-        mock_db.rollback.assert_called()  # classification pass may add a guarded rollback
-        mock_db.close.assert_called_once()
+        mock_db.rollback.assert_not_called()
+        mock_db.close.assert_not_called()
 
 
 class TestJobPerformanceTracking:


### PR DESCRIPTION
The job handed its Session to run_in_executor then rolled back/closed it on a wait_for timeout — while the executor thread was still mid-query on it (a timeout cancels the await, not the thread). Now all DB work runs in one nested fn inside a single executor call that owns + closes its own Session; the job holds none, so a timeout just abandons the future. 120s classify sub-timeout preserved in-thread. Rewrote 3 job tests to the new contract (timeout/error assert NO cross-thread rollback/close). 187 passed; 0 new assertion-theater violations.

Generated with Claude Code — https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea