### PR TITLE
Hotlist watch: part-level standing monitor, catalog channels, retro-match (flag-off auto re-search)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -253,6 +253,12 @@ PROACTIVE_OFFER_WINDOW_DAYS=7
 PROACTIVE_PRICE_LOOKBACK_MONTHS=24
 # Push new proactive matches into Teams as an Adaptive Card digest (opt-in).
 PROACTIVE_TEAMS_PUSH_ENABLED=false
+# Weekly automated re-search of hotlist demand through the ICS/NC/TBF connectors
+# (Sun 02:00). OFF by owner decision 2026-08-14 ("build now, enable later") —
+# turning it on spends real connector quota.
+HOTLIST_RESEARCH_ENABLED=false
+# Cap on distinct hotlist MPNs enqueued per weekly research run.
+HOTLIST_RESEARCH_MAX_PARTS=200
 
 # ── Sighting scoring (score_sighting_v2 factor weights) ──
 # The five factor weights behind every sighting's buyer-usefulness score

--- a/app/config.py
+++ b/app/config.py
@@ -277,6 +277,13 @@ class Settings(BaseSettings):
     # OFF so enabling delivery is a deliberate admin choice (it sends real Teams
     # messages). Admin can override via the proactive_teams_push_enabled flag.
     proactive_teams_push_enabled: bool = False
+    # Weekly automated re-search of hotlist demand through the ICS/NC/TBF
+    # connectors. Default OFF by owner decision (2026-08-14: "build now, enable
+    # later") — flipping this on spends real connector quota. Admin can
+    # override via the hotlist_research_enabled flag.
+    hotlist_research_enabled: bool = False
+    # Cap on distinct hotlist MPNs enqueued per weekly run.
+    hotlist_research_max_parts: int = 200
 
     # --- Sighting scoring (score_sighting_v2 factor weights) ---
     # The five factor weights behind every sighting's buyer-usefulness score.

--- a/app/constants.py
+++ b/app/constants.py
@@ -477,8 +477,11 @@ class ProactiveMatchSource(StrEnum):
     """How a ProactiveMatch was seeded (2026-08-06 rework).
 
     REQUIREMENT — the customer asked for this part inside the requirement window (any
-    requisition status; a won/lost ask is still demand history). HOTLIST — a salesperson
-    explicitly monitors this part for the customer.
+    requisition status; a won/lost ask is still demand history). HOTLIST — an explicit
+    standing monitor, at either level: a HOTLIST requisition (match has requirement_id
+    NULL, no ask history) or a HOTLIST part (migration 210 — match carries
+    requirement_id + real last-asked signals). Both share this value; disambiguate by
+    requirement_id when it matters.
     """
 
     REQUIREMENT = "requirement"

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -16,6 +16,7 @@ def register_all_jobs(scheduler, settings):
     from .eight_by_eight_jobs import register_eight_by_eight_jobs
     from .email_jobs import register_email_jobs
     from .health_jobs import register_health_jobs
+    from .hotlist_jobs import register_hotlist_jobs
     from .inventory_jobs import register_inventory_jobs
     from .knowledge_jobs import register_knowledge_jobs
     from .maintenance_jobs import register_maintenance_jobs
@@ -38,6 +39,7 @@ def register_all_jobs(scheduler, settings):
         register_email_jobs(scheduler, settings, db)
         register_inventory_jobs(scheduler, settings)
         register_offers_jobs(scheduler, settings, db)
+        register_hotlist_jobs(scheduler, settings, db)
         register_prospecting_jobs(scheduler, settings)
         register_sweep_jobs(scheduler, settings)
         register_resell_jobs(scheduler, settings)

--- a/app/jobs/hotlist_jobs.py
+++ b/app/jobs/hotlist_jobs.py
@@ -1,0 +1,102 @@
+"""jobs/hotlist_jobs.py — weekly automated re-search of hotlist demand (FLAG-OFF).
+
+Hotlist demand (part-level `Requirement.sourcing_status == 'hotlist'`, migration
+210, plus deal-level `Requisition.status == 'hotlist'`) is a standing "watch
+this part for the customer" request. The passive catalog builds from manual
+searches, vendor stock-list emails, logged offers, and the excess mirror; this
+job adds ACTIVE weekly re-searching through the ICS/NC/TBF browser connectors
+so the catalog keeps growing even when nobody touches the part.
+
+Ships behind `hotlist_research_enabled` (config default False; admin override
+via system_config) by explicit owner decision (2026-08-14): the job exists so
+enabling it later is a one-flag flip, but it spends real connector quota so it
+stays OFF until the owner says otherwise. Load is bounded three ways: one run a
+week (Sun 02:00), `hotlist_research_max_parts` distinct MPNs per run (oldest
+`last_searched_at` first, never-searched first of all), and the workers' 7-day
+cross-requirement dedup (a recently searched MPN clones sightings instead of
+re-searching).
+
+Called by: app/jobs/__init__.py register_all_jobs (flag-gated registration).
+Depends on: app.models (Requirement, Requisition), ics/nc/tbf queue managers.
+"""
+
+from apscheduler.triggers.cron import CronTrigger
+from loguru import logger
+from sqlalchemy import or_
+
+from ..constants import RequisitionStatus, SourcingStatus
+from ..scheduler import _traced_job
+
+
+@_traced_job
+async def _job_hotlist_research():
+    """Enqueue the stalest hotlist MPNs (one requirement each) for connector search."""
+    from ..config import settings
+    from ..database import SessionLocal
+    from ..models import Requirement, Requisition
+    from ..services.ics_worker.queue_manager import enqueue_for_ics_search
+    from ..services.nc_worker.queue_manager import enqueue_for_nc_search
+    from ..services.tbf_worker.queue_manager import enqueue_for_tbf_search
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(Requirement)
+            .join(Requisition, Requirement.requisition_id == Requisition.id)
+            .filter(
+                Requisition.is_scratch.is_(False),
+                Requirement.normalized_mpn.isnot(None),
+                or_(
+                    Requirement.sourcing_status == SourcingStatus.HOTLIST,
+                    Requisition.status == RequisitionStatus.HOTLIST,
+                ),
+            )
+            .order_by(Requirement.last_searched_at.asc().nullsfirst())
+            .all()
+        )
+        cap = max(1, settings.hotlist_research_max_parts)
+        seen_keys: set[str] = set()
+        enqueued = 0
+        for req_item in rows:
+            if len(seen_keys) >= cap:
+                break
+            if req_item.normalized_mpn in seen_keys:
+                continue
+            seen_keys.add(req_item.normalized_mpn)
+            for enqueue in (enqueue_for_ics_search, enqueue_for_nc_search, enqueue_for_tbf_search):
+                try:
+                    enqueue(req_item.id, db)
+                    enqueued += 1
+                except Exception as exc:
+                    logger.warning("Hotlist research enqueue failed (req {}): {}", req_item.id, exc)
+        db.commit()
+        logger.info(
+            "Hotlist research: {} distinct MPNs → {} queue entries (cap {})",
+            len(seen_keys),
+            enqueued,
+            cap,
+        )
+    except Exception as exc:
+        logger.error("Hotlist research job failed: {}", exc)
+        db.rollback()
+    finally:
+        db.close()
+
+
+def register_hotlist_jobs(scheduler, settings, db=None):
+    """Register the weekly hotlist re-search job (only when the flag is ON).
+
+    *db* (when provided) lets hotlist_research_enabled resolve from the system_config DB
+    row (admin toggle) instead of only the env default. `is True` (not truthiness) so a
+    MagicMock settings in unrelated scheduler tests resolves to off, not a spurious job.
+    """
+    from ..services.admin_service import get_effective_flag
+
+    if get_effective_flag(db, "hotlist_research_enabled", settings.hotlist_research_enabled) is True:
+        scheduler.add_job(
+            _job_hotlist_research,
+            CronTrigger(day_of_week="sun", hour=2, minute=0),
+            id="hotlist_research",
+            name="Hotlist weekly re-search",
+        )
+        logger.info("Hotlist weekly re-search job registered (flag ON)")

--- a/app/jobs/inventory_jobs.py
+++ b/app/jobs/inventory_jobs.py
@@ -13,7 +13,7 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
 
-from ..constants import RequisitionStatus
+from ..constants import RequisitionStatus, SourcingStatus
 from ..scheduler import _traced_job
 from ..services.price_snapshot_service import record_price_snapshot
 
@@ -425,6 +425,7 @@ async def _download_and_import_stock_list(
     # Auto-create actionable sightings for open requirements that match imported stock.
     try:
         from sqlalchemy import func as sa_func
+        from sqlalchemy import or_ as sa_or
 
         from app.models import Requirement, Requisition, Sighting
         from app.utils import safe_float, safe_int
@@ -450,7 +451,16 @@ async def _download_and_import_stock_list(
                 )
                 .join(Requisition, Requirement.requisition_id == Requisition.id)
                 .filter(
-                    Requisition.status.in_([RequisitionStatus.OPEN, RequisitionStatus.OFFERS]),
+                    # Vendor stock now also supplies hotlist demand: HOTLIST
+                    # requisitions (deal-level monitor) and HOTLIST parts —
+                    # the latter on requisitions in ANY status incl. won/lost,
+                    # which is exactly what a standing part monitor means.
+                    sa_or(
+                        Requisition.status.in_(
+                            [RequisitionStatus.OPEN, RequisitionStatus.OFFERS, RequisitionStatus.HOTLIST]
+                        ),
+                        Requirement.sourcing_status == SourcingStatus.HOTLIST,
+                    ),
                     sa_func.upper(Requirement.primary_mpn).in_(imported_mpns_upper),
                 )
                 .all()

--- a/app/models/intelligence.py
+++ b/app/models/intelligence.py
@@ -353,7 +353,10 @@ class ProactiveMatch(Base):
     dismiss_reason = Column(String(255))
 
     # Requirement-demand signals (2026-08-06 rework — seeded from asks, not purchases)
-    match_source = Column(String(20), default=ProactiveMatchSource.REQUIREMENT)  # requirement | hotlist
+    # requirement | hotlist. hotlist covers BOTH monitor levels: requisition
+    # hotlist (requirement_id NULL) and part hotlist (requirement_id set, real
+    # ask signals — migration 210).
+    match_source = Column(String(20), default=ProactiveMatchSource.REQUIREMENT)
     requirement_count = Column(Integer, default=0)  # asks by this customer inside the window
     last_asked_at = Column(UTCDateTime)
     last_asked_qty = Column(Integer)

--- a/app/services/proactive_digest.py
+++ b/app/services/proactive_digest.py
@@ -118,13 +118,23 @@ def find_duplicate_material_groups(db: Session) -> list[list[str]]:
 
 
 def _render_line(line: dict) -> list[str]:
-    """One digest bullet + its indented anchor sub-lines (text form)."""
+    """One digest bullet + its indented anchor sub-lines (text form).
+
+    Hotlist matches keep the hotlist framing even when they carry real ask history
+    (part-level hotlist, migration 210) — the salesperson should read "standing
+    monitor", not "recent ask".
+    """
+    is_hotlist = line.get("match_source") == "hotlist"
     ask = ""
     if line["last_asked_at"]:
         ask = f"last asked {fmt_date(line['last_asked_at'])} for {fmt_qty(line['last_asked_qty'])} pcs"
         if (line["requirement_count"] or 0) > 1:
             ask += f" ({line['requirement_count']} requests on file)"
+        if is_hotlist:
+            ask = f"on your hotlist — {ask}"
     else:
+        # No ask history = requisition-level hotlist (the only source that
+        # seeds without a requirement).
         ask = "on your hotlist"
     avail = f"available {fmt_qty(line['available_qty'])} pcs"
     if line["low_cost"] is not None:
@@ -228,6 +238,7 @@ def generate_digests(db: Session) -> dict:
             "match_id": m.id,
             "mpn": m.mpn,
             "company_id": m.company_id,
+            "match_source": m.match_source or "requirement",
             "last_asked_at": m.last_asked_at,
             "last_asked_qty": m.last_asked_qty,
             "requirement_count": m.requirement_count or 0,

--- a/app/services/proactive_matching.py
+++ b/app/services/proactive_matching.py
@@ -29,11 +29,17 @@ Depends on: models, config, services/proactive_helpers
 from datetime import UTC, datetime, timedelta
 
 from loguru import logger
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from ..config import settings
-from ..constants import OfferStatus, ProactiveMatchSource, ProactiveMatchStatus, RequisitionStatus
+from ..constants import (
+    OfferStatus,
+    ProactiveMatchSource,
+    ProactiveMatchStatus,
+    RequisitionStatus,
+    SourcingStatus,
+)
 from ..models import (
     ActivityLog,
     Company,
@@ -334,31 +340,45 @@ def _aggregate_cph_by_company(cph_rows: list) -> dict[int, dict]:
 def find_matches_for_offer(offer_id: int, db: Session) -> list[ProactiveMatch]:
     """Find customer matches for a single offer.
 
-    Two seeding sources:
+    Three seeding sources:
       1. Requirement history inside the requirement window (any requisition
-         status) via ``_find_requirement_matches`` — the primary backbone.
-      2. Active HOTLIST requisitions via ``_find_hotlist_matches`` — surfaces a
+         status, hotlist parts excluded) via ``_find_requirement_matches`` —
+         the primary backbone.
+      2. HOTLIST *parts* (Requirement.sourcing_status, migration 210) via
+         ``_find_part_hotlist_matches`` — standing per-part monitors with real
+         ask history, no time window, any requisition status.
+      3. Active HOTLIST requisitions via ``_find_hotlist_matches`` — surfaces a
          part the customer never asked for recently but a salesperson
-         explicitly monitors.
+         explicitly monitors at the deal level.
 
-    Dedup stays one active match per (part, company). The requirement pass
-    ``db.add()``s rows that are still uncommitted when the hotlist pass runs, so
-    the hotlist pass's DB query can't see them — we pass the companies in via
-    ``skip_company_ids`` so the same customer never gets two matches in one call.
+    Dedup stays one active match per (part, company). Each pass ``db.add()``s
+    rows that are still uncommitted when the next pass runs, so a fresh DB
+    query can't see them — the accumulated companies ride ``skip_company_ids``
+    so the same customer never gets two matches in one call.
     """
     offer = db.get(Offer, offer_id)
     part = part_key(offer.mpn) if offer else None
     if not offer or not part:
         return []
+    our_cost = float(offer.unit_price) if offer.unit_price else None
     req_matches = _find_requirement_matches(db, part=part, source_offer=offer)
+    skip = {m.company_id for m in req_matches if m.company_id}
+    part_hot_matches = _find_part_hotlist_matches(
+        db,
+        part=part,
+        our_cost=our_cost,
+        source_offer=offer,
+        skip_company_ids=skip,
+    )
+    skip = skip | {m.company_id for m in part_hot_matches if m.company_id}
     hot_matches = _find_hotlist_matches(
         db,
         part=part,
-        our_cost=float(offer.unit_price) if offer.unit_price else None,
+        our_cost=our_cost,
         source_offer=offer,
-        skip_company_ids={m.company_id for m in req_matches if m.company_id},
+        skip_company_ids=skip,
     )
-    return req_matches + hot_matches
+    return req_matches + part_hot_matches + hot_matches
 
 
 def _existing_match_company_ids(db: Session, spellings: set[str]) -> set[int | None]:
@@ -427,6 +447,14 @@ def _find_requirement_matches(
             Requirement.created_at >= _requirement_window_start(),
             Requisition.is_scratch.is_(False),
             Requisition.status != RequisitionStatus.HOTLIST.value,
+            # Part-level hotlist rows belong to _find_part_hotlist_matches
+            # (standing monitor, no window). NULL-safe: sourcing_status is
+            # nullable and `!= 'hotlist'` would silently drop NULL-status rows
+            # (same trap as routers/sightings._active_sourcing_status_clause).
+            or_(
+                Requirement.sourcing_status.is_(None),
+                Requirement.sourcing_status != SourcingStatus.HOTLIST.value,
+            ),
         )
         .order_by(Requirement.created_at.desc())
         .all()
@@ -688,6 +716,202 @@ def _find_hotlist_matches(
             )
         )
     return out
+
+
+def _find_part_hotlist_matches(
+    db: Session,
+    *,
+    part: str,
+    our_cost: float | None,
+    source_offer: Offer | None,
+    skip_company_ids: set[int] | None = None,
+) -> list[ProactiveMatch]:
+    """Seed ProactiveMatch rows from HOTLIST *parts* (Requirement.sourcing_status,
+    migration 210) for this part.
+
+    The part-level sibling of :func:`_find_hotlist_matches`: NO time window (a
+    hotlist part is a standing "customer uses this, watch for stock" monitor)
+    and NO requisition-status filter — a hotlist part on a WON/LOST deal is
+    exactly the case this exists for. Unlike the requisition-level pass, the
+    match carries REAL demand signals (requirement_id, last asked date/qty,
+    count of hotlist rows), so the score is computed from them, floored at the
+    hotlist baseline 60 so an old hotlisted ask never ranks below a signal-less
+    requisition hotlist. Customer resolution mirrors the requirement pass
+    (requisition.company_id, else the site's company; active-site fallback) but
+    rows with no resolvable company are logged and skipped — a hotlist is
+    customer-specific by definition, there is no back-order fallback.
+
+    ``skip_company_ids`` carries companies already matched by the requirement
+    pass in THIS call (their ``db.add()``s are uncommitted and invisible to a
+    fresh query) so one customer never gets two matches per scan.
+    """
+    from .part_equivalence import expand_part, observed_spellings
+
+    fallback_offer_id = source_offer.id if source_offer else None
+    if not fallback_offer_id:
+        return []
+
+    rollup = compute_offer_rollup(db, part=part)
+    if not rollup["offer_count"]:
+        return []
+
+    eq = expand_part(db, part)
+    class_keys = set(eq["keys"])
+    class_spellings = {part} | {s for group in observed_spellings(db, class_keys).values() for s in group}
+
+    rows = (
+        db.query(Requirement, Requisition, CustomerSite)
+        .join(Requisition, Requirement.requisition_id == Requisition.id)
+        .outerjoin(CustomerSite, CustomerSite.id == Requisition.customer_site_id)
+        .filter(
+            Requirement.normalized_mpn.in_(class_keys),
+            Requirement.sourcing_status == SourcingStatus.HOTLIST.value,
+            Requisition.is_scratch.is_(False),
+        )
+        .order_by(Requirement.created_at.desc())
+        .all()
+    )
+    if not rows:
+        return []
+
+    # ── Group hotlist rows per company (newest first) — requirement-pass style. ──
+    groups: dict[int, dict] = {}
+    for req_item, requisition, ask_site in rows:
+        row_company_id = requisition.company_id or (ask_site.company_id if ask_site else None)
+        if not row_company_id:
+            logger.debug(
+                "Part-hotlist row skipped (no resolvable company): requirement {} on requisition {}",
+                req_item.id,
+                requisition.id,
+            )
+            continue
+        grp = groups.setdefault(
+            row_company_id,
+            {
+                "count": 0,
+                "newest_req": req_item,
+                "newest_requisition": requisition,
+                "newest_site": ask_site,
+            },
+        )
+        grp["count"] += 1
+    if not groups:
+        return []
+
+    company_ids = set(groups)
+    companies = {c.id: c for c in db.query(Company).filter(Company.id.in_(company_ids)).all()}
+
+    # First active site per company, preferring the newest ask's own site.
+    sites: dict[int, CustomerSite] = {}
+    for s in (
+        db.query(CustomerSite).filter(CustomerSite.company_id.in_(company_ids), CustomerSite.is_active.is_(True)).all()
+    ):
+        sites.setdefault(s.company_id, s)
+
+    existing = _existing_match_company_ids(db, class_spellings)
+    existing |= skip_company_ids or set()
+    dno = build_batch_dno_set_multi(db, class_spellings, company_ids)
+
+    out: list[ProactiveMatch] = []
+    for company_id, grp in groups.items():
+        company = companies.get(company_id)
+        if company is None or company_id in existing or company_id in dno:
+            continue
+        newest_req = grp["newest_req"]
+        requisition = grp["newest_requisition"]
+        salesperson_id = company.account_owner_id or requisition.created_by
+        if not salesperson_id:
+            continue
+        ask_site = grp["newest_site"]
+        site = ask_site if (ask_site and ask_site.is_active) else sites.get(company_id)
+
+        score = max(
+            60,  # hotlist baseline — an explicit monitor never scores below one
+            compute_match_score(
+                last_asked_at=newest_req.created_at,
+                requirement_count=grp["count"],
+                available_qty=rollup["available_qty"],
+                last_asked_qty=newest_req.target_qty,
+            ),
+        )
+        match = ProactiveMatch(
+            offer_id=fallback_offer_id,
+            requirement_id=newest_req.id,
+            requisition_id=requisition.id,
+            customer_site_id=site.id if site else None,
+            salesperson_id=salesperson_id,
+            mpn=part_key(newest_req.primary_mpn) or part,
+            material_card_id=(source_offer.material_card_id if source_offer else None) or newest_req.material_card_id,
+            company_id=company_id,
+            match_score=score,
+            margin_pct=None,
+            customer_purchase_count=0,
+            our_cost=our_cost,
+            match_source=ProactiveMatchSource.HOTLIST,
+            requirement_count=grp["count"],
+            last_asked_at=newest_req.created_at,
+            last_asked_qty=newest_req.target_qty,
+        )
+        db.add(match)
+        out.append(match)
+        existing.add(company_id)
+        db.add(
+            ActivityLog(
+                user_id=salesperson_id,
+                activity_type="proactive_match",
+                channel="system",
+                requisition_id=requisition.id,
+                company_id=company_id,
+                contact_name=company.name,
+                subject=f"Hotlist match: {part} — {company.name}",
+            )
+        )
+    return out
+
+
+def trigger_rematch_on_part_hotlist(db: Session, requirement: Requirement) -> int:
+    """Immediate retro-match when a part is flagged hotlist.
+
+    The 4h batch scan only sees offers newer than the watermark, so a freshly
+    hotlisted part with EXISTING live supply would wait for the next new offer
+    before matching. This anchors one part-hotlist pass on the newest live
+    in-window offer for the part's equivalence class.
+
+    UNLIKE :func:`trigger_rematch_on_offer_approval` this NEVER commits or
+    rolls back — it is called from inside ``transition_requirement`` whose
+    callers own the transaction (bulk_outcome commits once after its loop).
+    Work happens inside a SAVEPOINT so a matching failure can never poison the
+    caller's status-change transaction.
+    """
+    from .part_equivalence import expand_part
+
+    part = part_key(requirement.primary_mpn)
+    if not part:
+        return 0
+    try:
+        with db.begin_nested():
+            class_keys = set(expand_part(db, part)["keys"])
+            offer = (
+                db.query(Offer)
+                .filter(
+                    Offer.normalized_mpn.in_(class_keys),
+                    Offer.status.in_(_LIVE_STATUSES),
+                    Offer.created_at >= _offer_window_start(),
+                )
+                .order_by(Offer.created_at.desc())
+                .first()
+            )
+            if offer is None:
+                return 0
+            our_cost = float(offer.unit_price) if offer.unit_price else None
+            matches = _find_part_hotlist_matches(db, part=part, our_cost=our_cost, source_offer=offer)
+    except Exception as exc:
+        logger.warning("Part-hotlist retro-match failed for requirement {}: {}", requirement.id, exc)
+        return 0
+    if matches:
+        _bust_picks_cache()
+        logger.info("Part-hotlist retro-match: requirement {} → {} matches", requirement.id, len(matches))
+    return len(matches)
 
 
 _WATERMARK_KEY = "proactive_last_scan"

--- a/app/services/requirement_status.py
+++ b/app/services/requirement_status.py
@@ -65,6 +65,19 @@ def transition_requirement(
     if new_val not in RequirementSourcingStatus.TERMINAL:
         requirement.outcome_reason = None
 
+    # A part flagged hotlist retro-matches against EXISTING live supply
+    # immediately (the 4h scan only sees offers newer than its watermark).
+    # Function-level import mirrors the other trigger_rematch_* call sites;
+    # the hook is savepoint-only and never commits — our caller owns the
+    # transaction. Failures log and never block the status change.
+    if new_val == RequirementSourcingStatus.HOTLIST:
+        try:
+            from .proactive_matching import trigger_rematch_on_part_hotlist
+
+            trigger_rematch_on_part_hotlist(db, requirement)
+        except Exception as e:
+            logger.warning("Part-hotlist retro-match hook failed for requirement {}: {}", requirement.id, e)
+
     try:
         actor_id = actor.id if actor else None
         log_entry = ActivityLog(

--- a/app/templates/htmx/partials/proactive/_match_row.html
+++ b/app/templates/htmx/partials/proactive/_match_row.html
@@ -32,6 +32,12 @@
   {# MPN + ask context #}
   <td>
     <p class="text-sm font-medium text-gray-900 font-mono">{{ match.mpn | default('--') }}</p>
+    {# The hotlist tag renders independently of ask history — a part-level
+       hotlist match (migration 210) carries BOTH the standing-monitor badge
+       and its real last-asked context. #}
+    {% if match.match_source == 'hotlist' %}
+    <span class="badge-mini bg-orange-50 text-orange-700 border border-orange-200 mt-0.5">hotlist</span>
+    {% endif %}
     {% if match.last_asked_at %}
     <p class="text-secondary mt-0.5">
       last asked {{ match.last_asked_at.month }}/{{ match.last_asked_at.day }}/{{ match.last_asked_at.year }}
@@ -41,8 +47,6 @@
             title="{{ match.requirement_count }} requirement records inside the window">{{ match.requirement_count }} requests</span>
       {% endif %}
     </p>
-    {% elif match.match_source == 'hotlist' %}
-    <p class="text-secondary mt-0.5">hotlist</p>
     {% endif %}
     {% if match.has_ai_variants %}
     <span class="badge-mini bg-amber-100 text-amber-800 border border-amber-300 mt-0.5"

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -538,6 +538,7 @@ authoritative reference. Static-analysis tests in
 | requirement_refresh | 4 hours | Re-search stale requirements |
 | proactive_matcher | 4 hours | Match live offers to requirement history (24mo, any status) + hotlists |
 | proactive_digest_drafts | Weekly (Mon 07:00) | Generate per-salesperson digest DRAFTS (human reviews + sends) |
+| hotlist_research | Weekly (Sun 02:00) — **FLAG-OFF** (`hotlist_research_enabled=False`) | Re-search hotlist demand (part-level + requisition-level) through ICS/NC/TBF; cap `hotlist_research_max_parts`/run, workers' 7-day dedup bounds connector load. Owner enables later (see master backlog) |
 | vendor_scorer | Daily | Update vendor reliability scores |
 | health_check | 5 min | DB, Redis, API connector health |
 | backup | 6 hours | pg_dump |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2684,23 +2684,38 @@ NO history:
 
 ```
 find_matches_for_offer(offer, db)
-    +---> _find_matches(...)            # CPH-gated (purchase history)
-    +---> _find_hotlist_matches(...)    # NEW: seeds from active HOTLIST reqs
-            |   JOIN Requisition(status='hotlist')
-            |        -> Requirement(material_card_id == offer.material_card_id)
-            |        -> CustomerSite(is_active) -> Company(account_owner_id NOT NULL)
-            +---> reuse suppression (do_not_offer) + dedup (company_id)
-            +---> baseline match_score=60 (explicit monitor, no history to weight)
+    +---> _find_requirement_matches(...)     # windowed ask history (hotlist parts excluded, NULL-safe)
+    +---> _find_part_hotlist_matches(...)    # HOTLIST PARTS (migration 210): sourcing_status='hotlist',
+            |                                #   NO window, ANY requisition status (won/lost incl.),
+            |                                #   real signals: requirement_id / last_asked_at / qty / count,
+            |                                #   score = max(60, computed); company via requisition/site
+            |                                #   (log+skip when unresolvable — no back-order fallback)
+    +---> _find_hotlist_matches(...)         # HOTLIST REQUISITIONS: standing deal-level monitor,
+            |                                #   requirement_id NULL, flat baseline 60
+            +---> all passes reuse suppression (do_not_offer) + dedup (company_id)
             +---> DB: INSERT proactive_matches (status=NEW), ActivityLog
-    return cph_matches + hot_matches    # deduped on company_id across both passes
+    return req + part_hot + hot              # skip_company_ids accumulates across passes —
+                                             # one active match per (part, company)
 ```
 
-The seeded `ProactiveMatch` carries the hotlist `requisition_id` and the company's
-`account_owner_id` as salesperson, and surfaces on the **existing Proactive list**
-with the same one-click-send pipeline (`proactive_email.py` → Graph sendMail) — no
-new surface. So a HOTLIST req turns "an offer arrived for the part you're watching"
-into a one-click outbound, even for a customer with zero purchase history. (Auto-send
-on a hotlist hit is intentionally out of scope — the salesperson confirms the send.)
+Both hotlist levels share `match_source='hotlist'` (disambiguate by
+`requirement_id` NULL-ness). The seeded `ProactiveMatch` routes to
+`company.account_owner_id or requisition.created_by` and surfaces on the
+**existing Proactive list** with the same human-in-loop send pipeline — no new
+surface. The digest line for a part-hotlist match reads "on your hotlist — last
+asked {date} for {qty} pcs" (`proactive_digest._render_line` branches on
+match_source); `_match_row.html` shows the orange hotlist tag independent of ask
+history. Flipping a part INTO hotlist retro-matches immediately against the
+newest live in-window offer (`trigger_rematch_on_part_hotlist`, called inside
+`transition_requirement`; SAVEPOINT-only, never commits — the status-change
+caller owns the transaction). The vendor stock-list ingest matcher
+(`inventory_jobs.py`) now also supplies hotlist demand: `OR(Requisition.status
+IN (open, offers, hotlist), Requirement.sourcing_status='hotlist')`. (Auto-send
+on a hotlist hit is intentionally out of scope — the salesperson confirms the
+send.) A weekly ACTIVE re-search job exists but ships **flag-OFF**
+(`app/jobs/hotlist_jobs.py`, `hotlist_research_enabled=False`, Sun 02:00, cap
+`hotlist_research_max_parts`, ICS/NC/TBF via the workers' 7-day dedup) — owner
+enables it later; see the master backlog.
 
 ### Unified AI Email Drafting (RFQ rephrase · vendor reply · follow-up)
 

--- a/docs/superpowers/2026-07-03-master-requested-work-backlog.md
+++ b/docs/superpowers/2026-07-03-master-requested-work-backlog.md
@@ -169,6 +169,13 @@ Deploy + verify each shippable increment to staging. User can reorder any time.
 |------|--------|
 | **API-search core sprint** (full program, Phases 0-4) — the product's central function; user mandate: highly functional, optimized, stable | ✅ **Phases 0-4 SHIPPED** (verified item-by-item against main 2026-07-15; landed via commits 2026-07-03/04 + the PR #714 hardening merge — e.g. OAuth token-cache hoist `sources.py:135-177`, Redis re-probe `app/cache/redis_probe.py`, interactive ApiSource telemetry `search_service.py:2922-2949`, Nexar REST→GraphQL fall-through `sources.py:557-598`, `@cached_endpoint` async guard `decorators.py:81-93`). **Last loose end CLOSED 2026-07-15:** Phase-4 "validate/disable Sourcengine parser" — live probes (PR #730) found the entire official `api.sourcengine.com` host dead (Cloudflare 530/1016 on every path incl. the documented `searchpart` endpoint); connector already `disabled`/`is_active=false` on the live DB with zero successes ever, so it stays disabled; revive path documented in the connector. **Sprint complete.** Audit: docs/superpowers/specs/2026-07-03-api-search-core-audit.md. |
 
+## 🔔 QUEUED — hotlist follow-ups (2026-08-14, owner: "make sure this is not forgotten")
+
+| Item | Status |
+|------|--------|
+| **Enable hotlist auto re-search** (`hotlist_research_enabled`) | Job BUILT + shipped flag-OFF with the part-level hotlist feature (weekly Sun 02:00, ICS/NC/TBF, cap `hotlist_research_max_parts`, 7-day worker dedup). Owner decision: passive watching now, flip the flag "later down the road" — enabling costs real connector quota, needs the owner's word. |
+| **Wire LOOKING_AGAIN outreach outcome → Clone-to-Active** | The proactive outreach tracking records "Looking again" but creates nothing. Natural hook: one-tap clone from that outcome row via `clone_parts_to_active` (service shipped with Clone-to-Active). Not built — future planning item. |
+
 ## ⭐ QUEUED — user-requested module review/rework programs (after the API-core sprint)
 
 Each = deep review → prioritized findings → optimization + rework. Treat like the

--- a/tests/test_hotlist_jobs.py
+++ b/tests/test_hotlist_jobs.py
@@ -1,0 +1,128 @@
+"""tests/test_hotlist_jobs.py — the flag-OFF weekly hotlist re-search job.
+
+Covers: registration gating on `hotlist_research_enabled` (explicit-True only,
+mirroring the teams-push pattern), and the job body's selection/dedup/cap
+behavior against the ics/nc/tbf enqueue wrappers (mocked — no browser workers).
+
+Called by: pytest
+Depends on: app/jobs/hotlist_jobs.py, conftest fixtures.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from app.jobs.hotlist_jobs import _job_hotlist_research, register_hotlist_jobs
+from app.models import Requirement, Requisition
+from tests.conftest import engine  # noqa: F401
+
+
+class TestRegistration:
+    def _register(self, *, enabled):
+        mock_scheduler = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.hotlist_research_enabled = enabled
+        register_hotlist_jobs(mock_scheduler, mock_settings)
+        return [c.kwargs.get("id") for c in mock_scheduler.add_job.call_args_list]
+
+    def test_registered_when_flag_on(self):
+        assert "hotlist_research" in self._register(enabled=True)
+
+    def test_absent_when_flag_off(self):
+        assert "hotlist_research" not in self._register(enabled=False)
+
+    def test_absent_on_magicmock_settings(self):
+        # `is True` check: a MagicMock attribute (truthy but not True) must not
+        # register a spurious job in unrelated scheduler tests.
+        mock_scheduler = MagicMock()
+        register_hotlist_jobs(mock_scheduler, MagicMock())
+        assert "hotlist_research" not in [c.kwargs.get("id") for c in mock_scheduler.add_job.call_args_list]
+
+
+async def test_job_enqueues_hotlist_demand_deduped(db_session, test_user, monkeypatch):
+    """Part-level AND requisition-level hotlist MPNs are enqueued once each through all
+    three connectors; non-hotlist parts are not."""
+    open_req = Requisition(name="open deal", status="open", created_by=test_user.id)
+    hot_req = Requisition(name="hot deal", status="hotlist", created_by=test_user.id)
+    won_req = Requisition(name="won deal", status="won", created_by=test_user.id)
+    db_session.add_all([open_req, hot_req, won_req])
+    db_session.flush()
+    # Part-level hotlist on the won deal + two duplicate-MPN rows (dedup) +
+    # a requisition-level hotlist part + a plain open part (excluded).
+    db_session.add_all(
+        [
+            Requirement(requisition_id=won_req.id, primary_mpn="HOTJOB-1", sourcing_status="hotlist"),
+            Requirement(requisition_id=open_req.id, primary_mpn="HOTJOB-1", sourcing_status="hotlist"),
+            Requirement(requisition_id=hot_req.id, primary_mpn="HOTJOB-2", sourcing_status="open"),
+            Requirement(requisition_id=open_req.id, primary_mpn="HOTJOB-3", sourcing_status="open"),
+        ]
+    )
+    db_session.commit()
+
+    calls: list[tuple[str, int]] = []
+
+    def _rec(name):
+        def _f(requirement_id, db, **kwargs):
+            calls.append((name, requirement_id))
+
+        return _f
+
+    with (
+        patch("app.services.ics_worker.queue_manager.enqueue_for_ics_search", side_effect=_rec("ics")),
+        patch("app.services.nc_worker.queue_manager.enqueue_for_nc_search", side_effect=_rec("nc")),
+        patch("app.services.tbf_worker.queue_manager.enqueue_for_tbf_search", side_effect=_rec("tbf")),
+        patch("app.jobs.hotlist_jobs.SessionLocal", create=True) as _,
+        patch("app.database.SessionLocal", return_value=db_session),
+    ):
+        # SessionLocal is imported inside the job — patch the source module and
+        # neutralize close() so the shared test session survives.
+        monkeypatch.setattr(db_session, "close", lambda: None)
+        await _job_hotlist_research()
+
+    enqueued_reqs = {rid for _, rid in calls}
+    hot_part_ids = {
+        r.id for r in db_session.query(Requirement).filter(Requirement.primary_mpn.in_(["HOTJOB-1", "HOTJOB-2"])).all()
+    }
+    open_part_id = db_session.query(Requirement).filter_by(primary_mpn="HOTJOB-3").first().id
+    # One requirement per distinct MPN (dedup collapsed the duplicate HOTJOB-1),
+    # each fanned out to 3 connectors; the plain open part never enqueued.
+    assert len(enqueued_reqs) == 2
+    assert enqueued_reqs <= hot_part_ids
+    assert open_part_id not in enqueued_reqs
+    assert len(calls) == 6
+
+
+async def test_job_respects_cap(db_session, test_user, monkeypatch):
+    """hotlist_research_max_parts caps distinct MPNs per run (oldest-searched first)."""
+    req = Requisition(name="hot deal", status="hotlist", created_by=test_user.id)
+    db_session.add(req)
+    db_session.flush()
+    now = datetime.now(UTC)
+    for i in range(3):
+        db_session.add(
+            Requirement(
+                requisition_id=req.id,
+                primary_mpn=f"CAP-{i}",
+                sourcing_status="hotlist",
+                last_searched_at=now - timedelta(days=i),
+            )
+        )
+    db_session.commit()
+
+    calls: list[int] = []
+    with (
+        patch(
+            "app.services.ics_worker.queue_manager.enqueue_for_ics_search",
+            side_effect=lambda r, d, **k: calls.append(r),
+        ),
+        patch("app.services.nc_worker.queue_manager.enqueue_for_nc_search", side_effect=lambda r, d, **k: None),
+        patch("app.services.tbf_worker.queue_manager.enqueue_for_tbf_search", side_effect=lambda r, d, **k: None),
+        patch("app.database.SessionLocal", return_value=db_session),
+        patch("app.config.settings.hotlist_research_max_parts", 1),
+    ):
+        monkeypatch.setattr(db_session, "close", lambda: None)
+        await _job_hotlist_research()
+
+    assert len(calls) == 1
+    # Oldest last_searched_at first → CAP-2 (searched 2 days ago) wins the slot.
+    picked = db_session.get(Requirement, calls[0])
+    assert picked.primary_mpn == "CAP-2"

--- a/tests/test_jobs_inventory.py
+++ b/tests/test_jobs_inventory.py
@@ -814,6 +814,105 @@ def test_download_and_import_stock_list_teams_alert(scheduler_db, test_user, tes
     assert sightings[0].qty_available == 100
 
 
+def test_stock_list_matches_hotlist_requisition(scheduler_db, test_user, test_requisition):
+    """A HOTLIST requisition's parts receive stock-list sightings (was excluded pre-
+    migration-210 — the matcher only took OPEN/OFFERS)."""
+    import base64
+
+    from app.models import Sighting
+
+    test_user.access_token = "at_dl"
+    test_requisition.status = "hotlist"
+    scheduler_db.commit()
+
+    mock_gc = _graph_client({"contentBytes": base64.b64encode(b"data").decode()})
+    rows = [{"mpn": "LM317T", "qty": 60}]
+
+    with (
+        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+        patch("app.utils.file_validation.validate_file", return_value=(True, "text/csv")),
+        patch("app.services.attachment_parser.parse_attachment", new_callable=AsyncMock, return_value=rows),
+        patch("app.vendor_utils.normalize_vendor_name", return_value="arrow"),
+        patch("app.services.activity_service.match_email_to_entity", return_value=None),
+    ):
+        _run_download(test_user, scheduler_db)
+
+    req_id = test_requisition.requirements[0].id
+    assert (
+        scheduler_db.query(Sighting)
+        .filter(Sighting.requirement_id == req_id, Sighting.source_type == "email_auto_import")
+        .count()
+        == 1
+    )
+
+
+def test_stock_list_matches_hotlist_part_on_closed_deal(scheduler_db, test_user, test_requisition):
+    """A HOTLIST *part* on a WON requisition still receives stock-list sightings — the
+    standing monitor outlives the deal (migration 210)."""
+    import base64
+
+    from app.models import Sighting
+
+    test_user.access_token = "at_dl"
+    test_requisition.status = "won"
+    part = test_requisition.requirements[0]
+    part.sourcing_status = "hotlist"
+    scheduler_db.commit()
+
+    mock_gc = _graph_client({"contentBytes": base64.b64encode(b"data").decode()})
+    rows = [{"mpn": "LM317T", "qty": 75}]
+
+    with (
+        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+        patch("app.utils.file_validation.validate_file", return_value=(True, "text/csv")),
+        patch("app.services.attachment_parser.parse_attachment", new_callable=AsyncMock, return_value=rows),
+        patch("app.vendor_utils.normalize_vendor_name", return_value="arrow"),
+        patch("app.services.activity_service.match_email_to_entity", return_value=None),
+    ):
+        _run_download(test_user, scheduler_db)
+
+    assert (
+        scheduler_db.query(Sighting)
+        .filter(Sighting.requirement_id == part.id, Sighting.source_type == "email_auto_import")
+        .count()
+        == 1
+    )
+
+
+def test_stock_list_still_skips_plain_closed_deals(scheduler_db, test_user, test_requisition):
+    """A WON requisition whose parts are NOT hotlisted stays excluded."""
+    import base64
+
+    from app.models import Sighting
+
+    test_user.access_token = "at_dl"
+    test_requisition.status = "won"
+    scheduler_db.commit()
+
+    mock_gc = _graph_client({"contentBytes": base64.b64encode(b"data").decode()})
+    rows = [{"mpn": "LM317T", "qty": 75}]
+
+    with (
+        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="token"),
+        patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+        patch("app.utils.file_validation.validate_file", return_value=(True, "text/csv")),
+        patch("app.services.attachment_parser.parse_attachment", new_callable=AsyncMock, return_value=rows),
+        patch("app.vendor_utils.normalize_vendor_name", return_value="arrow"),
+        patch("app.services.activity_service.match_email_to_entity", return_value=None),
+    ):
+        _run_download(test_user, scheduler_db)
+
+    req_id = test_requisition.requirements[0].id
+    assert (
+        scheduler_db.query(Sighting)
+        .filter(Sighting.requirement_id == req_id, Sighting.source_type == "email_auto_import")
+        .count()
+        == 0
+    )
+
+
 def test_download_and_import_stock_list_final_commit_fails(scheduler_db, test_user):
     """Final db.commit() failure in _download_and_import is handled."""
     import base64

--- a/tests/test_proactive_digest.py
+++ b/tests/test_proactive_digest.py
@@ -132,6 +132,43 @@ def test_digest_line_format_exact(db_session):
     assert line.requirement_count == 2
 
 
+def test_part_hotlist_line_keeps_hotlist_framing_with_ask_history(db_session):
+    """A part-level hotlist match (migration 210) carries real ask history AND
+    the standing-monitor framing: 'on your hotlist — last asked …'."""
+    owner = _mk_user(db_session, "Sales Rep", "hl@trioscs.com")
+    customer, _ = _mk_customer(db_session, "Vertiv", owner)
+    _mk_offer(db_session, mpn="HL-77", qty=500, price="12")
+    asked = datetime(2026, 7, 1, tzinfo=UTC)
+    m = _mk_match(db_session, mpn="HL-77", owner=owner, company=customer, asked_qty=250, req_count=1)
+    m.match_source = "hotlist"
+    m.last_asked_at = asked
+    db_session.commit()
+
+    generate_digests(db_session)
+    db_session.commit()
+    body = db_session.query(ProactiveDigest).one().body_html
+    assert "on your hotlist — last asked 7/1/2026 for 250 pcs" in body
+
+
+def test_requisition_hotlist_line_unchanged(db_session):
+    """A requisition-level hotlist match (no ask history) keeps the plain 'on your
+    hotlist' line."""
+    owner = _mk_user(db_session, "Sales Rep", "hl2@trioscs.com")
+    customer, _ = _mk_customer(db_session, "Siemens", owner)
+    _mk_offer(db_session, mpn="HL-88", qty=900, price="3")
+    m = _mk_match(db_session, mpn="HL-88", owner=owner, company=customer)
+    m.match_source = "hotlist"
+    m.last_asked_at = None
+    m.last_asked_qty = None
+    m.requirement_count = 0
+    db_session.commit()
+
+    generate_digests(db_session)
+    db_session.commit()
+    body = db_session.query(ProactiveDigest).one().body_html
+    assert "| on your hotlist |" in body
+
+
 def test_single_request_omits_count_suffix(db_session):
     owner = _mk_user(db_session, "Sales Rep", "sr@trioscs.com")
     customer, _ = _mk_customer(db_session, "IBM Corporation", owner)

--- a/tests/test_proactive_part_hotlist.py
+++ b/tests/test_proactive_part_hotlist.py
@@ -1,0 +1,263 @@
+"""Part-level hotlist parts seed Proactive matches as standing monitors.
+
+A HOTLIST *part* (Requirement.sourcing_status, migration 210) is the per-part
+"customer uses this but doesn't need it now — keep watching" state. The
+matcher's part-hotlist pass has NO time window and NO requisition-status
+filter (a hotlist part on a won/lost deal is the core case), carries REAL
+demand signals (requirement_id, last asked date/qty), scores computed-floored-
+at-60, and dedups against the requirement and requisition-hotlist passes.
+Flipping a part to hotlist also retro-matches against existing live supply.
+
+Called by: pytest.
+Depends on: app.services.proactive_matching, app.services.requirement_status,
+            models, conftest db_session fixture.
+"""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from app.constants import RequisitionStatus, SourcingStatus
+from app.models import (
+    Company,
+    CustomerSite,
+    MaterialCard,
+    Offer,
+    ProactiveMatch,
+    Requirement,
+    Requisition,
+    User,
+)
+from app.models.intelligence import ProactiveDoNotOffer
+from app.services.proactive_matching import find_matches_for_offer
+from app.services.requirement_status import transition_requirement
+from tests.conftest import engine  # noqa: F401
+
+
+def _setup(
+    db,
+    *,
+    mpn="PH-100",
+    req_status=RequisitionStatus.OPEN.value,
+    part_status=SourcingStatus.HOTLIST.value,
+    ask_age_days=10,
+    account_owner=True,
+):
+    """Company + active site + requisition (any status) + hotlist part + live offer."""
+    owner = User(
+        email=f"owner-{mpn}@trioscs.com",
+        name="Account Owner",
+        role="sales",
+        azure_id=f"owner-{mpn}",
+        created_at=datetime.now(UTC),
+    )
+    db.add(owner)
+    db.flush()
+
+    card = MaterialCard(normalized_mpn=mpn.lower().replace("-", ""), display_mpn=mpn, search_count=1)
+    db.add(card)
+    db.flush()
+
+    co = Company(name=f"Acme {mpn}", is_active=True, account_owner_id=owner.id if account_owner else None)
+    db.add(co)
+    db.flush()
+
+    site = CustomerSite(company_id=co.id, site_name="Acme HQ", is_active=True)
+    db.add(site)
+    db.flush()
+
+    req = Requisition(
+        name=f"deal {mpn}",
+        status=req_status,
+        customer_site_id=site.id,
+        company_id=co.id,
+        created_by=owner.id,
+    )
+    db.add(req)
+    db.flush()
+
+    part = Requirement(
+        requisition_id=req.id,
+        material_card_id=card.id,
+        primary_mpn=mpn,
+        target_qty=500,
+        sourcing_status=part_status,
+        created_at=datetime.now(UTC) - timedelta(days=ask_age_days),
+    )
+    db.add(part)
+    offer = Offer(
+        material_card_id=card.id,
+        vendor_name="Arrow",
+        mpn=mpn,
+        unit_price=Decimal("10"),
+        qty_available=1000,
+        status="active",
+    )
+    db.add(offer)
+    db.commit()
+    return {"owner": owner, "company": co, "site": site, "req": req, "part": part, "offer": offer, "card": card}
+
+
+def test_part_hotlist_seeds_match_with_real_signals(db_session):
+    """A hotlist part seeds a match carrying requirement_id + ask history."""
+    db = db_session
+    d = _setup(db, mpn="PH-SIG")
+    matches = find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+
+    rows = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).all()
+    assert len(rows) == 1
+    m = rows[0]
+    assert m.match_source == "hotlist"
+    assert m.requirement_id == d["part"].id  # part-level: real requirement link
+    assert m.last_asked_at is not None
+    assert m.last_asked_qty == 500
+    assert m.requirement_count == 1
+    assert m.match_score >= 60  # computed, floored at the hotlist baseline
+    assert m.customer_site_id == d["site"].id
+    assert m.salesperson_id == d["owner"].id
+    assert any(x.company_id == d["company"].id for x in matches)
+
+
+def test_part_hotlist_is_a_standing_monitor_beyond_window(db_session):
+    """An ask older than the 24-month requirement window still seeds — no window."""
+    db = db_session
+    d = _setup(db, mpn="PH-OLD", ask_age_days=30 * 30)  # ~30 months
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+
+    m = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).first()
+    assert m is not None
+    assert m.match_source == "hotlist"
+    assert m.requirement_id == d["part"].id
+
+
+def test_part_hotlist_on_won_requisition_seeds(db_session):
+    """The core case: the deal closed WON but the hotlist part keeps matching."""
+    db = db_session
+    d = _setup(db, mpn="PH-WON", req_status=RequisitionStatus.WON.value)
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+
+    m = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).first()
+    assert m is not None
+    assert m.match_source == "hotlist"
+
+
+def test_requirement_pass_no_longer_seeds_hotlist_parts(db_session):
+    """A company whose ONLY in-window ask is hotlisted gets exactly ONE match, owned by
+    the hotlist pass (the requirement pass excludes hotlist parts)."""
+    db = db_session
+    d = _setup(db, mpn="PH-OWN", ask_age_days=5)  # well inside the window
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+
+    rows = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).all()
+    assert len(rows) == 1
+    assert rows[0].match_source == "hotlist"
+
+
+def test_null_status_part_still_seeds_requirement_pass(db_session):
+    """Regression: the hotlist exclusion in the requirement pass is NULL-safe —
+    a legacy NULL-status part still seeds an ordinary requirement match."""
+    db = db_session
+    d = _setup(db, mpn="PH-NULL", part_status=None)
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+
+    rows = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).all()
+    assert len(rows) == 1
+    assert rows[0].match_source == "requirement"
+
+
+def test_cross_pass_dedup_one_match_per_company(db_session):
+    """A company with an in-window OPEN ask AND a hotlist part gets ONE match (the
+    requirement pass wins the slot)."""
+    db = db_session
+    d = _setup(db, mpn="PH-DUP")
+    # Second, ordinary open ask for the same part by the same company.
+    db.add(
+        Requirement(
+            requisition_id=d["req"].id,
+            material_card_id=d["card"].id,
+            primary_mpn="PH-DUP",
+            target_qty=100,
+            sourcing_status=SourcingStatus.OPEN.value,
+            created_at=datetime.now(UTC) - timedelta(days=2),
+        )
+    )
+    db.commit()
+
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+
+    rows = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).all()
+    assert len(rows) == 1
+    assert rows[0].match_source == "requirement"
+
+
+def test_scratch_requisitions_excluded(db_session):
+    """Hotlist parts on scratch requisitions never seed."""
+    db = db_session
+    d = _setup(db, mpn="PH-SCR")
+    d["req"].is_scratch = True
+    db.commit()
+
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+    assert db.query(ProactiveMatch).filter_by(company_id=d["company"].id).count() == 0
+
+
+def test_do_not_offer_suppresses(db_session):
+    """A DNO row for (mpn, company) blocks the part-hotlist match."""
+    db = db_session
+    d = _setup(db, mpn="PH-DNO")
+    db.add(ProactiveDoNotOffer(mpn="PH-DNO", company_id=d["company"].id, created_by_id=d["owner"].id))
+    db.commit()
+
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+    assert db.query(ProactiveMatch).filter_by(company_id=d["company"].id).count() == 0
+
+
+def test_salesperson_falls_back_to_requisition_owner(db_session):
+    """No account owner on the company → the requisition creator gets the match."""
+    db = db_session
+    d = _setup(db, mpn="PH-FBK", account_owner=False)
+    find_matches_for_offer(d["offer"].id, db)
+    db.commit()
+
+    m = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).first()
+    assert m is not None
+    assert m.salesperson_id == d["owner"].id  # created_by fallback
+
+
+def test_retro_match_on_hotlist_transition(db_session):
+    """Flipping a part to hotlist with EXISTING live supply seeds immediately (no
+    waiting for the next new offer)."""
+    db = db_session
+    d = _setup(db, mpn="PH-RETRO", part_status=SourcingStatus.OPEN.value)
+
+    changed = transition_requirement(d["part"], SourcingStatus.HOTLIST, db, actor=d["owner"])
+    assert changed is True
+    db.commit()
+
+    m = db.query(ProactiveMatch).filter_by(company_id=d["company"].id).first()
+    assert m is not None
+    assert m.match_source == "hotlist"
+    assert m.requirement_id == d["part"].id
+
+
+def test_retro_match_noop_without_live_supply(db_session):
+    """Flipping to hotlist with no live in-window offer creates nothing and never blocks
+    the status change."""
+    db = db_session
+    d = _setup(db, mpn="PH-QUIET", part_status=SourcingStatus.OPEN.value)
+    d["offer"].status = "expired"
+    db.commit()
+
+    changed = transition_requirement(d["part"], SourcingStatus.HOTLIST, db, actor=d["owner"])
+    assert changed is True
+    db.commit()
+
+    assert d["part"].sourcing_status == SourcingStatus.HOTLIST
+    assert db.query(ProactiveMatch).filter_by(company_id=d["company"].id).count() == 0


### PR DESCRIPTION
## What

Gives the new **Hotlist** part status (PR #873) its watching behavior: "the customer uses this part but doesn't need it now — keep collecting sightings/offers and offer proactively when stock appears."

**Stacked on #873** (base branch `feat/part-outcome-hotlist`) — merge that first, then retarget/merge this.

## Changes

- **Matcher — third seeding pass** (`_find_part_hotlist_matches`): hotlist parts match **with no time window** and on **any requisition status** — a hotlist part on a won/lost deal is the core case. Unlike the requisition-level hotlist pass, matches carry real demand signals (`requirement_id`, last asked date/qty, request count) and a computed score floored at the hotlist baseline 60. The requirement pass now excludes hotlist parts (NULL-safely); cross-pass dedup keeps one active match per (part, company). Both monitor levels share `match_source='hotlist'` (disambiguated by `requirement_id`, documented).
- **Instant retro-match**: flipping a part to Hotlist immediately matches it against the newest live in-window offer instead of waiting for the next new offer (`trigger_rematch_on_part_hotlist` — savepoint-only, never commits; the status-change caller owns the transaction).
- **Catalog channels**: the vendor stock-list email matcher now supplies hotlist demand — `OR(requisition status IN (open, offers, hotlist), part sourcing_status = hotlist)` — so hotlist parts on closed deals keep receiving stock-list sightings (the sightings board already keeps them visible per #873).
- **Copy**: digest lines for part-hotlist matches read "on your hotlist — last asked 7/1/2026 for 250 pcs"; the Matches tab shows the orange hotlist tag alongside ask context (was an either/or `elif`).
- **Weekly auto re-search job — built, ships OFF**: `hotlist_research_enabled=False` (+ admin override), Sun 02:00, cap `HOTLIST_RESEARCH_MAX_PARTS=200`/run, ICS/NC/TBF connectors, workers' 7-day dedup bounds load. Owner decision 2026-08-14: "build now, enable later — make sure this is not forgotten" → recorded in the master backlog doc + APP_MAP jobs table.
- **Send posture unchanged**: nothing auto-sends to customers — matches flow into the existing human-reviewed digests and Process flow with zero changes there (verified).

## Tests

- New `tests/test_proactive_part_hotlist.py` (11): real signals, standing monitor beyond the 24-month window, won-deal seeding, requirement-pass exclusion + NULL-status regression, cross-pass dedup, scratch exclusion, DNO suppression, owner fallback, retro-match (+quiet no-op).
- Stock-list ingest: hotlist requisition + hotlist-part-on-won-deal receive sightings; plain closed deals still don't.
- Digest copy tests (both monitor levels) + `tests/test_hotlist_jobs.py` (flag gating incl. MagicMock guard, dedup/fan-out, cap+staleness ordering).
- Full suite in worktree: **24,285 passed**. `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)