### PR TITLE
refactor(qc): delete three dead legacy routes (Tier D)

### DIFF
--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -13,7 +13,7 @@ from ...constants import RESTRICTED_ROLES, QuoteStatus, RequisitionStatus
 from ...database import get_db
 from ...dependencies import require_user
 from ...models import CustomerSite, Offer, Quote, Requisition, User
-from ...schemas.crm import QuoteCreate, QuoteReopen, QuoteResult, QuoteSendOverride, QuoteUpdate
+from ...schemas.crm import QuoteCreate, QuoteReopen, QuoteResult, QuoteSendOverride
 from ...schemas.responses import QuoteDetailResponse
 from ...services.status_machine import require_valid_transition
 from ._helpers import (
@@ -323,32 +323,6 @@ async def create_quote(
     return result
 
 
-@router.put("/api/quotes/{quote_id}")
-async def update_quote(
-    quote_id: int,
-    payload: QuoteUpdate,
-    user: User = Depends(require_user),
-    db: Session = Depends(get_db),
-):
-    from ...dependencies import get_quote_for_user
-
-    quote = get_quote_for_user(db, user, quote_id)
-    if not quote:
-        raise HTTPException(404, "Quote not found")
-    if quote.status not in (QuoteStatus.DRAFT.value, None):
-        raise HTTPException(400, "Only draft quotes can be edited")
-    updates = payload.model_dump(exclude_unset=True)
-    if "line_items" in updates:
-        quote.line_items = updates.pop("line_items")
-        quote.subtotal, quote.total_cost, quote.total_margin_pct = _compute_quote_totals(quote.line_items or [])
-    for field, value in updates.items():
-        setattr(quote, field, value)
-    db.commit()
-    # Eager-load relations for serialization
-    quote = db.query(Quote).options(*_quote_load_options()).filter(Quote.id == quote.id).first()
-    return quote_to_dict(quote, db)
-
-
 @router.delete("/api/quotes/{quote_id}")
 async def delete_quote(
     quote_id: int,
@@ -491,19 +465,6 @@ async def quote_result(
         "req_status": req.status if req else None,
         "status_changed": True,
     }
-
-
-@router.post("/api/quotes/{quote_id}/revise")
-async def revise_quote(quote_id: int, user: User = Depends(require_user), db: Session = Depends(get_db)):
-    from ...dependencies import get_quote_for_user
-
-    old = get_quote_for_user(db, user, quote_id)
-    if not old:
-        raise HTTPException(404, "Quote not found")
-    new_quote = _build_revision(old, user)
-    db.add(new_quote)
-    db.commit()
-    return quote_to_dict(new_quote, db)
 
 
 @router.post("/api/quotes/{quote_id}/reopen")

--- a/app/routers/prepayments.py
+++ b/app/routers/prepayments.py
@@ -20,7 +20,6 @@ import secrets
 from decimal import Decimal, InvalidOperation
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
-from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 from starlette.responses import HTMLResponse
 
@@ -52,80 +51,6 @@ _PAYMENT_METHOD_CHOICES: list[tuple[str, str]] = [
 
 # Form checkbox / string truthy values ("on" from an HTML checkbox; "true"/"1" from JS).
 _TRUTHY = {"true", "on", "1", "yes"}
-
-
-class PrepaymentCreate(BaseModel):
-    """Request body for POST /v2/prepayments.
-
-    ``buy_plan_line_id`` is optional at the schema boundary so the ownership gate in
-    ``create_prepayment`` (get_buyplan_for_user) still runs FIRST and a restricted
-    non-owner gets a 404 rather than a 422 — line validation follows the ownership check.
-    """
-
-    model_config = ConfigDict(str_strip_whitespace=True)
-
-    buy_plan_id: int
-    buy_plan_line_id: int | None = None
-    vendor_card_id: int | None = None
-    payment_method: str | None = None
-    total_incl_fees: Decimal
-    test_report_sent: bool = False
-    buyer_remarks: str | None = None
-    # Client-prefilled payee (fallback only — the authoritative payee is snapshotted
-    # server-side in create_prepayment from the line's offer / vendor card).
-    vendor_name: str | None = None
-    currency: str = "USD"
-
-
-@router.post("/v2/prepayments")
-def post_prepayment(
-    body: PrepaymentCreate,
-    db: Session = Depends(get_db),
-    current_user=Depends(require_user),
-):
-    """Create a prepayment and spawn its approval gate.
-
-    Returns JSON with the prepayment_id and approval_request_id so the caller can poll
-    or redirect to the approval workflow.
-    """
-    # Same COD/method guards as the HTMX create (router-level — the service stays
-    # untouched): COD lines have nothing to pay in advance; only PREPAYMENT_METHODS pass.
-    if body.payment_method and body.payment_method not in {m.value for m in PREPAYMENT_METHODS}:
-        raise HTTPException(status_code=400, detail="That payment method can't be prepaid.")
-    if body.buy_plan_line_id is not None:
-        guard_line = db.get(BuyPlanLine, body.buy_plan_line_id)
-        if guard_line is not None and guard_line.payment_method == PaymentMethod.COD.value:
-            raise HTTPException(
-                status_code=400,
-                detail="This PO is COD — payment happens on delivery, so there's nothing to pay in advance.",
-            )
-    try:
-        prepayment, request = create_prepayment(
-            db,
-            buy_plan_id=body.buy_plan_id,
-            buy_plan_line_id=body.buy_plan_line_id,
-            vendor_card_id=body.vendor_card_id,
-            payment_method=body.payment_method,
-            total_incl_fees=body.total_incl_fees,
-            test_report_sent=body.test_report_sent,
-            buyer_remarks=body.buyer_remarks,
-            created_by=current_user,
-            vendor_name=body.vendor_name,
-            currency=body.currency,
-        )
-        db.commit()
-    except NoEligibleApproverError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    return {
-        "prepayment_id": prepayment.id,
-        "approval_request_id": request.id,
-    }
-
-
-# ── HTMX request entry point ────────────────────────────────────────────────
 
 
 def _prepayment_toast(response: HTMLResponse, message: str, kind: str = "success") -> None:

--- a/app/schemas/crm.py
+++ b/app/schemas/crm.py
@@ -314,15 +314,6 @@ class QuoteCreate(BaseModel):
     line_items: list[QuoteLineItem] = []
 
 
-class QuoteUpdate(BaseModel):
-    line_items: list[QuoteLineItem] | None = None
-    payment_terms: str | None = None
-    shipping_terms: str | None = None
-    notes: str | None = None
-    valid_until: str | None = None
-    validity_days: int | None = None
-
-
 class QuoteResult(BaseModel):
     result: Literal["won", "lost"]
     reason: str | None = None

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -273,56 +273,6 @@ def get_excess_list(db: Session, list_id: int) -> ExcessList:
 # ---------------------------------------------------------------------------
 
 
-def import_line_items(db: Session, list_id: int, rows: list[dict]) -> dict:
-    """Import line items from parsed CSV/Excel rows into an excess list.
-
-    Flexible header detection maps common column names to canonical fields. Skips rows
-    with blank part_number or invalid quantity.
-
-    Returns {imported: int, skipped: int, errors: list[str]}.
-    """
-    excess_list = get_excess_list(db, list_id)
-
-    imported = 0
-    skipped = 0
-    errors: list[str] = []
-
-    for i, raw_row in enumerate(rows, start=1):
-        fields, error_reason = _parse_import_row(raw_row)
-        if fields is None:
-            skipped += 1
-            errors.append(f"Row {i}: {error_reason} — skipped")
-            continue
-
-        part_number = fields["part_number"]
-        item = ExcessLineItem(
-            excess_list_id=list_id,
-            part_number=part_number,
-            normalized_part_number=normalize_mpn_key(part_number) or None,
-            manufacturer=fields["manufacturer"],
-            quantity=fields["quantity"],
-            date_code=fields["date_code"],
-            condition=fields["condition"],
-            asking_price=fields["asking_price"],
-        )
-        db.add(item)
-        _resolve_line_material_card(db, item)
-        imported += 1
-
-    # Update total_line_items counter
-    if imported > 0:
-        excess_list.total_line_items = (excess_list.total_line_items or 0) + imported
-        _safe_commit(db, entity="excess line items")
-
-    logger.info(
-        "Imported {} line items into ExcessList id={} (skipped={})",
-        imported,
-        list_id,
-        skipped,
-    )
-    return {"imported": imported, "skipped": skipped, "errors": errors}
-
-
 def preview_import(rows: list[dict]) -> dict:
     """Parse rows and return a preview with validation results.
 

--- a/tests/fixtures/excess_import.py
+++ b/tests/fixtures/excess_import.py
@@ -1,0 +1,72 @@
+"""excess_import.py — test-only seeding helper for excess-list line items.
+
+The old ``excess_service.import_line_items`` was the unguarded legacy twin of the
+live ``preview_import``/``confirm_import`` path (no route reached it; QC item #33).
+It moved here because ~15 tests use it to seed DRAFT lists directly at the service
+layer without the preview round-trip.
+
+Called by: tests (fixture-style seeding)
+Depends on: app.services.excess_service internals (_parse_import_row et al.)
+"""
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.models.excess import ExcessLineItem
+from app.services.excess_service import (
+    _parse_import_row,
+    _resolve_line_material_card,
+    _safe_commit,
+    get_excess_list,
+)
+from app.utils.normalization import normalize_mpn_key
+
+
+def import_line_items(db: Session, list_id: int, rows: list[dict]) -> dict:
+    """Import line items from parsed CSV/Excel rows into an excess list.
+
+    Flexible header detection maps common column names to canonical fields. Skips rows
+    with blank part_number or invalid quantity.
+
+    Returns {imported: int, skipped: int, errors: list[str]}.
+    """
+    excess_list = get_excess_list(db, list_id)
+
+    imported = 0
+    skipped = 0
+    errors: list[str] = []
+
+    for i, raw_row in enumerate(rows, start=1):
+        fields, error_reason = _parse_import_row(raw_row)
+        if fields is None:
+            skipped += 1
+            errors.append(f"Row {i}: {error_reason} — skipped")
+            continue
+
+        part_number = fields["part_number"]
+        item = ExcessLineItem(
+            excess_list_id=list_id,
+            part_number=part_number,
+            normalized_part_number=normalize_mpn_key(part_number) or None,
+            manufacturer=fields["manufacturer"],
+            quantity=fields["quantity"],
+            date_code=fields["date_code"],
+            condition=fields["condition"],
+            asking_price=fields["asking_price"],
+        )
+        db.add(item)
+        _resolve_line_material_card(db, item)
+        imported += 1
+
+    # Update total_line_items counter
+    if imported > 0:
+        excess_list.total_line_items = (excess_list.total_line_items or 0) + imported
+        _safe_commit(db, entity="excess line items")
+
+    logger.info(
+        "Imported {} line items into ExcessList id={} (skipped={})",
+        imported,
+        list_id,
+        skipped,
+    )
+    return {"imported": imported, "skipped": skipped, "errors": errors}

--- a/tests/test_authz_app_routers_crm_quotes.py
+++ b/tests/test_authz_app_routers_crm_quotes.py
@@ -69,12 +69,6 @@ def test_create_quote_blocks_non_owner_sales(client, db_session, test_requisitio
     assert resp.status_code == 404
 
 
-def test_update_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
-    _make_sales(test_user, db_session)
-    resp = client.put(f"/api/quotes/{other_owned_quote.id}", json={"notes": "hacked"})
-    assert resp.status_code == 404
-
-
 def test_delete_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
     _make_sales(test_user, db_session)
     resp = client.delete(f"/api/quotes/{other_owned_quote.id}")
@@ -99,12 +93,6 @@ def test_quote_result_blocks_non_owner_sales(client, db_session, test_user, othe
     assert resp.status_code == 404
 
 
-def test_revise_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
-    _make_sales(test_user, db_session)
-    resp = client.post(f"/api/quotes/{other_owned_quote.id}/revise")
-    assert resp.status_code == 404
-
-
 def test_reopen_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
     _make_sales(test_user, db_session)
     resp = client.post(f"/api/quotes/{other_owned_quote.id}/reopen", json={"revise": False})
@@ -114,7 +102,9 @@ def test_reopen_quote_blocks_non_owner_sales(client, db_session, test_user, othe
 # ── Buyer happy path stays unchanged (owner / unrestricted role allowed) ─
 
 
-def test_update_quote_allows_buyer_owner(client, other_owned_quote):
-    # test_user is a buyer (unrestricted) by default — must NOT be blocked.
-    resp = client.put(f"/api/quotes/{other_owned_quote.id}", json={"notes": "ok"})
+def test_delete_quote_allows_buyer_owner(client, other_owned_quote):
+    # test_user is a buyer (unrestricted) by default — must NOT be blocked. (Was the
+    # PUT update route until Tier D deleted it; DELETE pins the same
+    # get_quote_for_user gate's allow side.)
+    resp = client.delete(f"/api/quotes/{other_owned_quote.id}")
     assert resp.status_code == 200

--- a/tests/test_authz_app_routers_crm_quotes.py
+++ b/tests/test_authz_app_routers_crm_quotes.py
@@ -102,9 +102,12 @@ def test_reopen_quote_blocks_non_owner_sales(client, db_session, test_user, othe
 # ── Buyer happy path stays unchanged (owner / unrestricted role allowed) ─
 
 
-def test_delete_quote_allows_buyer_owner(client, other_owned_quote):
+def test_delete_quote_allows_buyer_owner(client, db_session, other_owned_quote):
     # test_user is a buyer (unrestricted) by default — must NOT be blocked. (Was the
     # PUT update route until Tier D deleted it; DELETE pins the same
     # get_quote_for_user gate's allow side.)
-    resp = client.delete(f"/api/quotes/{other_owned_quote.id}")
+    quote_id = other_owned_quote.id
+    resp = client.delete(f"/api/quotes/{quote_id}")
     assert resp.status_code == 200
+    # The allow actually took effect: the quote is gone.
+    assert db_session.get(Quote, quote_id) is None

--- a/tests/test_authz_hardening.py
+++ b/tests/test_authz_hardening.py
@@ -323,11 +323,14 @@ def _buy_plan(db_session, owner_id):
 
 
 def test_g5_prepayment_blocks_restricted_non_owner_sales(client, db_session, test_user, admin_user):
+    # The legacy JSON POST /v2/prepayments was deleted (Tier D #11) — the ownership
+    # gate is pinned on the surviving HTMX create route instead. The nonexistent
+    # line id is fine: get_buyplan_for_user 404s BEFORE line validation.
     bp = _buy_plan(db_session, admin_user.id)  # foreign buy plan
     _make_sales(test_user, db_session)
     resp = client.post(
-        "/v2/prepayments",
-        json={"buy_plan_id": bp.id, "total_incl_fees": "100.00"},
+        "/v2/partials/prepayments",
+        data={"buy_plan_id": bp.id, "buy_plan_line_id": 999999, "total_incl_fees": "100.00"},
     )
     assert resp.status_code == 404
     # No prepayment attached to the foreign plan
@@ -339,11 +342,12 @@ def test_g5_prepayment_blocks_restricted_non_owner_sales(client, db_session, tes
 def test_g5_prepayment_allows_buyer_owner(client, db_session, test_user):
     bp = _buy_plan(db_session, test_user.id)  # test_user (buyer) owns the requisition
     resp = client.post(
-        "/v2/prepayments",
-        json={"buy_plan_id": bp.id, "total_incl_fees": "100.00"},
+        "/v2/partials/prepayments",
+        data={"buy_plan_id": bp.id, "buy_plan_line_id": 999999, "total_incl_fees": "100.00"},
     )
-    # Past the ownership gate. Routing may raise NoEligibleApprover (no approvers seeded);
-    # the security boundary is simply that it is NOT a 404 buy-plan-ownership rejection.
+    # Past the ownership gate. Line validation / approver routing may still reject
+    # (rendered as an error toast, 200); the security boundary is simply that it is
+    # NOT a 404 buy-plan-ownership rejection.
     assert resp.status_code != 404
 
 

--- a/tests/test_company_merge_service.py
+++ b/tests/test_company_merge_service.py
@@ -10,7 +10,8 @@ from app.models import Company, CustomerSite, User
 from app.models.sourcing import Requisition, Sighting
 from app.services.company_merge_service import delete_companies, merge_companies
 from app.services.excess_mirror import _virtual_req_name, publish_list
-from app.services.excess_service import create_excess_list, import_line_items
+from app.services.excess_service import create_excess_list
+from tests.fixtures.excess_import import import_line_items
 
 
 def _make_pair(db_session, keep_kwargs, remove_kwargs):

--- a/tests/test_excess_crud.py
+++ b/tests/test_excess_crud.py
@@ -17,10 +17,10 @@ from app.services.excess_service import (
     confirm_import,
     create_excess_list,
     get_excess_list,
-    import_line_items,
     preview_import,
 )
 from tests.conftest import engine
+from tests.fixtures.excess_import import import_line_items
 
 _ = engine  # Ensure test DB tables are created
 

--- a/tests/test_prepayment.py
+++ b/tests/test_prepayment.py
@@ -263,40 +263,6 @@ def test_create_prepayment_2500_excludes_capped_approver(db_session: Session, te
 # ── Route tests ───────────────────────────────────────────────────────────────
 
 
-def test_post_prepayments_returns_200_with_request_id(db_session: Session, client, test_user: User):
-    """POST /v2/prepayments → 200 + JSON with approval_request_id."""
-    _make_approver(
-        db_session,
-        email="approver@trioscs.com",
-        name="Approver",
-        azure_id="az-approver-route",
-        limit=None,
-    )
-    db_session.commit()
-
-    buy_plan = _make_buy_plan(db_session, test_user)
-    line = _make_po_line(db_session, buy_plan)
-    db_session.commit()
-
-    resp = client.post(
-        "/v2/prepayments",
-        json={
-            "buy_plan_id": buy_plan.id,
-            "buy_plan_line_id": line.id,
-            "vendor_card_id": None,
-            "payment_method": PaymentMethod.WIRE,
-            "total_incl_fees": "500.00",
-            "test_report_sent": False,
-            "buyer_remarks": "Test route",
-        },
-    )
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert "approval_request_id" in data
-    assert isinstance(data["approval_request_id"], int)
-    assert data["approval_request_id"] > 0
-
-
 def test_prepayment_state_for_lines_returns_batch_states(db_session: Session, test_user: User):
     """prepayment_state_for_lines maps each line to its Prepayment.status lifecycle in ONE
     query: requested → 'requested', approved → 'approved', paid → 'paid'; a VOID prepayment is
@@ -335,19 +301,3 @@ def test_prepayment_state_for_lines_returns_batch_states(db_session: Session, te
     state = prepayment_state_for_lines(db_session, [line_req.id, line_app.id, line_paid.id, line_void.id, line_none.id])
     assert state == {line_req.id: "requested", line_app.id: "approved", line_paid.id: "paid"}
     assert prepayment_state_for_lines(db_session, []) == {}
-
-
-def test_post_prepayments_unauth_returns_401(db_session: Session, unauthenticated_client):
-    """POST /v2/prepayments without auth → 401."""
-    resp = unauthenticated_client.post(
-        "/v2/prepayments",
-        json={
-            "buy_plan_id": 1,
-            "vendor_card_id": None,
-            "payment_method": PaymentMethod.WIRE,
-            "total_incl_fees": "100.00",
-            "test_report_sent": False,
-            "buyer_remarks": None,
-        },
-    )
-    assert resp.status_code == 401

--- a/tests/test_prepayment_workspace.py
+++ b/tests/test_prepayment_workspace.py
@@ -166,20 +166,6 @@ def test_cod_method_value_rejected_htmx(hub_client: TestClient, db_session: Sess
     assert db_session.query(Prepayment).filter(Prepayment.buy_plan_line_id == line.id).count() == 0
 
 
-def test_cod_line_cannot_request_prepayment_json(hub_client: TestClient, db_session: Session, test_user: User):
-    req, q, rq = _req_quote(db_session, test_user)
-    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
-    line = _pending_verify_line(db_session, bp, rq, test_user)
-    line.payment_method = PaymentMethod.COD.value
-    db_session.commit()
-
-    r = hub_client.post(
-        "/v2/prepayments",
-        json={"buy_plan_id": bp.id, "buy_plan_line_id": line.id, "total_incl_fees": "100.00"},
-    )
-    assert r.status_code == 400
-
-
 # ── Pane rendering ───────────────────────────────────────────────────────
 
 

--- a/tests/test_resell_draft_edit.py
+++ b/tests/test_resell_draft_edit.py
@@ -27,7 +27,8 @@ from app.models import Company, User
 from app.models.excess import ExcessLineItem, ExcessList
 from app.models.intelligence import MaterialCard
 from app.services import excess_service
-from app.services.excess_service import create_excess_list, import_line_items
+from app.services.excess_service import create_excess_list
+from tests.fixtures.excess_import import import_line_items
 
 # ── Fixtures ─────────────────────────────────────────────────────────
 

--- a/tests/test_resell_list_lifecycle.py
+++ b/tests/test_resell_list_lifecycle.py
@@ -39,7 +39,8 @@ from app.models.excess import ExcessLineItem, ExcessList, ExcessOffer, ExcessOff
 from app.models.sourcing import Sighting
 from app.services import excess_service
 from app.services.excess_mirror import publish_list
-from app.services.excess_service import create_excess_list, import_line_items
+from app.services.excess_service import create_excess_list
+from tests.fixtures.excess_import import import_line_items
 
 # ── Fixtures / helpers ───────────────────────────────────────────────
 

--- a/tests/test_resell_mirror.py
+++ b/tests/test_resell_mirror.py
@@ -45,9 +45,10 @@ from app.services.excess_mirror import (
     sync_list_mirror,
     teardown_list_mirror,
 )
-from app.services.excess_service import create_excess_list, import_line_items
+from app.services.excess_service import create_excess_list
 from app.utils.normalization import normalize_mpn_key
 from tests.conftest import engine
+from tests.fixtures.excess_import import import_line_items
 
 _ = engine  # Ensure test DB tables are created
 

--- a/tests/test_resell_offers.py
+++ b/tests/test_resell_offers.py
@@ -37,11 +37,11 @@ from app.routers.resell import _award_response_context, _offers_context, _outrea
 from app.services.excess_service import (
     confirm_import,
     create_excess_list,
-    import_line_items,
     submit_offer,
 )
 from app.utils.normalization import normalize_mpn_key
 from tests.conftest import engine
+from tests.fixtures.excess_import import import_line_items
 
 _ = engine  # Ensure test DB tables are created
 

--- a/tests/test_resell_posting_window.py
+++ b/tests/test_resell_posting_window.py
@@ -32,8 +32,9 @@ from app.models import Company, User
 from app.models.excess import ExcessList
 from app.routers.resell import _close_at_display, _detail_context, _is_live, _list_cards
 from app.services.excess_mirror import publish_list
-from app.services.excess_service import create_excess_list, import_line_items
+from app.services.excess_service import create_excess_list
 from tests.conftest import engine
+from tests.fixtures.excess_import import import_line_items
 
 _ = engine  # Ensure test DB tables are created
 

--- a/tests/test_resell_rollup.py
+++ b/tests/test_resell_rollup.py
@@ -21,12 +21,12 @@ from app.models import Company, User
 from app.models.excess import ExcessLineItem, ExcessList
 from app.services.excess_service import (
     create_excess_list,
-    import_line_items,
     recompute_line_rollup,
     submit_offer,
     withdraw_offer,
 )
 from tests.conftest import engine
+from tests.fixtures.excess_import import import_line_items
 
 _ = engine  # Ensure test DB tables are created
 

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -1448,70 +1448,6 @@ class TestQuotesAdditional:
         assert "quote_number" in data
         assert len(data["line_items"]) >= 1
 
-    def test_update_quote(self, client, db_session, test_requisition, test_customer_site, test_user):
-        q = Quote(
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
-            quote_number="Q-2026-UPD1",
-            status="draft",
-            line_items=[{"mpn": "LM317T", "qty": 100, "sell_price": 5.00, "cost_price": 3.00}],
-            subtotal=500.0,
-            total_cost=300.0,
-            total_margin_pct=40.0,
-            created_by_id=test_user.id,
-            created_at=datetime.now(UTC),
-        )
-        db_session.add(q)
-        db_session.commit()
-
-        resp = client.put(
-            f"/api/quotes/{q.id}",
-            json={"payment_terms": "Net 60"},
-        )
-        assert resp.status_code == 200
-
-    def test_update_quote_line_items(self, client, db_session, test_requisition, test_customer_site, test_user):
-        """Updating line_items recalculates totals."""
-        q = Quote(
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
-            quote_number="Q-2026-UPD2",
-            status="draft",
-            line_items=[],
-            subtotal=0,
-            total_cost=0,
-            total_margin_pct=0,
-            created_by_id=test_user.id,
-            created_at=datetime.now(UTC),
-        )
-        db_session.add(q)
-        db_session.commit()
-
-        resp = client.put(
-            f"/api/quotes/{q.id}",
-            json={
-                "line_items": [
-                    {"mpn": "LM317T", "qty": 200, "sell_price": 10.00, "cost_price": 7.00},
-                ],
-            },
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["subtotal"] == 2000.0
-        assert data["total_cost"] == 1400.0
-
-    def test_update_quote_not_found(self, client):
-        resp = client.put("/api/quotes/99999", json={"notes": "x"})
-        assert resp.status_code == 404
-
-    def test_update_quote_not_draft(self, client, db_session, test_quote):
-        """Non-draft quotes cannot be edited."""
-        resp = client.put(
-            f"/api/quotes/{test_quote.id}",
-            json={"notes": "nope"},
-        )
-        assert resp.status_code == 400
-
     def test_delete_quote_not_found(self, client):
         resp = client.delete("/api/quotes/99999")
         assert resp.status_code == 404
@@ -1700,17 +1636,6 @@ class TestQuotesAdditional:
 
     def test_quote_result_not_found(self, client):
         resp = client.post("/api/quotes/99999/result", json={"result": "won"})
-        assert resp.status_code == 404
-
-    def test_revise_quote(self, client, db_session, test_quote):
-        resp = client.post(f"/api/quotes/{test_quote.id}/revise")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["revision"] == 2
-        assert data["quote_number"] == "TEST-Q-2026-0001"
-
-    def test_revise_quote_not_found(self, client):
-        resp = client.post("/api/quotes/99999/revise")
         assert resp.status_code == 404
 
     def test_reopen_quote_without_revise(self, client, db_session, test_quote):
@@ -2721,7 +2646,9 @@ def test_quote_mutation_scope_enforced_for_sales(db_session, sales_user, test_qu
     app.dependency_overrides[require_user] = _override_user
     try:
         with TestClient(app) as c:
-            resp = c.put(f"/api/quotes/{test_quote.id}", json={"notes": "should fail"})
+            # PUT /api/quotes was deleted (Tier D) — pin the same get_quote_for_user
+            # scope gate on the surviving result route instead.
+            resp = c.post(f"/api/quotes/{test_quote.id}/result", json={"result": "won"})
     finally:
         for dep in [get_db, require_user]:
             app.dependency_overrides.pop(dep, None)

--- a/tests/test_schemas_crm.py
+++ b/tests/test_schemas_crm.py
@@ -18,7 +18,6 @@ from app.schemas.crm import (
     QuoteReopen,
     QuoteResult,
     QuoteSendOverride,
-    QuoteUpdate,
     SuggestedContactItem,
     SuggestedSiteContact,
 )
@@ -305,7 +304,7 @@ class TestQuoteLineItem:
         assert li.custom_field == "value"
 
 
-# ── QuoteCreate / QuoteUpdate ──────────────────────────────────────
+# ── QuoteCreate ────────────────────────────────────────────────────
 
 
 class TestQuoteCreate:
@@ -313,16 +312,6 @@ class TestQuoteCreate:
         q = QuoteCreate()
         assert q.offer_ids == []
         assert q.line_items == []
-
-
-class TestQuoteUpdate:
-    def test_all_none(self) -> None:
-        q = QuoteUpdate()
-        assert q.line_items is None
-        assert q.payment_terms is None
-
-
-# ── CustomerImportRow ──────────────────────────────────────────────
 
 
 class TestCustomerImportRow:

--- a/tests/test_sightings_mirror_exclusion.py
+++ b/tests/test_sightings_mirror_exclusion.py
@@ -24,8 +24,9 @@ from app.routers import sightings as sightings_router
 from app.routers.sightings import build_board_requirement_query
 from app.schemas.sightings import SightingsListParams
 from app.services.excess_mirror import ensure_virtual_requirement
-from app.services.excess_service import create_excess_list, import_line_items
+from app.services.excess_service import create_excess_list
 from tests.conftest import engine
+from tests.fixtures.excess_import import import_line_items
 
 _ = engine  # Ensure test DB tables are created
 


### PR DESCRIPTION
Owner decision 4: delete all three. Verified dead three ways — no frontend caller (UI uses the HTMX paths), no app-code caller, zero hits in 14 days of live access logs.

- **PUT /api/quotes/{id}** + **POST /api/quotes/{id}/revise** (crm/quotes.py) — the legacy JSON editor/revise pair that diverged from the HTMX path (QC M2). `QuoteUpdate` schema removed with them. The JSON reopen route survives; the scope pin moved to /result and the authz allow-side pin to DELETE.
- **POST /v2/prepayments** — the JSON create that never sent the accounting notice (QC #11); the HTMX create is the only live path and now carries the G5 ownership authz pins.
- **excess_service.import_line_items** — unguarded legacy twin of preview/confirm_import, unreachable by any route (QC #33); moved to tests/fixtures/excess_import.py for the ~15 tests that seed with it.

+107/−356. Full suite in worktree: 24,317 passed (sole failure was the revenue time bomb, fixed in #886).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf