### PR TITLE
feat(proactive): one-tap Clone-to-Active from a 'Looking again' outreach outcome

### DIFF
--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -14,7 +14,7 @@ import asyncio
 import html as html_mod
 import json
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from loguru import logger
 from sqlalchemy import func as sqlfunc
@@ -866,9 +866,54 @@ async def proactive_line_tracking(
         "contacted": line.contacted,
         "outcome": line.outcome,
         "sales_order_number": line.sales_order_number,
+        "produced_requisition_id": line.produced_requisition_id,
         "can_edit": can_manage or line.salesperson_id == user.id,
     }
     return template_response("htmx/partials/proactive/_outreach_line_cells.html", ctx)
+
+
+@router.post("/v2/partials/proactive/lines/{line_id}/clone", response_class=HTMLResponse)
+async def proactive_line_clone(
+    request: Request,
+    line_id: int,
+    background_tasks: BackgroundTasks,
+    user: User = Depends(require_access(AccessKey.PROACTIVE)),
+    db: Session = Depends(get_db),
+):
+    """One-tap "Looking again" clone: copy the line's source part into a fresh OPEN
+    requisition (clone_parts_to_active), stamp produced_requisition_id, fire a
+    background sightings search on the clone, and re-render the row cells."""
+    from ...dependencies import is_manager_or_admin
+    from ...routers.sightings import run_search_and_publish
+    from ...services.proactive_digest import clone_line_to_active
+
+    can_manage = is_manager_or_admin(user)
+    try:
+        line, new_req = clone_line_to_active(db, line_id, viewer=user, can_manage=can_manage)
+    except ValueError as e:
+        raise HTTPException(403 if "Not your" in str(e) else 400, str(e)) from e
+
+    new_requirement_ids = [r.id for r in new_req.requirements]
+    if new_requirement_ids:
+        background_tasks.add_task(run_search_and_publish, new_requirement_ids, user.id)
+
+    company = db.get(Company, line.company_id) if line.company_id else None
+    ctx = _base_ctx(request, user, "proactive")
+    ctx["line"] = {
+        "id": line.id,
+        "mpn": line.mpn,
+        "company_name": company.name if company else None,
+        "contacted": line.contacted,
+        "outcome": line.outcome,
+        "sales_order_number": line.sales_order_number,
+        "produced_requisition_id": line.produced_requisition_id,
+        "can_edit": can_manage or line.salesperson_id == user.id,
+    }
+    response = template_response("htmx/partials/proactive/_outreach_line_cells.html", ctx)
+    response.headers["HX-Trigger"] = json.dumps(
+        {"showToast": {"message": f"Part cloned → REQ-{new_req.id:03d} (search running)", "type": "success"}}
+    )
+    return response
 
 
 @router.post("/v2/partials/proactive/equivalence/verdict", response_class=HTMLResponse)

--- a/app/services/proactive_digest.py
+++ b/app/services/proactive_digest.py
@@ -42,6 +42,7 @@ from ..models import (
     ProactiveMatch,
     ProactiveOutreachLine,
     Requirement,
+    Requisition,
     User,
 )
 from .pricing_history import last_quote_for_part, last_win_for_part
@@ -411,6 +412,7 @@ def get_digests_for_view(db: Session, *, viewer: User, can_see_all: bool) -> lis
                         "contacted": line.contacted,
                         "outcome": line.outcome,
                         "sales_order_number": line.sales_order_number,
+                        "produced_requisition_id": line.produced_requisition_id,
                         "can_edit": can_see_all or line.salesperson_id == viewer.id,
                     }
                     for line in lines
@@ -480,6 +482,62 @@ def update_line_tracking(
             _log("sales_order_number", line.sales_order_number, sales_order_number)
             line.sales_order_number = sales_order_number
     return line
+
+
+def clone_line_to_active(
+    db: Session,
+    line_id: int,
+    *,
+    viewer: User,
+    can_manage: bool,
+) -> tuple[ProactiveOutreachLine, Requisition]:
+    """One-tap clone for a "Looking again" outcome: copy the line's source part into a
+    fresh OPEN requisition via ``clone_parts_to_active`` and stamp
+    ``produced_requisition_id`` on the line.
+
+    Source-part resolution: the line's match → ``requirement_id`` when present;
+    otherwise (hotlist/back-order match, or the requirement FK was nulled) the newest
+    requirement for the same normalized MPN on one of this company's requisitions.
+    Same edit rights as tracking (line's salesperson or manager/admin). Commits (the
+    clone service commits the new requisition; the produced-id stamp commits after).
+    Raises ValueError on missing/unsent/foreign line, an already-recorded clone, or
+    no resolvable source part.
+    """
+    from ..utils.normalization import normalize_mpn_key
+    from .requisition_service import clone_parts_to_active
+
+    line = db.get(ProactiveOutreachLine, line_id)
+    if not line:
+        raise ValueError("Line not found")
+    if not line.sent_at:
+        raise ValueError("Line not sent yet — tracking starts after send")
+    if not can_manage and line.salesperson_id != viewer.id:
+        raise ValueError("Not your line")
+    if line.produced_requisition_id:
+        raise ValueError("Already cloned — this line produced a requisition.")
+
+    part: Requirement | None = None
+    match = db.get(ProactiveMatch, line.match_id) if line.match_id else None
+    if match is not None and match.requirement_id is not None:
+        part = db.get(Requirement, match.requirement_id)
+    if part is None and line.company_id:
+        norm = normalize_mpn_key(line.mpn)
+        if norm:
+            part = db.scalars(
+                select(Requirement)
+                .join(Requisition, Requirement.requisition_id == Requisition.id)
+                .where(Requirement.normalized_mpn == norm, Requisition.company_id == line.company_id)
+                .order_by(Requirement.id.desc())
+                .limit(1)
+            ).first()
+    if part is None:
+        raise ValueError("No source part on file for this line — clone it from the parts workspace instead.")
+
+    new_req = clone_parts_to_active(db, [part], viewer)[0]
+    line.produced_requisition_id = new_req.id
+    db.commit()
+    logger.info("Looking-again clone by user {}: line {} → requisition {}", viewer.id, line.id, new_req.id)
+    return line, new_req
 
 
 # ── Weekly outreach summary (Step 8) ─────────────────────────────────────

--- a/app/templates/htmx/partials/proactive/_outreach_line_cells.html
+++ b/app/templates/htmx/partials/proactive/_outreach_line_cells.html
@@ -32,6 +32,24 @@
     <option value="no_longer_needed" {{ 'selected' if line.outcome == 'no_longer_needed' }}>No longer needed</option>
     <option value="no_response" {{ 'selected' if line.outcome == 'no_response' }}>No response</option>
   </select>
+  {# "Looking again" one-tap clone: copies the source part into a fresh OPEN
+     requisition (clone_parts_to_active) and fires a sightings search. Once done,
+     the produced REQ replaces the button (produced_requisition_id). #}
+  {% if line.produced_requisition_id %}
+    <span class="block mt-1 text-[11px] text-emerald-700 font-semibold">
+      Cloned &rarr; REQ-{{ '%03d'|format(line.produced_requisition_id) }}
+    </span>
+  {% elif line.outcome == 'looking_again' and line.can_edit %}
+    <button type="button"
+            hx-post="/v2/partials/proactive/lines/{{ line.id }}/clone"
+            hx-target="#outreach-line-{{ line.id }}"
+            hx-swap="innerHTML"
+            hx-disabled-elt="this"
+            title="Customer needs this part again — copy it into a fresh open requisition and start a search"
+            class="mt-1 px-2 py-0.5 text-[11px] font-semibold bg-accent-500 text-white rounded hover:bg-accent-600">
+      Clone to Active
+    </button>
+  {% endif %}
 </td>
 <td>
   <input type="text" value="{{ line.sales_order_number or '' }}" maxlength="100"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2760,6 +2760,19 @@ send.) A weekly ACTIVE re-search job exists but ships **flag-OFF**
 `hotlist_research_max_parts`, ICS/NC/TBF via the workers' 7-day dedup) — owner
 enables it later; see the master backlog.
 
+**"Looking again" → one-tap clone:** a sent digest line whose tracked outcome is
+`looking_again` renders a **Clone to Active** button in its outcome cell
+(`_outreach_line_cells.html`). `POST /v2/partials/proactive/lines/{id}/clone`
+(`proactive_line_clone`) calls `proactive_digest.clone_line_to_active` — same edit
+rights as tracking (line's salesperson or manager/admin) — which resolves the source
+part (the match's `requirement_id`, else the newest requirement for the same
+normalized MPN on one of the company's requisitions), copies it via
+`clone_parts_to_active` (§ 1c: fresh OPEN requisition, `cloned_from_id`
+provenance, reference offers, buyer task), stamps
+`ProactiveOutreachLine.produced_requisition_id`, and fires `run_search_and_publish`
+as a background task. The row re-renders with "Cloned → REQ-xxx" in place of the
+button (idempotent — a second tap is refused on the stamped id).
+
 ### Unified AI Email Drafting (RFQ rephrase · vendor reply · follow-up)
 
 ```

--- a/tests/test_looking_again_clone.py
+++ b/tests/test_looking_again_clone.py
@@ -1,0 +1,128 @@
+"""test_looking_again_clone.py — one-tap Clone-to-Active from a "Looking again" outcome.
+
+The proactive outreach tracking records looking_again but used to create nothing;
+clone_line_to_active copies the line's source part into a fresh OPEN requisition via
+clone_parts_to_active and stamps produced_requisition_id. Covers: source resolution
+via the match's requirement, the (normalized_mpn, company) fallback, no-source and
+already-cloned refusals, the ownership gate, and the row-cells rendering states
+(button on looking_again, REQ label once produced).
+
+Called by: pytest
+Depends on: conftest (db_session, client, test_user), proactive_digest service
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.constants import SourcingStatus
+from app.models import Company, Offer, ProactiveDigest, ProactiveMatch, ProactiveOutreachLine, Requirement, Requisition
+from app.services.proactive_digest import clone_line_to_active
+
+
+def _seed(db, user, *, with_match_requirement=True, mpn="LM317T"):
+    co = Company(name="LA Clone Co", is_active=True)
+    db.add(co)
+    db.flush()
+    req = Requisition(name="LA src req", customer_name=co.name, status="open", company_id=co.id, created_by=user.id)
+    db.add(req)
+    db.flush()
+    part = Requirement(
+        requisition_id=req.id,
+        primary_mpn=mpn,
+        normalized_mpn=mpn.lower(),
+        sourcing_status=SourcingStatus.OPEN,
+        target_qty=10,
+    )
+    db.add(part)
+    db.flush()
+    offer = Offer(requisition_id=req.id, mpn=mpn, vendor_name="Arrow")
+    db.add(offer)
+    db.flush()
+    match = ProactiveMatch(
+        offer_id=offer.id,
+        requirement_id=part.id if with_match_requirement else None,
+        mpn=mpn.lower(),
+        company_id=co.id,
+        salesperson_id=user.id,
+        status="sent",
+    )
+    db.add(match)
+    digest = ProactiveDigest(salesperson_id=user.id, status="sent", sent_at=datetime.now(UTC))
+    db.add(digest)
+    db.flush()
+    line = ProactiveOutreachLine(
+        digest_id=digest.id,
+        match_id=match.id,
+        mpn=mpn,
+        company_id=co.id,
+        salesperson_id=user.id,
+        sent_at=datetime.now(UTC),
+        outcome="looking_again",
+    )
+    db.add(line)
+    db.commit()
+    return co, part, line
+
+
+class TestCloneLineToActive:
+    def test_clones_via_match_requirement(self, db_session, test_user):
+        co, part, line = _seed(db_session, test_user)
+        line2, new_req = clone_line_to_active(db_session, line.id, viewer=test_user, can_manage=False)
+
+        assert line2.produced_requisition_id == new_req.id
+        assert new_req.status == "open"
+        clones = db_session.query(Requirement).filter(Requirement.cloned_from_id == part.id).all()
+        assert len(clones) == 1
+        assert clones[0].requisition_id == new_req.id
+
+    def test_fallback_resolves_by_mpn_and_company(self, db_session, test_user):
+        co, part, line = _seed(db_session, test_user, with_match_requirement=False)
+        line2, new_req = clone_line_to_active(db_session, line.id, viewer=test_user, can_manage=False)
+        assert db_session.query(Requirement).filter(Requirement.cloned_from_id == part.id).count() == 1
+        assert line2.produced_requisition_id == new_req.id
+
+    def test_no_source_part_refused(self, db_session, test_user):
+        co, part, line = _seed(db_session, test_user, with_match_requirement=False)
+        # Orphan the fallback too: different company on the line.
+        other = Company(name="Other Co", is_active=True)
+        db_session.add(other)
+        db_session.flush()
+        line.company_id = other.id
+        db_session.commit()
+        with pytest.raises(ValueError, match="No source part"):
+            clone_line_to_active(db_session, line.id, viewer=test_user, can_manage=False)
+
+    def test_already_cloned_refused(self, db_session, test_user):
+        co, part, line = _seed(db_session, test_user)
+        clone_line_to_active(db_session, line.id, viewer=test_user, can_manage=False)
+        with pytest.raises(ValueError, match="Already cloned"):
+            clone_line_to_active(db_session, line.id, viewer=test_user, can_manage=False)
+
+    def test_foreign_line_refused_without_manage(self, db_session, test_user, admin_user):
+        co, part, line = _seed(db_session, admin_user)
+        with pytest.raises(ValueError, match="Not your"):
+            clone_line_to_active(db_session, line.id, viewer=test_user, can_manage=False)
+
+
+class TestRowRendering:
+    def test_route_clones_and_renders_req_label(self, client, db_session, test_user):
+        co, part, line = _seed(db_session, test_user)
+        resp = client.post(f"/v2/partials/proactive/lines/{line.id}/clone")
+        assert resp.status_code == 200
+        assert "Cloned" in resp.text and "REQ-" in resp.text
+        assert "showToast" in resp.headers.get("HX-Trigger", "")
+        db_session.refresh(line)
+        assert line.produced_requisition_id is not None
+
+    def test_tracking_rerender_shows_button_for_looking_again(self, client, db_session, test_user):
+        co, part, line = _seed(db_session, test_user)
+        resp = client.post(f"/v2/partials/proactive/lines/{line.id}/tracking", data={"outcome": "looking_again"})
+        assert resp.status_code == 200
+        assert "Clone to Active" in resp.text
+
+    def test_no_button_for_other_outcomes(self, client, db_session, test_user):
+        co, part, line = _seed(db_session, test_user)
+        resp = client.post(f"/v2/partials/proactive/lines/{line.id}/tracking", data={"outcome": "still_looking"})
+        assert resp.status_code == 200
+        assert "Clone to Active" not in resp.text


### PR DESCRIPTION
Owner decision 7. A tracked `looking_again` outcome used to create nothing — now its outcome cell renders a **Clone to Active** button (line's salesperson or manager only). `POST /v2/partials/proactive/lines/{id}/clone` → `clone_line_to_active`: resolves the source part (the match's requirement, else the newest requirement for the same normalized MPN on the company's requisitions), copies it via `clone_parts_to_active` (fresh OPEN requisition, `cloned_from_id` provenance, reference offers, buyer task), stamps `produced_requisition_id` (idempotent — second tap refused), and fires a background sightings search. Row re-renders 'Cloned → REQ-xxx'; the digest scorecard's requirements_reopened rollup picks the stamp up automatically. 8 tests; APP_MAP § updated. Full suite: 24,337 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf