### PR TITLE
fix(qc): route every raw card.manufacturer write through the provenance ladder

### DIFF
--- a/alembic/versions/096_spec_provenance.py
+++ b/alembic/versions/096_spec_provenance.py
@@ -74,12 +74,16 @@ _SOURCE_TIER_SQL_CASE = (
     "WHEN 'psref' THEN 80 "
     "WHEN 'oem_official' THEN 80 "
     "WHEN 'web_search' THEN 70 "
+    "WHEN 'form_entry' THEN 70 "
     "WHEN 'brokerbin' THEN 65 "
+    "WHEN 'sighting_consensus' THEN 65 "
+    "WHEN 'sighting_reported' THEN 65 "
     "WHEN 'spec_extraction' THEN 60 "
     "WHEN 'legacy_backfill' THEN 50 "
     "WHEN 'ai_guess' THEN 40 "
     "WHEN 'claude_opus_inferred' THEN 40 "
     "WHEN 'claude_haiku' THEN 40 "
+    "WHEN 'prefix_infer' THEN 40 "
     "ELSE 0 END"
 )
 

--- a/app/routers/materials.py
+++ b/app/routers/materials.py
@@ -31,9 +31,6 @@ from ..services.material_card_service import (
     backfill_missing_manufacturers,
 )
 from ..services.material_card_service import (
-    infer_manufacturer as _infer_manufacturer_from_prefix,
-)
-from ..services.material_card_service import (
     merge_material_cards as _merge_material_cards_service,
 )
 from ..services.material_card_service import (
@@ -73,22 +70,6 @@ def _stamp_manual_provenance(card: MaterialCard, fields: list[str]) -> None:
 def _actor_email(user: User) -> str:
     """Audit/merge actor label — the user's email, or ``"admin"`` if it's unset."""
     return user.email if hasattr(user, "email") else "admin"
-
-
-def _backfill_manufacturer(card: MaterialCard, db: Session) -> None:
-    """Fill a card's missing manufacturer from its MPN prefix, committing on a hit.
-
-    Shared by the two single-card read endpoints (by-id and by-mpn) so a card surfaced
-    without a manufacturer gets one inferred lazily on first view.
-    """
-    if card.manufacturer:
-        return
-    inferred = _infer_manufacturer_from_prefix(db, card.normalized_mpn)
-    if inferred:
-        card.manufacturer = inferred
-        db.add(card)
-        db.commit()
-        invalidate_prefix("material_list")
 
 
 def render_add_modal(
@@ -352,7 +333,6 @@ async def get_material(card_id: int, user: User = Depends(require_user), db: Ses
     card = db.get(MaterialCard, card_id)
     if not card or card.deleted_at is not None:
         raise HTTPException(404, "Material not found")
-    _backfill_manufacturer(card, db)
     return material_card_to_dict(card, db)
 
 
@@ -388,7 +368,6 @@ async def get_material_by_mpn(mpn: str, user: User = Depends(require_user), db: 
     card = db.query(MaterialCard).filter_by(normalized_mpn=norm).filter(MaterialCard.deleted_at.is_(None)).first()
     if not card:
         raise HTTPException(404, "No material card found for this MPN")
-    _backfill_manufacturer(card, db)
     return material_card_to_dict(card, db)
 
 

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -54,6 +54,7 @@ from .services.ics_worker.queue_manager import enqueue_for_ics_search
 from .services.nc_worker.queue_manager import enqueue_for_nc_search
 from .services.price_snapshot_service import record_price_snapshot
 from .services.sourcing_leads import get_vendor_feedback_adjustment, sync_leads_for_sightings
+from .services.spec_tiers import set_manufacturer
 from .services.tbf_worker.queue_manager import enqueue_for_tbf_search
 from .services.vendor_affinity_service import find_vendor_affinity
 from .services.vendor_unavailability import apply_to_fresh_sightings
@@ -2667,7 +2668,7 @@ def resolve_material_card(mpn: str, db: Session, manufacturer: str = "") -> Mate
     card = db.query(MaterialCard).filter_by(normalized_mpn=norm).filter(MaterialCard.deleted_at.is_(None)).first()
     if card:
         if manufacturer and not card.manufacturer:
-            card.manufacturer = manufacturer
+            set_manufacturer(card, manufacturer, source="form_entry", confidence=0.7)
         logger.debug("MC_METRIC: action=resolved mpn={} card_id={}", norm, card.id)
         return card
 
@@ -2755,8 +2756,7 @@ def _upsert_material_card(pn: str, sightings: list[Sighting], db: Session, now: 
     card.last_searched_at = now
     if not card.manufacturer:
         for s in pn_sightings:
-            if s.manufacturer:
-                card.manufacturer = s.manufacturer
+            if s.manufacturer and set_manufacturer(card, s.manufacturer, source="sighting_reported", confidence=0.7):
                 break
 
     # Batch fetch all existing vendor histories for this card (avoids N+1).

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -2678,13 +2678,15 @@ def resolve_material_card(mpn: str, db: Session, manufacturer: str = "") -> Mate
     if dialect == "postgresql":  # pragma: no cover
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
+        # manufacturer deliberately NOT in the insert — the create path routes it
+        # through the ladder below like every other writer (garbage gate + alias
+        # canonicalization + form_entry provenance), same as the fast path above.
         stmt = (
             pg_insert(MaterialCard)
             .values(
                 normalized_mpn=norm,
                 display_mpn=display,
                 search_count=0,
-                manufacturer=manufacturer,
             )
             .on_conflict_do_nothing(
                 index_elements=["normalized_mpn"],
@@ -2707,18 +2709,19 @@ def resolve_material_card(mpn: str, db: Session, manufacturer: str = "") -> Mate
         else:
             logger.info("MC_METRIC: action=created mpn={} card_id={}", norm, card.id)
             _audit_card_created(db, card)
+        if card is not None and manufacturer and not card.manufacturer:
+            set_manufacturer(card, manufacturer, source="form_entry", confidence=0.7)
         return card
     else:
         # SQLite / test fallback — use try/except on IntegrityError
         from sqlalchemy.exc import IntegrityError
 
         try:
-            card = MaterialCard(normalized_mpn=norm, display_mpn=display, search_count=0, manufacturer=manufacturer)
+            card = MaterialCard(normalized_mpn=norm, display_mpn=display, search_count=0)
             db.add(card)
             db.flush()
             logger.info("MC_METRIC: action=created mpn={} card_id={}", norm, card.id)
             _audit_card_created(db, card)
-            return card
         except IntegrityError:
             db.rollback()
             logger.info("MC_METRIC: action=race_resolved mpn={}", norm)
@@ -2728,7 +2731,9 @@ def resolve_material_card(mpn: str, db: Session, manufacturer: str = "") -> Mate
                 card.deleted_at = None
                 db.flush()
                 logger.info("MC_METRIC: action=restored mpn={} card_id={}", norm, card.id)
-            return card
+        if card is not None and manufacturer and not card.manufacturer:
+            set_manufacturer(card, manufacturer, source="form_entry", confidence=0.7)
+        return card
 
 
 def _upsert_material_card(pn: str, sightings: list[Sighting], db: Session, now: datetime) -> MaterialCard | None:

--- a/app/services/material_card_service.py
+++ b/app/services/material_card_service.py
@@ -21,6 +21,7 @@ from ..models import (
 )
 from ..services.excess_mirror import mirror_sighting_filter
 from ..services.price_snapshot_service import record_price_snapshot
+from ..services.spec_tiers import set_manufacturer
 from ..vendor_utils import normalize_vendor_name
 
 MIN_MPN_PREFIX_LENGTH = 6  # Minimum prefix length for manufacturer inference
@@ -59,9 +60,7 @@ def backfill_missing_manufacturers(db: Session) -> int:
     updated = 0
     for part in null_parts:
         inferred = infer_manufacturer(db, part.normalized_mpn)
-        if inferred:
-            part.manufacturer = inferred
-            db.add(part)
+        if inferred and set_manufacturer(part, inferred, source="prefix_infer", confidence=0.6):
             updated += 1
     return updated
 

--- a/app/services/spec_tiers.py
+++ b/app/services/spec_tiers.py
@@ -104,12 +104,26 @@ SOURCE_TIER: dict[str, int] = {
     "psref": 80,
     "oem_official": 80,
     "web_search": 70,
+    # Staff-typed manufacturer on a requisition/excess form, recorded as a side effect
+    # of card lookup (resolve_material_card) — human-entered but un-reviewed, so it
+    # ranks with web_search (70), well below manual (100) which requires an explicit
+    # edit on the card itself.
+    "form_entry": 70,
     "brokerbin": 65,
+    # Broker-listing evidence classes (same trust class as brokerbin):
+    # sighting_consensus = majority vote across >=2 agreeing sightings (tagging_backfill);
+    # sighting_reported = first non-empty maker on a card's own sightings (upsert path).
+    "sighting_consensus": 65,
+    "sighting_reported": 65,
     "spec_extraction": 60,
     "legacy_backfill": 50,
     "ai_guess": 40,
     "claude_opus_inferred": 40,
     "claude_haiku": 40,
+    # MPN-prefix walk over donor cards (infer_manufacturer) — a guess that can propagate
+    # another card's junk, so it ranks with ai_guess (40): fills blanks, never beats
+    # anything with real provenance (even the legacy_backfill 50 floor).
+    "prefix_infer": 40,
 }
 
 # Provenance stamped on valued-but-unprovenanced data (categories that pre-date the
@@ -566,7 +580,10 @@ def _set_provenanced_column(
     current = getattr(card, attr)
     existing_tier = getattr(card, f"{attr}_tier")
     existing_source = getattr(card, f"{attr}_source")
-    if current is None:
+    if current is None or (isinstance(current, str) and not current.strip()):
+        # NULL or blank/whitespace — a blank can only come from an un-routed writer
+        # (the ladder itself rejects blank incoming values), so treat it as absent
+        # rather than ranking it at the legacy floor: any real value beats nothing.
         existing = None
     elif existing_tier is None and existing_source is None:
         # Valued but unprovenanced — written before the ladder or by an un-routed writer.

--- a/app/services/tagging_ai_batch.py
+++ b/app/services/tagging_ai_batch.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 
 from app.models.intelligence import MaterialCard
 from app.models.tags import MaterialTag, Tag
+from app.services.spec_tiers import set_manufacturer
 from app.services.tagging import (
     get_or_create_brand_tag,
     get_or_create_commodity_tag,
@@ -642,7 +643,7 @@ def _apply_chunked_batch(classifications: list[dict], db: Session) -> tuple[int,
         tag_material_card(card.id, tags_to_apply, db)
 
         if not card.manufacturer:
-            card.manufacturer = manufacturer
+            set_manufacturer(card, manufacturer, source="claude_haiku", confidence=confidence)
 
         matched += 1
 

--- a/app/services/tagging_ai_batch.py
+++ b/app/services/tagging_ai_batch.py
@@ -608,8 +608,9 @@ def _apply_chunked_batch(classifications: list[dict], db: Session) -> tuple[int,
         category = (item.get("category") or "").strip() or None
         model_confidence = item.get("confidence")
 
-        # v2 schema: skip null/Unknown manufacturers entirely (don't create 0.30 junk tags)
-        if not manufacturer or manufacturer == "Unknown":
+        # v2 schema: skip null/Unknown manufacturers entirely (don't create 0.30 junk
+        # tags); case-folded — the model sometimes returns "unknown"/"UNKNOWN".
+        if not manufacturer or manufacturer.lower() == "unknown":
             unknown += 1
             continue
 

--- a/app/services/tagging_ai_classify.py
+++ b/app/services/tagging_ai_classify.py
@@ -99,10 +99,14 @@ def _apply_ai_results(classified: list[dict], batch: list, db: Session) -> tuple
 
     for card_id, normalized_mpn in batch:
         result = mpn_to_result.get(normalized_mpn.lower(), {})
-        manufacturer = result.get("manufacturer", "Unknown")
+        # `or "Unknown"` also coalesces an explicit null/"" from the model — the prompt
+        # allows `"manufacturer": null`, which used to crash get_or_create_brand_tag.
+        manufacturer = result.get("manufacturer") or "Unknown"
         category = result.get("category", "Miscellaneous")
 
-        is_unknown = manufacturer == "Unknown"
+        # None-safe + case-folded: the model returns null or "unknown"/"UNKNOWN" too;
+        # none of those may slip past as a real maker at 0.92 confidence.
+        is_unknown = not manufacturer or str(manufacturer).strip().lower() == "unknown"
         confidence = 0.3 if is_unknown else 0.92
 
         tags_to_apply = []

--- a/app/services/tagging_ai_classify.py
+++ b/app/services/tagging_ai_classify.py
@@ -11,6 +11,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.models.intelligence import MaterialCard
+from app.services.spec_tiers import set_manufacturer
 from app.services.tagging import (
     get_or_create_brand_tag,
     get_or_create_commodity_tag,
@@ -133,6 +134,6 @@ def _apply_ai_results(classified: list[dict], batch: list, db: Session) -> tuple
             matched += 1
             card = db.get(MaterialCard, card_id)
             if card and not card.manufacturer:
-                card.manufacturer = manufacturer
+                set_manufacturer(card, manufacturer, source="claude_haiku", confidence=confidence)
 
     return matched, unknown

--- a/app/services/tagging_backfill.py
+++ b/app/services/tagging_backfill.py
@@ -281,9 +281,13 @@ def backfill_manufacturer_from_sightings(db: Session, batch_size: int = 500) -> 
                 total_skipped += 1
                 continue
 
-            # Update card manufacturer if not set
-            if not card.manufacturer:
-                set_manufacturer(card, winner, source=source, confidence=confidence)
+            # Update card manufacturer if not set. If the ladder REJECTS the winner
+            # (garbage shape / blank after canonicalization) on a maker-less card, skip
+            # the brand tag too — tagging would strand a junk tag on a clean card AND
+            # pop the card out of the untagged pool so it never gets reprocessed.
+            if not card.manufacturer and not set_manufacturer(card, winner, source=source, confidence=confidence):
+                total_skipped += 1
+                continue
 
             # Create brand tag
             brand_tag = get_or_create_brand_tag(winner, db)

--- a/app/services/tagging_backfill.py
+++ b/app/services/tagging_backfill.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 from app.models.intelligence import MaterialCard
 from app.models.sourcing import Sighting
 from app.models.tags import MaterialTag
+from app.services.spec_tiers import set_manufacturer
 from app.services.tagging import (
     classify_material_card,
     get_or_create_brand_tag,
@@ -282,7 +283,7 @@ def backfill_manufacturer_from_sightings(db: Session, batch_size: int = 500) -> 
 
             # Update card manufacturer if not set
             if not card.manufacturer:
-                card.manufacturer = winner
+                set_manufacturer(card, winner, source=source, confidence=confidence)
 
             # Create brand tag
             brand_tag = get_or_create_brand_tag(winner, db)

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -4804,13 +4804,26 @@ SOURCE_TIER  manual:100
                oem_crosswalk_enrich writer — decode channel 0.90, title channel 0.85 —
                and the broader oem_official umbrella is
                authoritative_enrichment_service's OEM-domain extractor; all the same
-               evidence class) · web_search:70 · brokerbin:65
+               evidence class) · web_search:70
+             · form_entry:70 (staff-typed maker on a requisition/excess form, recorded as
+               a side effect of resolve_material_card — human-entered but un-reviewed, so
+               web_search class, well below manual/100 which requires an explicit card edit)
+             · brokerbin:65 · {sighting_reported,sighting_consensus}:65 (broker-listing
+               evidence, same trust class as brokerbin: sighting_reported = first non-empty
+               maker on the card's own sightings at upsert; sighting_consensus = ≥2-agreeing
+               majority vote in tagging_backfill — brokers copy each other's listings, so
+               consensus is correlated, not independent, and stays in the same class)
              · spec_extraction:60 · legacy_backfill:50 (pre-ladder data; also the runtime
                floor for a valued category with NULL provenance) ·
-               {ai_guess,claude_opus_inferred,claude_haiku}:40
+               {ai_guess,claude_opus_inferred,claude_haiku}:40 · prefix_infer:40
+               (MPN-prefix donor walk in backfill_missing_manufacturers — a guess that can
+               propagate another card's junk: fills blanks, never beats real provenance)
              (unknown → 0 with a once-per-source WARNING — an unregistered writer loses
               every conflict; migration 096 carries a CASE snapshot of this map, pinned by
-              a sync test)
+              a sync test. ALL card.manufacturer writers route through set_manufacturer —
+              the single-card GET endpoints no longer lazily infer-and-commit on read, and
+              the ladder treats an existing blank/whitespace value as absent rather than
+              ranking it at the legacy floor)
 
 tier_for(source) -> int                 # SOURCE_TIER.get(source, 0); warns once on unknown
 

--- a/tests/test_manufacturer_ladder_routing.py
+++ b/tests/test_manufacturer_ladder_routing.py
@@ -1,0 +1,222 @@
+"""Tests for QC fix: raw ``card.manufacturer =`` writes routed through the provenance ladder.
+
+Every writer that used to assign MaterialCard.manufacturer directly now goes through
+set_manufacturer() with an honest source, so the value carries provenance instead of
+silently ranking at the legacy_backfill floor. Also covers the two GET endpoints that
+used to write-and-commit on read (they no longer write), and the ladder rule that a
+blank existing value ("") is treated as absent rather than a legacy-50 value.
+
+Called by: pytest
+Depends on: conftest fixtures (client, db_session, test_requisition)
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from app.models.intelligence import MaterialCard
+from app.services.material_card_service import backfill_missing_manufacturers
+from app.services.spec_tiers import SOURCE_TIER, set_manufacturer
+from app.services.tagging_ai_classify import _apply_ai_results
+from app.utils.normalization import normalize_mpn_key
+
+
+def _make_card(db, mpn, manufacturer=None):
+    card = MaterialCard(
+        normalized_mpn=normalize_mpn_key(mpn),
+        display_mpn=mpn,
+        manufacturer=manufacturer,
+        created_at=datetime.now(UTC),
+    )
+    db.add(card)
+    db.commit()
+    db.refresh(card)
+    return card
+
+
+class TestNewSourcesRegistered:
+    def test_new_ladder_sources_have_expected_tiers(self):
+        assert SOURCE_TIER["form_entry"] == 70
+        assert SOURCE_TIER["sighting_consensus"] == 65
+        assert SOURCE_TIER["sighting_reported"] == 65
+        assert SOURCE_TIER["prefix_infer"] == 40
+
+
+class TestAiClassifyRoutesThroughLadder:
+    def test_apply_ai_results_stamps_claude_haiku_provenance(self, db_session):
+        card = _make_card(db_session, "STM32F103")
+        classified = [{"mpn": "STM32F103", "manufacturer": "STMicroelectronics", "category": "Miscellaneous"}]
+
+        matched, unknown = _apply_ai_results(classified, [(card.id, "stm32f103")], db_session)
+        db_session.commit()
+        db_session.refresh(card)
+
+        assert matched == 1
+        assert card.manufacturer == "STMicroelectronics"
+        assert card.manufacturer_source == "claude_haiku"
+        assert card.manufacturer_tier == 40
+        assert abs(card.manufacturer_confidence - 0.92) < 1e-9
+
+    def test_apply_ai_results_never_touches_existing_manufacturer(self, db_session):
+        card = _make_card(db_session, "K4A8G085WB", manufacturer="Samsung")
+        card.manufacturer_source = "manual"
+        card.manufacturer_tier = 100
+        card.manufacturer_confidence = 1.0
+        db_session.commit()
+
+        _apply_ai_results(
+            [{"mpn": "K4A8G085WB", "manufacturer": "SK Hynix", "category": "Miscellaneous"}],
+            [(card.id, "k4a8g085wb")],
+            db_session,
+        )
+        db_session.commit()
+        db_session.refresh(card)
+
+        assert card.manufacturer == "Samsung"
+        assert card.manufacturer_source == "manual"
+        assert card.manufacturer_tier == 100
+
+
+class TestSightingConsensusProvenance:
+    def test_consensus_backfill_stamps_sighting_consensus(self, db_session, test_requisition):
+        from app.models.sourcing import Sighting
+        from app.services.tagging_backfill import backfill_manufacturer_from_sightings
+
+        card = _make_card(db_session, "BF-PROV-3")
+        req_item = test_requisition.requirements[0]
+        for i in range(3):
+            db_session.add(
+                Sighting(
+                    requirement_id=req_item.id,
+                    material_card_id=card.id,
+                    vendor_name=f"Vendor{i}",
+                    manufacturer="Texas Instruments",
+                    mpn_matched="BF-PROV-3",
+                    source_type="test",
+                )
+            )
+        db_session.flush()
+
+        result = backfill_manufacturer_from_sightings(db_session)
+        db_session.refresh(card)
+
+        assert result["total_tagged"] == 1
+        assert card.manufacturer == "Texas Instruments"
+        assert card.manufacturer_source == "sighting_consensus"
+        assert card.manufacturer_tier == 65
+        assert abs(card.manufacturer_confidence - 0.95) < 1e-9
+
+
+class TestBulkPrefixBackfill:
+    def test_backfill_stamps_prefix_infer_and_fills_blank_string(self, db_session):
+        null_card = _make_card(db_session, "PFX-NULL", manufacturer=None)
+        blank_card = _make_card(db_session, "PFX-BLANK", manufacturer="")
+
+        with patch("app.services.material_card_service.infer_manufacturer", return_value="Texas Instruments"):
+            updated = backfill_missing_manufacturers(db_session)
+        db_session.commit()
+        db_session.refresh(null_card)
+        db_session.refresh(blank_card)
+
+        assert updated == 2
+        for card in (null_card, blank_card):
+            assert card.manufacturer == "Texas Instruments"
+            assert card.manufacturer_source == "prefix_infer"
+            assert card.manufacturer_tier == 40
+            assert abs(card.manufacturer_confidence - 0.6) < 1e-9
+
+
+class TestLadderBlankIsAbsent:
+    def test_blank_existing_value_loses_to_any_real_write(self, db_session):
+        card = _make_card(db_session, "BLANK-1", manufacturer="")
+        assert set_manufacturer(card, "Fujitsu", source="prefix_infer", confidence=0.6) is True
+        assert card.manufacturer == "Fujitsu"
+        assert card.manufacturer_source == "prefix_infer"
+
+    def test_real_unprovenanced_value_still_beats_tier_40(self, db_session):
+        card = _make_card(db_session, "LEGACY-1", manufacturer="IBM")
+        assert set_manufacturer(card, "Lenovo", source="prefix_infer", confidence=0.9) is False
+        assert card.manufacturer == "IBM"
+        assert card.manufacturer_source is None  # a losing write never stamps provenance
+
+
+class TestGetEndpointsNoLongerWrite:
+    def test_get_material_by_id_does_not_backfill(self, client, db_session):
+        card = _make_card(db_session, "READONLY1")
+        resp = client.get(f"/api/materials/{card.id}")
+        db_session.refresh(card)
+
+        assert resp.status_code == 200
+        assert resp.json()["manufacturer"] is None
+        assert card.manufacturer is None
+        assert card.manufacturer_source is None
+
+    def test_get_material_by_mpn_does_not_backfill(self, client, db_session):
+        card = _make_card(db_session, "READONLY2")
+        resp = client.get("/api/materials/by-mpn/READONLY2")
+        db_session.refresh(card)
+
+        assert resp.status_code == 200
+        assert card.manufacturer is None
+        assert card.manufacturer_source is None
+
+
+class TestResolveMaterialCardFormEntry:
+    def test_resolve_stamps_form_entry_on_existing_empty_card(self, db_session):
+        from app.search_service import resolve_material_card
+
+        card = _make_card(db_session, "FORM-1")
+        resolved = resolve_material_card("FORM-1", db_session, manufacturer="Analog Devices")
+
+        assert resolved.id == card.id
+        assert resolved.manufacturer == "Analog Devices"
+        assert resolved.manufacturer_source == "form_entry"
+        assert resolved.manufacturer_tier == 70
+
+    def test_resolve_does_not_downgrade_manual_value(self, db_session):
+        from app.search_service import resolve_material_card
+
+        card = _make_card(db_session, "FORM-2", manufacturer="Samsung")
+        card.manufacturer_source = "manual"
+        card.manufacturer_tier = 100
+        card.manufacturer_confidence = 1.0
+        db_session.commit()
+
+        resolved = resolve_material_card("FORM-2", db_session, manufacturer="SK Hynix")
+        assert resolved.manufacturer == "Samsung"
+        assert resolved.manufacturer_source == "manual"
+
+
+class TestUpsertSightingReported:
+    def test_upsert_stamps_sighting_reported_and_skips_garbage(self, db_session, test_requisition):
+        from app.models.sourcing import Sighting
+        from app.search_service import _upsert_material_card
+
+        card = _make_card(db_session, "UPS-1")
+        req_item = test_requisition.requirements[0]
+        garbage = Sighting(
+            requirement_id=req_item.id,
+            material_card_id=card.id,
+            vendor_name="VendorA",
+            manufacturer="LF(T",  # garbage fragment — ladder rejects, loop must try the next sighting
+            mpn_matched="UPS-1",
+            source_type="test",
+        )
+        good = Sighting(
+            requirement_id=req_item.id,
+            material_card_id=card.id,
+            vendor_name="VendorB",
+            manufacturer="Fujitsu",
+            mpn_matched="UPS-1",
+            source_type="test",
+        )
+        db_session.add_all([garbage, good])
+        db_session.flush()
+
+        result = _upsert_material_card("UPS-1", [garbage, good], db_session, datetime.now(UTC))
+        db_session.commit()
+        db_session.refresh(card)
+
+        assert result.id == card.id
+        assert card.manufacturer == "Fujitsu"
+        assert card.manufacturer_source == "sighting_reported"
+        assert card.manufacturer_tier == 65

--- a/tests/test_manufacturer_ladder_routing.py
+++ b/tests/test_manufacturer_ladder_routing.py
@@ -76,6 +76,32 @@ class TestAiClassifyRoutesThroughLadder:
         assert card.manufacturer_tier == 100
 
 
+class TestAiClassifyUnknownCaseFold:
+    def test_lowercase_unknown_is_not_a_maker(self, db_session):
+        """Model-returned 'unknown' (any case) routes to the unknown counter — no
+        manufacturer write at 0.92 (the gate used to be case-sensitive)."""
+        card = _make_card(db_session, "UNKCASE1")
+        matched, unknown = _apply_ai_results(
+            [{"mpn": "UNKCASE1", "manufacturer": "unknown", "category": "Miscellaneous"}],
+            [(card.id, "unkcase1")],
+            db_session,
+        )
+        db_session.refresh(card)
+        assert (matched, unknown) == (0, 1)
+        assert card.manufacturer is None
+
+    def test_null_manufacturer_is_not_a_maker(self, db_session):
+        card = _make_card(db_session, "UNKCASE2")
+        matched, unknown = _apply_ai_results(
+            [{"mpn": "UNKCASE2", "manufacturer": None, "category": "Miscellaneous"}],
+            [(card.id, "unkcase2")],
+            db_session,
+        )
+        db_session.refresh(card)
+        assert (matched, unknown) == (0, 1)
+        assert card.manufacturer is None
+
+
 class TestSightingConsensusProvenance:
     def test_consensus_backfill_stamps_sighting_consensus(self, db_session, test_requisition):
         from app.models.sourcing import Sighting
@@ -104,6 +130,38 @@ class TestSightingConsensusProvenance:
         assert card.manufacturer_source == "sighting_consensus"
         assert card.manufacturer_tier == 65
         assert abs(card.manufacturer_confidence - 0.95) < 1e-9
+
+
+class TestSightingConsensusGarbageWinner:
+    def test_rejected_winner_skips_tag_and_stays_in_pool(self, db_session, test_requisition):
+        """When the ladder rejects the consensus winner (garbage shape) on a maker-less
+        card, NO brand tag is created and the card is counted skipped — a junk tag would
+        strand the card outside the untagged pool with a clean manufacturer."""
+        from app.models.sourcing import Sighting
+        from app.models.tags import MaterialTag
+        from app.services.tagging_backfill import backfill_manufacturer_from_sightings
+
+        card = _make_card(db_session, "BF-JUNK-1")
+        req_item = test_requisition.requirements[0]
+        for i in range(3):
+            db_session.add(
+                Sighting(
+                    requirement_id=req_item.id,
+                    material_card_id=card.id,
+                    vendor_name=f"JunkVendor{i}",
+                    manufacturer="LF(T",  # garbage fragment: majority winner, ladder-rejected
+                    mpn_matched="BF-JUNK-1",
+                    source_type="test",
+                )
+            )
+        db_session.flush()
+
+        result = backfill_manufacturer_from_sightings(db_session)
+        db_session.refresh(card)
+
+        assert result["total_tagged"] == 0
+        assert card.manufacturer is None
+        assert db_session.query(MaterialTag).filter_by(material_card_id=card.id).count() == 0
 
 
 class TestBulkPrefixBackfill:
@@ -161,6 +219,26 @@ class TestGetEndpointsNoLongerWrite:
 
 
 class TestResolveMaterialCardFormEntry:
+    def test_create_path_routes_manufacturer_through_ladder(self, db_session):
+        """A brand-NEW card gets its manufacturer via the ladder too (form_entry), not
+        raw in the INSERT — so garbage is rejected and provenance is stamped."""
+        from app.search_service import resolve_material_card
+
+        created = resolve_material_card("NEWCARD77", db_session, manufacturer="Analog Devices")
+        assert created.manufacturer == "Analog Devices"
+        assert created.manufacturer_source == "form_entry"
+        assert created.manufacturer_tier == 70
+
+    def test_create_path_rejects_garbage_manufacturer(self, db_session):
+        """Garbage fragment on CREATE: card is still created, maker stays NULL (the old
+        raw INSERT persisted the junk verbatim with no provenance)."""
+        from app.search_service import resolve_material_card
+
+        created = resolve_material_card("NEWCARD88", db_session, manufacturer="LF(T")
+        assert created is not None
+        assert created.manufacturer is None
+        assert created.manufacturer_source is None
+
     def test_resolve_stamps_form_entry_on_existing_empty_card(self, db_session):
         from app.search_service import resolve_material_card
 

--- a/tests/test_materials_coverage.py
+++ b/tests/test_materials_coverage.py
@@ -139,30 +139,10 @@ class TestListMaterialsWithBrandAndOfferStats:
         assert "materials" in data
 
 
-class TestGetMaterialWithManufacturerInference:
-    """Manufacturer inference in get_material (lines 171-176)."""
+class TestGetMaterialReadOnly:
+    """get_material is read-only — the old lazy manufacturer inference is gone."""
 
-    def test_get_material_infers_manufacturer(self, client, db_session):
-        """GET /api/materials/{id} triggers manufacturer inference when missing."""
-        mc = MaterialCard(
-            normalized_mpn="infer001",
-            display_mpn="INFER001",
-            manufacturer="",  # Empty manufacturer
-            search_count=0,
-            created_at=datetime.now(UTC),
-        )
-        db_session.add(mc)
-        db_session.commit()
-
-        with patch(
-            "app.routers.materials._infer_manufacturer_from_prefix",
-            return_value="Inferred Corp",
-        ):
-            resp = client.get(f"/api/materials/{mc.id}")
-        assert resp.status_code == 200
-
-    def test_get_material_no_inference_when_manufacturer_set(self, client, db_session, test_material_card):
-        """GET /api/materials/{id} skips inference when manufacturer is set."""
+    def test_get_material_returns_manufacturer(self, client, db_session, test_material_card):
         resp = client.get(f"/api/materials/{test_material_card.id}")
         assert resp.status_code == 200
         assert resp.json()["manufacturer"] == "Texas Instruments"
@@ -194,30 +174,6 @@ class TestQuickSearch:
         """POST /api/quick-search with no mpn key returns 400."""
         resp = client.post("/api/quick-search", json={})
         assert resp.status_code == 400
-
-
-class TestGetMaterialByMpnWithManufacturerInference:
-    """Manufacturer inference in get_material_by_mpn (lines 213-218)."""
-
-    def test_by_mpn_infers_manufacturer_when_missing(self, client, db_session):
-        """GET /api/materials/by-mpn/{mpn} triggers inference when manufacturer
-        empty."""
-        mc = MaterialCard(
-            normalized_mpn="infer002",
-            display_mpn="INFER002",
-            manufacturer=None,
-            search_count=0,
-            created_at=datetime.now(UTC),
-        )
-        db_session.add(mc)
-        db_session.commit()
-
-        with patch(
-            "app.routers.materials._infer_manufacturer_from_prefix",
-            return_value="By-MPN Corp",
-        ):
-            resp = client.get("/api/materials/by-mpn/INFER002")
-        assert resp.status_code == 200
 
 
 class TestEnrichMaterial:

--- a/tests/test_materials_router.py
+++ b/tests/test_materials_router.py
@@ -111,8 +111,9 @@ class TestGetMaterial:
         resp = client.get(f"/api/materials/{card.id}")
         assert resp.status_code == 404
 
-    @patch("app.routers.materials._infer_manufacturer_from_prefix", return_value="Texas Instruments")
-    def test_get_material_infers_manufacturer(self, mock_infer, client: TestClient, db_session: Session):
+    def test_get_material_read_only_leaves_missing_manufacturer(self, client: TestClient, db_session: Session):
+        # GET is read-only: a card without a manufacturer stays that way (the old
+        # lazy prefix-inference wrote and committed on read).
         card = MaterialCard(
             normalized_mpn="lm7805",
             display_mpn="LM7805",
@@ -123,7 +124,7 @@ class TestGetMaterial:
         resp = client.get(f"/api/materials/{card.id}")
         assert resp.status_code == 200
         db_session.refresh(card)
-        assert card.manufacturer == "Texas Instruments"
+        assert card.manufacturer is None
 
 
 # ── Get Material by MPN ─────────────────────────────────────────────────

--- a/tests/test_materials_router_coverage.py
+++ b/tests/test_materials_router_coverage.py
@@ -119,8 +119,8 @@ class TestGetMaterial:
         resp = client.get(f"/api/materials/{card.id}")
         assert resp.status_code == 404
 
-    def test_get_infers_manufacturer_when_missing(self, client, db_session):
-        """Card with no manufacturer should trigger infer_manufacturer path."""
+    def test_get_missing_manufacturer_stays_missing(self, client, db_session):
+        """GET is read-only — no lazy manufacturer inference on view."""
         card = MaterialCard(
             normalized_mpn="lm358dr",
             display_mpn="LM358DR",
@@ -130,9 +130,9 @@ class TestGetMaterial:
         db_session.add(card)
         db_session.commit()
 
-        with patch("app.routers.materials._infer_manufacturer_from_prefix", return_value="TI"):
-            resp = client.get(f"/api/materials/{card.id}")
+        resp = client.get(f"/api/materials/{card.id}")
         assert resp.status_code == 200
+        assert resp.json()["manufacturer"] is None
 
 
 # -- GET /api/materials/by-mpn/{mpn} ------------------------------------------
@@ -149,7 +149,8 @@ class TestGetMaterialByMpn:
         assert resp.status_code == 404
         assert "error" in resp.json()
 
-    def test_get_by_mpn_infers_manufacturer(self, client, db_session):
+    def test_get_by_mpn_missing_manufacturer_stays_missing(self, client, db_session):
+        """GET by-mpn is read-only — no lazy manufacturer inference on view."""
         card = MaterialCard(
             normalized_mpn="ne555",
             display_mpn="NE555",
@@ -159,9 +160,9 @@ class TestGetMaterialByMpn:
         db_session.add(card)
         db_session.commit()
 
-        with patch("app.routers.materials._infer_manufacturer_from_prefix", return_value="Philips"):
-            resp = client.get("/api/materials/by-mpn/NE555")
+        resp = client.get("/api/materials/by-mpn/NE555")
         assert resp.status_code == 200
+        assert resp.json()["manufacturer"] is None
 
 
 # -- PUT /api/materials/{card_id} ---------------------------------------------


### PR DESCRIPTION
The last hard item from the QC-mediums worklist: eight writers assigned `MaterialCard.manufacturer` directly, bypassing the F1 provenance ladder — so their values carried no source/tier/confidence and silently ranked at the legacy floor, and junk (garbage fragments, blank strings) could land unchecked.

## Changes
- **New ladder sources** (`spec_tiers.SOURCE_TIER`): `form_entry` 70 (staff-typed maker recorded as a side effect of card lookup — human but un-reviewed, web_search class), `sighting_reported` / `sighting_consensus` 65 (broker-listing evidence, brokerbin class — consensus among brokers is correlated, not independent, so it stays in the same class), `prefix_infer` 40 (MPN-prefix donor walk — a guess that can propagate another card's junk; fills blanks, never beats real provenance).
- **Routed writers**: `resolve_material_card` (form_entry), `_upsert_material_card` sighting loop (sighting_reported — now tries the next sighting when the ladder rejects one), `backfill_manufacturer_from_sightings` (sighting_consensus), both AI taggers (claude_haiku w/ model confidence), `backfill_missing_manufacturers` (prefix_infer).
- **GET endpoints are read-only**: the two single-card GETs no longer infer-and-commit a manufacturer on view (write-on-read side effect); the admin bulk backfill covers the gap, ladder-routed.
- **Blank-is-absent**: the ladder treats an existing `""`/whitespace value as absent, so any real write fills it (it can only come from an un-routed writer — the ladder itself rejects blank input).
- Migration 096's SQL CASE snapshot gains the new sources (`test_migration_096_spec_provenance` enforces sync).

## Tests
- New `tests/test_manufacturer_ladder_routing.py` (12 tests): provenance stamped per writer, manual values never downgraded, garbage rejected mid-loop, GETs read-only, blank-fill.
- 5 sibling tests that encoded the old write-on-GET contract updated to assert the read-only contract.
- Full suite in worktree: **24,282 passed, 29 skipped**; assertion-theater lint exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf