### PR TITLE
fix(ci): defuse revenue_90d time bomb + raise shard timeout past today's cliff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,13 @@ jobs:
     # ~24 min on a 2-vCPU runner and the timeout had been re-tuned three times
     # as the suite grew (15 → 25 → 40). Sharded into a 2-way matrix via
     # scripts/ci_shard.py (deterministic sorted-file round-robin — see that
-    # script's header) so each shard carries ~half the pytest wall-clock;
-    # 25 min = ~12 min of test-running headroom plus the one-time setup/gate
-    # cost that shard 0 alone still pays (see the per-step `if:` gates below).
-    timeout-minutes: 25
+    # script's header) so each shard carries ~half the pytest wall-clock.
+    # 2026-08-17: 25 min became the cliff — green shards were already at 15-21
+    # min and the #878/#879/#880 test additions pushed main past it (both
+    # shards "cancelled" at exactly 25:00 = job timeout, not a hang). 40 min
+    # restores headroom; when shards pass ~30 min real, move to a 3-way matrix
+    # instead of raising this again.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/tests/test_crm_service.py
+++ b/tests/test_crm_service.py
@@ -135,13 +135,19 @@ class TestCompanyCommercialStats:
         co = _make_company(db_session, "Revenue Co")
         site = _make_site(db_session, co)
 
+        # Seed relative to the REAL clock: company_commercial_stats computes its
+        # 90-day cutoff from datetime.now(UTC) (no clock seam), so seeding from the
+        # frozen module NOW was a time bomb — the "in-window" quote drifted out of
+        # the real window once the wall clock moved 90 days past it.
+        real_now = datetime.now(UTC)
+
         # WON req within the 90d window
-        req_in = _make_req(db_session, site, "won", created_at=NOW - timedelta(days=30))
-        _make_quote(db_session, req_in, site, subtotal=5000.0, created_at=NOW - timedelta(days=30))
+        req_in = _make_req(db_session, site, "won", created_at=real_now - timedelta(days=30))
+        _make_quote(db_session, req_in, site, subtotal=5000.0, created_at=real_now - timedelta(days=30))
 
         # WON req OUTSIDE the 90d window — should NOT be included
-        req_out = _make_req(db_session, site, "won", created_at=NOW - timedelta(days=120))
-        _make_quote(db_session, req_out, site, subtotal=9999.0, created_at=NOW - timedelta(days=120))
+        req_out = _make_req(db_session, site, "won", created_at=real_now - timedelta(days=120))
+        _make_quote(db_session, req_out, site, subtotal=9999.0, created_at=real_now - timedelta(days=120))
 
         db_session.commit()
 


### PR DESCRIPTION
`test_revenue_90d_sums_won_quotes_within_window` seeds its quotes from the module's frozen `NOW = 2026-06-18`, but `company_commercial_stats` computes its 90-day cutoff from the REAL `datetime.now(UTC)` — no clock seam. The "in-window" NOW−30d quote drifted out of the real window on **2026-08-17**, so the test now fails on every branch, blocking all CI (including #885 and the upcoming Tier D PR). Fix: seed the window rows relative to the real clock. The `next_best_touch` tests keep the frozen NOW safely — that function takes `now=` explicitly.

Verified: `tests/test_crm_service.py` 34 passed locally on today's date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf