### PR TITLE
fix(qc): claim proactive draft/digest DRAFT→SENT before the Graph send

### DIFF
--- a/app/services/proactive_digest.py
+++ b/app/services/proactive_digest.py
@@ -317,22 +317,42 @@ async def send_digest(db: Session, digest_id: int, actor: User, token: str) -> N
     if not salesperson or not salesperson.email:
         raise ValueError("Digest has no recipient")
 
-    gc = GraphClient(token)
-    await gc.post_json(
-        "/me/sendMail",
-        {
-            "message": {
-                "subject": digest.subject,
-                "body": {"contentType": "HTML", "content": digest.body_html},
-                "toRecipients": [{"emailAddress": {"address": salesperson.email}}],
-            },
-            "saveToSentItems": "true",
-        },
-    )
+    # Atomic claim (QC 2026-08-14): flip DRAFT→SENT in one conditional UPDATE and commit
+    # BEFORE the Graph send, so the generate_digests "clear ALL drafts" sweep (a separate
+    # job session) can no longer delete this digest mid-send, and a concurrent send_digest
+    # can't double-mail it. Only the caller whose UPDATE matches status=DRAFT wins; a send
+    # failure reverts the claim to DRAFT so it can be retried.
     now = datetime.now(UTC)
-    digest.status = ProactiveDigestStatus.SENT
-    digest.sent_at = now
-    digest.sent_by_id = actor.id
+    claimed = db.execute(
+        update(ProactiveDigest)
+        .where(ProactiveDigest.id == digest_id, ProactiveDigest.status == ProactiveDigestStatus.DRAFT)
+        .values(status=ProactiveDigestStatus.SENT, sent_at=now, sent_by_id=actor.id)
+    ).rowcount
+    db.commit()
+    if not claimed:
+        raise ValueError("Digest not found or not a draft")
+    db.refresh(digest)
+
+    gc = GraphClient(token)
+    try:
+        await gc.post_json(
+            "/me/sendMail",
+            {
+                "message": {
+                    "subject": digest.subject,
+                    "body": {"contentType": "HTML", "content": digest.body_html},
+                    "toRecipients": [{"emailAddress": {"address": salesperson.email}}],
+                },
+                "saveToSentItems": "true",
+            },
+        )
+    except Exception:
+        # Revert the claim so the digest can be retried with one click.
+        digest.status = ProactiveDigestStatus.DRAFT
+        digest.sent_at = None
+        digest.sent_by_id = None
+        db.commit()
+        raise
     db.execute(update(ProactiveOutreachLine).where(ProactiveOutreachLine.digest_id == digest.id).values(sent_at=now))
     logger.info("Proactive digest {} sent to {} by {}", digest.id, salesperson.email, actor.email)
 

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -754,6 +754,23 @@ async def send_draft_offer(db: Session, user: User, token: str, po_id: int, *, a
     if not recipient_emails:
         raise ValueError("No contact on file — open Prepare to pick or add one")
 
+    # Atomic claim (QC 2026-08-14): flip DRAFT→SENT in ONE conditional UPDATE BEFORE the
+    # Graph send. A concurrent send_draft_offer — or the digest-draft "supersede" sweep —
+    # can then no longer touch this offer while it is in flight: only the caller whose
+    # UPDATE matches status=DRAFT wins (rowcount 1); the rest see 0 rows and bail, so the
+    # customer is never double-emailed and no StaleDataError races the delete. No row
+    # lock is held across the await; a Graph rejection reverts the claim to DRAFT.
+    now = datetime.now(UTC)
+    claimed = db.execute(
+        update(ProactiveOffer)
+        .where(ProactiveOffer.id == po_id, ProactiveOffer.status == ProactiveOfferStatus.DRAFT)
+        .values(status=ProactiveOfferStatus.SENT, sent_at=now)
+    ).rowcount
+    db.commit()
+    if not claimed:
+        raise ValueError("This draft was already sent (or is being sent).")
+    db.refresh(po)
+
     # QC 2026-08-10 P0-1: no internal tracking tag in the customer subject.
     tagged_subject = po.subject
     gc = GraphClient(token)
@@ -770,12 +787,13 @@ async def send_draft_offer(db: Session, user: User, token: str, po_id: int, *, a
             },
         )
     except GraphAPIError as exc:
-        # Draft stays DRAFT, matches stay NEW, no throttle — retry is one click.
+        # Revert the claim so the draft can be retried with one click.
+        po.status = ProactiveOfferStatus.DRAFT
+        po.sent_at = None
+        db.commit()
         logger.error("Proactive draft #{} send rejected by Graph: {}", po.id, exc)
         raise ValueError("Send failed — Microsoft rejected the message; the draft is untouched, try again") from exc
-    now = datetime.now(UTC)
-    po.status = ProactiveOfferStatus.SENT
-    po.sent_at = now
+    # po is already SENT (claimed above); continue to flip matches + write throttles.
 
     match_ids = [li.get("match_id") for li in (po.line_items or []) if li.get("match_id")]
     matches = list(db.scalars(select(ProactiveMatch).where(ProactiveMatch.id.in_(match_ids)))) if match_ids else []

--- a/tests/test_proactive_digest.py
+++ b/tests/test_proactive_digest.py
@@ -312,6 +312,41 @@ async def test_send_digest_rejects_non_draft(db_session):
         await send_digest(db_session, 9999, manager, "tok")
 
 
+@pytest.mark.anyio
+async def test_send_digest_reverts_to_draft_on_send_failure(db_session):
+    """A Graph rejection after the claim must revert DRAFT — never a phantom SENT.
+
+    The claim flips the digest SENT before the await so the generate_digests sweep can't
+    delete it mid-send; if the send then fails, it must go back to DRAFT
+    (sent_at/sent_by cleared) so the next generate_digests run can retry it, not leave
+    it stuck as sent.
+    """
+    from app.utils.graph_client import GraphAPIError
+
+    owner = _mk_user(db_session, "Sales Rep", "sr@trioscs.com")
+    manager = _mk_user(db_session, "The Manager", "mgr@trioscs.com", role="manager")
+    customer, _ = _mk_customer(db_session, "IBM", owner)
+    _mk_offer(db_session, mpn="02PX530", qty=214, price="275")
+    _mk_match(db_session, mpn="02PX530", owner=owner, company=customer)
+    generate_digests(db_session)
+    db_session.commit()
+    digest = db_session.query(ProactiveDigest).one()
+
+    with patch(
+        "app.utils.graph_client.GraphClient.post_json",
+        new_callable=AsyncMock,
+        side_effect=GraphAPIError(401, "token expired"),
+    ):
+        with pytest.raises(GraphAPIError):
+            await send_digest(db_session, digest.id, manager, "tok")
+
+    db_session.refresh(digest)
+    assert digest.status == ProactiveDigestStatus.DRAFT  # reverted, retryable
+    assert digest.sent_at is None
+    assert digest.sent_by_id is None
+    assert db_session.query(ProactiveOutreachLine).filter(ProactiveOutreachLine.sent_at.isnot(None)).count() == 0
+
+
 # ── Weekly summary ───────────────────────────────────────────────────────
 
 

--- a/tests/test_proactive_process.py
+++ b/tests/test_proactive_process.py
@@ -19,6 +19,7 @@ from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from sqlalchemy import update
 
 from app.constants import ProactiveMatchStatus, ProactiveOfferStatus
 from app.models import (
@@ -43,7 +44,7 @@ from app.services.proactive_service import (
     process_matches,
     send_draft_offer,
 )
-from tests.conftest import engine  # noqa: F401
+from tests.conftest import engine, requires_postgres  # noqa: F401
 
 HX = {"HX-Request": "true"}
 
@@ -398,3 +399,37 @@ async def test_failed_oneshot_send_marks_offer_failed_not_sent(db_session):
     assert s["m1"].status == ProactiveMatchStatus.FAILED
     assert db_session.query(ProactiveThrottle).count() == 0  # retry not suppressed
     assert get_scorecard(db_session)["total_sent"] == 0  # never counted as outreach
+
+
+@requires_postgres
+def test_proactive_offer_claim_is_exclusive(pg_session, pg_engine):
+    """The DRAFT→SENT claim send_draft_offer runs before the Graph send can match a row
+    only ONCE — this is the DB-level guarantee that two racing sends never double-email
+    a customer.
+
+    First claimant gets rowcount 1; after it commits, the second sees 0 and bails.
+    """
+    from sqlalchemy.orm import sessionmaker
+
+    po = ProactiveOffer(status=ProactiveOfferStatus.DRAFT, line_items=[])
+    pg_session.add(po)
+    pg_session.commit()
+
+    def _claim(session):
+        return session.execute(
+            update(ProactiveOffer)
+            .where(ProactiveOffer.id == po.id, ProactiveOffer.status == ProactiveOfferStatus.DRAFT)
+            .values(status=ProactiveOfferStatus.SENT)
+        ).rowcount
+
+    second_session = sessionmaker(bind=pg_engine)()
+    try:
+        first = _claim(pg_session)
+        pg_session.commit()
+        second = _claim(second_session)
+        second_session.commit()
+    finally:
+        second_session.close()
+
+    assert first == 1  # this caller won the claim and sends
+    assert second == 0  # the racer finds no DRAFT row and must not send


### PR DESCRIPTION
Both `send_draft_offer` and `send_digest` held a DRAFT row across the `await gc.post_json(...)` send — a window where a concurrent send double-emailed the customer, and the `generate_digests` "clear ALL drafts" sweep (a separate job session) could delete a digest whose email had already gone out.

**Fix:** claim the row atomically **before** the await — one conditional `UPDATE ... SET status=SENT WHERE id=? AND status=DRAFT` + commit. Only the caller whose UPDATE matches `status=DRAFT` wins (rowcount 1); a racer sees 0 rows and bails, and the drafts sweep skips an in-flight (now SENT) row. No row lock is held across the await. A Graph rejection reverts the claim to DRAFT (sent_at/sent_by cleared) so the send stays retryable — never a phantom SENT.

**Tests:** `test_proactive_offer_claim_is_exclusive` (@requires_postgres, two sessions — claim matches once, rowcount 1 then 0); `test_send_digest_reverts_to_draft_on_send_failure` (Graph 401 after claim → back to DRAFT, retryable). Existing happy-path + GraphAPIError-untouched tests still green. 30 passed, 1 skipped (PG-only); 0 new assertion-theater violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK69vhS81SPCP49ZSgvXea