### PR TITLE
fix(qc): buy-plan money math is Decimal end-to-end (money-math-float)

### DIFF
--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -14,6 +14,7 @@ Depends on: app.models, app.dependencies, app.database, app.services.approvals,
 
 import json
 from datetime import datetime
+from decimal import Decimal
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -83,13 +84,19 @@ def _parse_optional_int(raw: str | None) -> int | None:
         raise HTTPException(400, "Expected a whole number.") from e
 
 
-def _parse_optional_float(raw: str | None) -> float | None:
-    """Parse an optional decimal form field: blank → None; non-numeric → 400."""
+def _parse_optional_float(raw: str | None) -> Decimal | None:
+    """Parse an optional money form field: blank → None; non-numeric → 400.
+
+    Returns Decimal (QC money-math-float): these values flow into unit_sell/unit_cost
+    Numeric columns and the plan-financial math, which is Decimal end-to-end — parsing
+    to binary float here was the drift's entry point. Name kept so call sites don't
+    churn; it parses "a decimal number", now literally.
+    """
     if raw is None or str(raw).strip() == "":
         return None
     try:
-        return float(str(raw).strip())
-    except (TypeError, ValueError) as e:
+        return Decimal(str(raw).strip())
+    except (ArithmeticError, TypeError, ValueError) as e:
         raise HTTPException(400, "Expected a number.") from e
 
 

--- a/app/services/buyplan_workflow/buyplan_approval.py
+++ b/app/services/buyplan_workflow/buyplan_approval.py
@@ -16,6 +16,7 @@ Depends on: buyplan_scoring, buyplan_po (_line_amount), buyplan_reports
 """
 
 from datetime import UTC, datetime
+from decimal import ROUND_HALF_UP, Decimal
 
 from loguru import logger
 from sqlalchemy import select
@@ -39,6 +40,7 @@ from ...models.buy_plan import (
 from ..buyplan_scoring import assign_buyer, score_offer
 from .buyplan_po import _line_amount
 from .buyplan_reports import generate_case_report
+from .money import CENT, pct, to_money
 
 # ── Workflow: Submit ─────────────────────────────────────────────────
 
@@ -791,11 +793,13 @@ def _apply_line_edits(plan: BuyPlan, edits: list[dict], db: Session):
             if not offer:
                 raise ValueError(f"Offer {edit['offer_id']} not found")
 
-            unit_cost = float(offer.unit_price) if offer.unit_price else None
-            unit_sell = float(requirement.target_price) if requirement and requirement.target_price else None
+            # Decimal end-to-end (QC money-math-float): unit_price/target_price are
+            # Numeric columns — a float round-trip here re-introduces cent drift.
+            unit_cost = offer.unit_price if offer.unit_price else None
+            unit_sell = requirement.target_price if requirement and requirement.target_price else None
             margin_pct = None
             if unit_sell and unit_cost and unit_sell > 0:
-                margin_pct = round(((unit_sell - unit_cost) / unit_sell) * 100, 2)
+                margin_pct = pct(unit_sell - unit_cost, unit_sell)
 
             buyer, reason = assign_buyer(offer, offer.vendor_card, db)
             ai_score = score_offer(offer, requirement, offer.vendor_card) if requirement else None
@@ -830,11 +834,12 @@ def _apply_line_overrides(plan: BuyPlan, overrides: list[dict], db: Session):
             offer = db.get(Offer, ovr["offer_id"])
             if offer:
                 line.offer_id = offer.id
-                line.unit_cost = float(offer.unit_price) if offer.unit_price else None
-                if line.unit_sell and line.unit_cost and float(line.unit_sell) > 0:
-                    line.margin_pct = round(
-                        ((float(line.unit_sell) - float(line.unit_cost)) / float(line.unit_sell)) * 100, 2
-                    )
+                line.unit_cost = offer.unit_price if offer.unit_price else None
+                # to_money: unit_sell may still be an in-session float from a legacy
+                # writer — coerce exactly before Decimal arithmetic.
+                sell, cost = to_money(line.unit_sell), to_money(line.unit_cost)
+                if sell and cost and sell > 0:
+                    line.margin_pct = pct(sell - cost, sell)
 
         if ovr.get("quantity"):
             line.quantity = ovr["quantity"]
@@ -858,22 +863,24 @@ def _recalculate_financials(plan: BuyPlan):
     free-sample) reports ``0.0`` ("$0.00", a real fact) instead of ``None`` ("no data",
     which would be wrong — the data IS there, it's just zero).
     """
-    total_cost = 0.0
-    total_revenue = 0.0
+    total_cost = Decimal("0")
+    total_revenue = Decimal("0")
     has_cost = False
     has_revenue = False
     for line in plan.lines:
+        # to_money: a line freshly written this session may still carry a float from a
+        # legacy writer — coerce exactly (via str) before Decimal arithmetic.
         if line.unit_cost is not None and line.quantity:
-            total_cost += float(line.unit_cost) * line.quantity
+            total_cost += to_money(line.unit_cost) * line.quantity
             has_cost = True
         if line.unit_sell is not None and line.quantity:
-            total_revenue += float(line.unit_sell) * line.quantity
+            total_revenue += to_money(line.unit_sell) * line.quantity
             has_revenue = True
 
-    plan.total_cost = round(total_cost, 2) if has_cost else None
-    plan.total_revenue = round(total_revenue, 2) if has_revenue else None
+    plan.total_cost = total_cost.quantize(CENT, rounding=ROUND_HALF_UP) if has_cost else None
+    plan.total_revenue = total_revenue.quantize(CENT, rounding=ROUND_HALF_UP) if has_revenue else None
     if total_revenue > 0:
-        plan.total_margin_pct = round(((total_revenue - total_cost) / total_revenue) * 100, 2)
+        plan.total_margin_pct = pct(total_revenue - total_cost, total_revenue)
     else:
         plan.total_margin_pct = None
 

--- a/app/services/buyplan_workflow/buyplan_lines.py
+++ b/app/services/buyplan_workflow/buyplan_lines.py
@@ -31,6 +31,7 @@ from .buyplan_approval import (
     _recalculate_financials,
     check_completion,
 )
+from .money import pct, to_money
 
 # ── Workflow: Re-source (PO cancelled → open claim pool) ─────────────
 
@@ -376,10 +377,14 @@ def _ensure_can_edit_lines(user: User, plan: BuyPlan) -> None:
         raise PermissionError("You cannot edit this buy plan's lines in its current status.")
 
 
-def _line_margin_pct(unit_sell: float | None, unit_cost: float | None) -> float | None:
-    """Per-line margin % from sell/cost (None when sell is missing/zero)."""
-    if unit_sell and unit_cost and unit_sell > 0:
-        return round(((unit_sell - unit_cost) / unit_sell) * 100, 2)
+def _line_margin_pct(unit_sell, unit_cost):
+    """Per-line margin % from sell/cost (None when sell is missing/zero).
+
+    Decimal end-to-end (QC money-math-float); number-like legacy inputs coerced exactly.
+    """
+    sell, cost = to_money(unit_sell), to_money(unit_cost)
+    if sell and cost and sell > 0:
+        return pct(sell - cost, sell)
     return None
 
 
@@ -543,7 +548,7 @@ def _apply_line_edit(
             )
             edits.append(FieldEdit(field="vendor", old=old_vendor, new=offer.vendor_name or str(offer.id)))
             line.offer_id = offer.id
-            line.unit_cost = float(offer.unit_price) if offer.unit_price is not None else None
+            line.unit_cost = offer.unit_price if offer.unit_price is not None else None
             # Stale-score fix: an offer swap must re-score the line against the NEW
             # offer, same as a fresh add via _build_new_line — otherwise ai_score keeps
             # scoring the line against a vendor it no longer points at.
@@ -563,7 +568,7 @@ def _apply_line_edit(
             line.quantity = quantity_int
 
     if unit_sell is not _UNSET:
-        new_sell = float(unit_sell) if unit_sell is not None else None
+        new_sell = to_money(unit_sell)
         edits.extend(diff_fields(line, {"unit_sell": new_sell}))
         line.unit_sell = new_sell
 
@@ -587,17 +592,14 @@ def _apply_line_edit(
             line.estimated_ship_date = estimated_ship_date
 
     if unit_cost is not _UNSET and unit_cost is not None:
-        new_cost = float(unit_cost)
+        new_cost = to_money(unit_cost)
         if diff_fields(line, {"unit_cost": new_cost}):
             if not _manager_verify_override(actor, line):
                 raise ValueError("Only a manager can edit the unit cost at verify.")
             edits.extend(diff_fields(line, {"unit_cost": new_cost}))
             line.unit_cost = new_cost
 
-    line.margin_pct = _line_margin_pct(
-        float(line.unit_sell) if line.unit_sell is not None else None,
-        float(line.unit_cost) if line.unit_cost is not None else None,
-    )
+    line.margin_pct = _line_margin_pct(line.unit_sell, line.unit_cost)
     return edits
 
 
@@ -649,11 +651,11 @@ def _build_new_line(
         raise ValueError(f"Offer {offer_id} not found")
     _ensure_offer_attachable(offer, plan, requirement.id)
 
-    unit_cost = float(offer.unit_price) if offer.unit_price is not None else None
+    unit_cost = offer.unit_price if offer.unit_price is not None else None
     resolved_sell = (
-        float(unit_sell)
+        to_money(unit_sell)
         if unit_sell is not None
-        else (float(requirement.target_price) if requirement.target_price else None)
+        else (requirement.target_price if requirement.target_price else None)
     )
     buyer, reason = assign_buyer(offer, offer.vendor_card, db)
     return BuyPlanLine(

--- a/app/services/buyplan_workflow/buyplan_po.py
+++ b/app/services/buyplan_workflow/buyplan_po.py
@@ -11,6 +11,7 @@ Depends on: dependencies (can_approve_purchase_orders), buyplan_approval (lazy),
 """
 
 from datetime import UTC, datetime
+from decimal import Decimal
 
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -138,14 +139,16 @@ def mark_line_received(plan_id: int, line_id: int, user: User, db: Session) -> B
     return line
 
 
-def _line_amount(line: BuyPlanLine) -> float:
+def _line_amount(line: BuyPlanLine) -> Decimal:
     """Dollar amount of one line's PO (``unit_cost * quantity``).
 
     Mirrors ``_recalculate_financials``'s per-line cost math — the single grain for the
     per-PO dollar-limit check (``verify_po``, ``can_verify_po_line``) and the per-line
-    stall detector (``plan_needs_approver_reason``).
+    stall detector (``plan_needs_approver_reason``). Decimal end-to-end: unit_cost is a
+    Numeric column, and the approval limits it is compared against are Numeric too — a
+    float round-trip here is exactly the at-limit routing edge the QC finding flagged.
     """
-    return float(line.unit_cost or 0) * (line.quantity or 0)
+    return (line.unit_cost or Decimal("0")) * (line.quantity or 0)
 
 
 def _log_po_line_activity(

--- a/app/services/buyplan_workflow/money.py
+++ b/app/services/buyplan_workflow/money.py
@@ -1,0 +1,27 @@
+"""money.py — Decimal money helpers for the buy-plan workflow (QC money-math-float).
+
+Plan financials are Decimal end-to-end: the columns are Numeric and the approval
+limits they are compared against are Numeric — binary-float round-trips were where
+cent drift and the at-limit routing edge came from. ``to_money`` is the single
+coercion point for number-like inputs still arriving from legacy callers/tests
+(str() first, so a float like 0.1 coerces to Decimal("0.1"), not its binary noise).
+
+Called by: buyplan_approval, buyplan_lines (margin/total math)
+Depends on: stdlib decimal only
+"""
+
+from decimal import ROUND_HALF_UP, Decimal
+
+CENT = Decimal("0.01")
+
+
+def to_money(value) -> Decimal | None:
+    """None-safe coercion to Decimal (exact via str() for float/int/str inputs)."""
+    if value is None:
+        return None
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+def pct(numerator: Decimal, denominator: Decimal) -> Decimal:
+    """(numerator / denominator) * 100, quantized to 2 places, HALF_UP."""
+    return (numerator / denominator * 100).quantize(CENT, rounding=ROUND_HALF_UP)

--- a/tests/test_buyplan_money_decimal.py
+++ b/tests/test_buyplan_money_decimal.py
@@ -1,0 +1,84 @@
+"""test_buyplan_money_decimal.py — plan financials are Decimal-exact (QC money-math-
+float).
+
+Pins the two failure modes of the old binary-float math:
+1. Cent drift: sums like 3 × $0.10 must be exactly $0.30 (float gives 0.30000000000000004
+   pre-round, and larger plans accumulate real cent errors).
+2. The at-limit routing edge: a line amount exactly equal to an approver's limit must
+   compare as equal (float 16.1 * 3 = 48.30000000000000426... > Decimal("48.30") would
+   wrongly exclude an at-limit approver).
+
+Called by: pytest
+Depends on: buyplan_workflow.money, buyplan_workflow.buyplan_approval, buyplan_po
+"""
+
+from decimal import Decimal
+
+from app.services.buyplan_workflow.buyplan_po import _line_amount
+from app.services.buyplan_workflow.money import pct, to_money
+
+
+class _Line:
+    def __init__(self, unit_cost, unit_sell, quantity):
+        self.unit_cost = unit_cost
+        self.unit_sell = unit_sell
+        self.quantity = quantity
+
+
+class _Plan:
+    total_cost = None
+    total_revenue = None
+    total_margin_pct = None
+
+    def __init__(self, lines):
+        self.lines = lines
+
+
+class TestRecalculateFinancials:
+    def test_cent_exact_sum(self):
+        from app.services.buyplan_workflow.buyplan_approval import _recalculate_financials
+
+        plan = _Plan([_Line(Decimal("0.10"), Decimal("0.30"), 3)])
+        _recalculate_financials(plan)
+        assert plan.total_cost == Decimal("0.30")
+        assert plan.total_revenue == Decimal("0.90")
+        assert plan.total_margin_pct == Decimal("66.67")
+
+    def test_float_written_lines_coerced_exactly(self):
+        """Legacy writers may leave in-session floats on lines — totals stay exact."""
+        from app.services.buyplan_workflow.buyplan_approval import _recalculate_financials
+
+        plan = _Plan([_Line(0.10, 0.30, 3), _Line(Decimal("16.10"), None, 3)])
+        _recalculate_financials(plan)
+        assert plan.total_cost == Decimal("48.60")  # 0.30 + 48.30, no binary noise
+        assert plan.total_revenue == Decimal("0.90")
+
+    def test_zero_priced_lines_report_zero_not_none(self):
+        from app.services.buyplan_workflow.buyplan_approval import _recalculate_financials
+
+        plan = _Plan([_Line(Decimal("0"), Decimal("0"), 5)])
+        _recalculate_financials(plan)
+        assert plan.total_cost == Decimal("0.00")
+        assert plan.total_revenue == Decimal("0.00")
+        assert plan.total_margin_pct is None  # revenue 0 → margin undefined
+
+
+class TestLineAmountAtLimit:
+    def test_line_amount_equals_limit_exactly(self):
+        """16.10 × 3 must equal a $48.30 approval limit — the float version yields
+        48.30000000000000426 and wrongly excludes the at-limit approver."""
+        line = _Line(Decimal("16.10"), None, 3)
+        amount = _line_amount(line)
+        assert amount == Decimal("48.30")
+        assert amount <= Decimal("48.30")  # the routing comparison
+
+
+class TestMoneyHelpers:
+    def test_to_money_exact_from_float(self):
+        assert to_money(0.1) == Decimal("0.1")
+        assert to_money(None) is None
+        assert to_money(Decimal("5.55")) == Decimal("5.55")
+
+    def test_pct_quantizes_half_up(self):
+        assert pct(Decimal("1"), Decimal("3")) == Decimal("33.33")
+        assert pct(Decimal("0.005"), Decimal("1")) == Decimal("0.50")


### PR DESCRIPTION
Owner decision 5a. The columns are Numeric and the approval limits are Numeric — every `float()` round-trip between them was where cent drift and the at-limit routing edge came from.

New `buyplan_workflow/money.py` (`CENT`, `to_money` exact str-coercion, `pct` HALF_UP quantize). Converted: `_recalculate_financials`, both line-margin sites, the line writers (`buyplan_lines`), `_line_amount` (the per-PO limit grain), and the HTMX form parser (`_parse_optional_float` now returns Decimal). `to_money` coercion at the math boundaries keeps legacy in-session float writers safe.

Pins: cent-exact sums (3×$0.10 == $0.30), float-written lines coerced exactly, **16.10×3 == a $48.30 approval limit** (the float version yields 48.30000000000000426 and wrongly excludes the at-limit approver), zero-priced plans still report $0.00 not None. Full suite: 24,335 passed.

Note on live numbers: totals requantize on each plan's next recalculation (line edit/approval) — expected shifts are sub-cent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf