### PR TITLE
fix(qc): revenue_90d counts only the quote that WON (oq-06)

### DIFF
--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -771,7 +771,10 @@ def company_commercial_stats(db: Session, company_ids: list[int]) -> dict[int, d
         result[row.company_id]["win_rate"] = wr
         result[row.company_id]["last_req_date"] = row.last_req_date.isoformat() if row.last_req_date else None
 
-    # 90-day won revenue — CustomerSite → Requisition → Quote join
+    # 90-day won revenue — CustomerSite → Requisition → Quote join. Only quotes that
+    # actually WON count (QC oq-06): a won requisition can carry the original, its
+    # revisions, and lost/draft attempts — summing every quote double/triple-counted
+    # the deal. Quote.result is stamped by the result route / apply_quote_result.
     rev_cutoff = datetime.now(UTC) - timedelta(days=90)
     rev_rows = (
         db.query(
@@ -783,6 +786,7 @@ def company_commercial_stats(db: Session, company_ids: list[int]) -> dict[int, d
         .filter(
             CustomerSite.company_id.in_(company_ids),
             Requisition.status == RequisitionStatus.WON,
+            Quote.result == "won",
             Quote.created_at >= rev_cutoff,
         )
         .group_by(CustomerSite.company_id)

--- a/tests/test_crm_service.py
+++ b/tests/test_crm_service.py
@@ -63,12 +63,14 @@ def _make_quote(
     site: CustomerSite,
     subtotal: float,
     created_at: datetime | None = None,
+    result: str | None = "won",
 ) -> Quote:
     q = Quote(
         requisition_id=req.id,
         customer_site_id=site.id,
-        quote_number=f"Q-{req.id}-001",
+        quote_number=f"Q-{req.id}-{subtotal:.0f}",
         status="sent",
+        result=result,
         line_items=[],
         subtotal=subtotal,
         total_cost=subtotal * 0.5,
@@ -154,6 +156,25 @@ class TestCompanyCommercialStats:
         result = company_commercial_stats(db_session, [co.id])
         assert co.id in result
         assert result[co.id]["revenue_90d"] == pytest.approx(5000.0)
+
+    def test_revenue_90d_counts_only_the_won_quote(self, db_session: Session):
+        """QC oq-06: a WON requisition carries the original, revisions, and lost
+        attempts — only the quote that actually WON may count, or the deal is
+        double/triple-counted."""
+        from app.services.crm_service import company_commercial_stats
+
+        co = _make_company(db_session, "DoubleCount Co")
+        site = _make_site(db_session, co)
+        real_now = datetime.now(UTC)
+        req = _make_req(db_session, site, "won", created_at=real_now - timedelta(days=10))
+        _make_quote(db_session, req, site, subtotal=8000.0, created_at=real_now - timedelta(days=10), result="won")
+        # superseded revision + a lost attempt on the SAME won requisition
+        _make_quote(db_session, req, site, subtotal=7500.0, created_at=real_now - timedelta(days=12), result=None)
+        _make_quote(db_session, req, site, subtotal=7000.0, created_at=real_now - timedelta(days=14), result="lost")
+        db_session.commit()
+
+        result = company_commercial_stats(db_session, [co.id])
+        assert result[co.id]["revenue_90d"] == pytest.approx(8000.0)
 
     def test_last_req_date_is_max_created_at(self, db_session: Session):
         """last_req_date is the ISO string of the most recent requisition's

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -613,6 +613,7 @@ class TestCompaniesAdditional:
             requisition_id=req.id,
             customer_site_id=test_customer_site.id,
             quote_number="WON-Q-001",
+            result="won",  # oq-06: only the quote that WON counts toward revenue_90d
             subtotal=5000.00,
             created_at=datetime.now(UTC),
         )
@@ -648,6 +649,7 @@ class TestCompaniesAdditional:
             requisition_id=req.id,
             customer_site_id=test_customer_site.id,
             quote_number="WON-ENUM-001",
+            result="won",  # oq-06: only the quote that WON counts toward revenue_90d
             subtotal=4200.00,
             created_at=datetime.now(UTC),
         )


### PR DESCRIPTION
Owner decision 5b. A won requisition carries its original quote, revisions, and lost attempts — `company_commercial_stats` summed every one, double/triple-counting the deal on company dashboards. Now filtered on `Quote.result = 'won'` (stamped by the result route and `apply_quote_result`).

**Live before/after (owner-requested): identical today** — the live DB has no WON requisition with an in-window quote, so both old and new logic report $0 for every company. The fix matters the first time a real deal closes. New test pins: won req with won + revision + lost quotes counts the won one only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf