### PR TITLE
Nav wayfinding: shell negotiation, canonical URLs, deep links, mobile shell, page identity

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ import os
 import re
 import uuid
 from contextlib import asynccontextmanager
+from urllib.parse import urlencode
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
@@ -475,7 +476,50 @@ class ModuleAccessMiddleware:
 # scope["session"] first, then both inner middlewares read it. ModuleAccess is added
 # after Audit (so it wraps inside Audit), which is irrelevant to correctness: both
 # only read the session Session already decoded.
+
+
+class ShellNegotiationMiddleware:
+    """Rewrite any browser TOP-LEVEL navigation to a partial URL onto the shell route.
+
+    Root cause of the owner's "ended up on different pages with no way back"
+    (nav audit 2026-08-20): controls push ``/v2/partials/*`` URLs into history, and a
+    reload / share / back-past-the-history-cache then issues a plain browser GET of
+    that URL — which routes answer with a naked, nav-less fragment. Rather than
+    content-negotiating 200+ routes individually, this chokepoint detects a top-level
+    browser navigation (``Sec-Fetch-Dest: document`` — sent by every modern browser on
+    address-bar loads, reloads, back/forward, and link opens; absent on htmx/XHR
+    requests AND on TestClient requests, so tests and fragments pass through
+    untouched) and rewrites the scope onto ``GET /v2/shell?partial=<original url>``.
+    That ORDINARY route (htmx_views.v2_shell) then does auth the ordinary way — a
+    logged-out browser gets the login page — and serves the chrome + nav,
+    lazy-loading the SAME partial URL into #main-content. A pure path rewrite: no
+    session reads, no DB access, no response building here, so it needs nothing from
+    the middlewares around it. Download-ish paths (exports) are excluded — those are
+    legitimately fetched as documents.
+    """
+
+    _EXCLUDE_SUBSTRINGS = ("/export", "/download", "/excel", ".csv", ".xlsx")
+
+    def __init__(self, app_inner):
+        self._app = app_inner
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope.get("method") == "GET":
+            path = scope.get("path", "")
+            if path.startswith("/v2/partials/") and not any(x in path for x in self._EXCLUDE_SUBSTRINGS):
+                headers = {k.lower(): v for k, v in scope.get("headers", [])}
+                if headers.get(b"sec-fetch-dest") == b"document":
+                    query = scope.get("query_string", b"").decode("latin-1")
+                    partial_url = f"{path}?{query}" if query else path
+                    scope = dict(scope)
+                    scope["path"] = "/v2/shell"
+                    scope["raw_path"] = b"/v2/shell"
+                    scope["query_string"] = urlencode({"partial": partial_url}).encode("latin-1")
+        await self._app(scope, receive, send)
+
+
 app.add_middleware(ModuleAccessMiddleware)
+app.add_middleware(ShellNegotiationMiddleware)
 app.add_middleware(AuditUserMiddleware)
 app.add_middleware(
     SessionMiddleware,

--- a/app/main.py
+++ b/app/main.py
@@ -498,7 +498,13 @@ class ShellNegotiationMiddleware:
     legitimately fetched as documents.
     """
 
-    _EXCLUDE_SUBSTRINGS = ("/export", "/download", "/excel", ".csv", ".xlsx")
+    # Download-ish partial routes must NOT be shell-wrapped — the browser fetches them
+    # as documents (Sec-Fetch-Dest: document) but they stream a file, not a page. This
+    # is a denylist: any NEW /v2/partials/* route that streams a download (stream_csv,
+    # StreamingResponse, FileResponse, Content-Disposition) whose URL matches none of
+    # these substrings must add one here (e.g. /bid-sheet — its .csv is only in the
+    # response filename, not the path).
+    _EXCLUDE_SUBSTRINGS = ("/export", "/download", "/excel", ".csv", ".xlsx", "/bid-sheet")
 
     def __init__(self, app_inner):
         self._app = app_inner

--- a/app/routers/htmx/_shared.py
+++ b/app/routers/htmx/_shared.py
@@ -89,6 +89,27 @@ def _base_ctx(request: Request, user: User, current_view: str = "") -> dict:
     }
 
 
+def set_canonical_url(resp, request: Request, canonical_path: str) -> None:
+    """Server-owned history for a filtered list partial (nav audit 2026-08-20 #1).
+
+    Templates must NEVER push a /v2/partials/* URL (a reload of one lands on a naked
+    fragment); instead the partial route stamps every htmx response with HX-Replace-Url:
+    the CANONICAL page URL + the current query. REPLACE, never push — entering the page
+    is the only history entry (the nav <a>'s own hx-push-url provides it); filters,
+    typing, and the shell's initial lazy load all just keep the address bar truthful.
+    Pushing here would trap Back (shell load → push → Back → shell load → push …) and
+    walk it keystroke-by-keystroke through filter states. A shell-negotiated reload of a
+    stale /v2/partials/* history entry gets healed to the canonical URL by the same
+    stamp. No-ops for non-htmx callers (the browser's own URL is already canonical).
+    """
+    if not request.headers.get("hx-request"):
+        return
+    query = str(request.url.query)
+    sep = "&" if "?" in canonical_path else "?"
+    canonical = f"{canonical_path}{sep}{query}" if query else canonical_path
+    resp.headers["HX-Replace-Url"] = canonical
+
+
 def full_page_shell(request: Request, user: User, partial_url: str, nav_active: str = "") -> Response:
     """Serve the base app shell that HTMX-loads ``partial_url`` into #main-content.
 

--- a/app/routers/htmx/_shared.py
+++ b/app/routers/htmx/_shared.py
@@ -90,19 +90,24 @@ def _base_ctx(request: Request, user: User, current_view: str = "") -> dict:
 
 
 def set_canonical_url(resp, request: Request, canonical_path: str) -> None:
-    """Server-owned history for a filtered list partial (nav audit 2026-08-20 #1).
+    """Server-owned history for a filtered list partial (nav audit 2026-08-20 #1, #10).
 
-    Templates must NEVER push a /v2/partials/* URL (a reload of one lands on a naked
-    fragment); instead the partial route stamps every htmx response with HX-Replace-Url:
-    the CANONICAL page URL + the current query. REPLACE, never push — entering the page
-    is the only history entry (the nav <a>'s own hx-push-url provides it); filters,
-    typing, and the shell's initial lazy load all just keep the address bar truthful.
-    Pushing here would trap Back (shell load → push → Back → shell load → push …) and
-    walk it keystroke-by-keystroke through filter states. A shell-negotiated reload of a
-    stale /v2/partials/* history entry gets healed to the canonical URL by the same
-    stamp. No-ops for non-htmx callers (the browser's own URL is already canonical).
+    Templates must NEVER push a /v2/partials/* URL (the old hx-push-url="true" attrs
+    pushed fragment URLs keystroke-by-keystroke); instead the list route calls this and
+    the response REPLACES the address bar with the CANONICAL page URL + current query.
+
+    The stamp fires only when a NAMED form control triggered the request (HX-Trigger-
+    Name: the filter selects and search inputs) — that is precisely the "state changed
+    within the page" case, where replace keeps one history entry per page and the URL
+    truthful. It deliberately stays silent for navigations (nav <a>s, view toggles,
+    "view all" links have no name): an HX-Replace-Url header OVERRIDES the triggering
+    element's own hx-push-url in htmx, so stamping those would erase the page you came
+    from instead of pushing. Non-htmx callers no-op (a full-page load's address bar is
+    already canonical, and reloads are healed by /v2/shell).
     """
     if not request.headers.get("hx-request"):
+        return
+    if not request.headers.get("hx-trigger-name"):
         return
     query = str(request.url.query)
     sep = "&" if "?" in canonical_path else "?"

--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -20,6 +20,7 @@ Depends on: app.dependencies, app.database, app.services.approvals.{queue,po_que
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -218,7 +219,7 @@ def _viewer_badges(db: Session, user: User) -> dict[str, int]:
 async def approvals_hub_shell(
     request: Request,
     tab: str = "",
-    select: int | None = None,
+    select: str = "",
     user: User = Depends(require_access(AccessKey.BUY_PLANS)),
     db: Session = Depends(get_db),
 ):
@@ -248,7 +249,7 @@ async def approvals_hub_tab(
     request: Request,
     tab: str,
     scope: str = "all",
-    select: int | None = None,
+    select: str = "",
     q: str = "",
     show_closed: str = "",
     user: User = Depends(require_user),
@@ -272,7 +273,7 @@ def render_tab_body(
     db: Session,
     tab: str,
     scope: str = "all",
-    select: int | None = None,
+    select: str = "",
     q: str = "",
     show_closed: str = "",
 ) -> HTMLResponse:
@@ -1186,27 +1187,67 @@ async def approvals_remove_attachment(
 # ── The left work list ──────────────────────────────────────────────────
 
 
-def _selected_plan_row(db: Session, user: User, rows: list[WorkspaceRow], tab: str, select: int) -> WorkspaceRow | None:
-    """Resolve a ``?select=<plan id>`` deep link to the row whose pane should open.
+_SELECT_SHAPES = re.compile(r"^(?:plan-\d+|line-\d+|prepay-\d+|\d+)$")
 
-    The plan's own rendered row when it is in the list; otherwise (the plan sits in the
-    other live/closed set, or is filtered out) a dispatch-only stand-in targeting its
-    pane — gated by the SAME access check the pane route uses (get_buyplan_for_user), so
-    an unknown/inaccessible id resolves to None and the caller falls back to the normal
-    default silently.
+
+def _normalize_select(raw: str | None, tab: str) -> str:
+    """Validate + normalize a ?select= deep-link key (nav audit 2026-08-20 #3).
+
+    Accepts the row-key shapes the lists use (plan-N / line-N / prepay-N) plus bare
+    digits (the retired /v2/buy-plans/{id} redirect), normalized to the tab's shape.
+    Anything else → "" (silently fall back to the default selection — same contract the
+    digits-only version had).
     """
-    row = next((r for r in rows if r.key == f"plan-{select}"), None)
+    val = (raw or "").strip()
+    if not val or not _SELECT_SHAPES.match(val):
+        return ""
+    if val.isdigit():
+        val = (
+            f"line-{val}" if tab == "purchase-orders" else (f"prepay-{val}" if tab == "prepayments" else f"plan-{val}")
+        )
+    return val
+
+
+def _selected_row(db: Session, user: User, rows: list[WorkspaceRow], tab: str, select_key: str) -> WorkspaceRow | None:
+    """Resolve a normalized select key to the row whose pane should open — on ANY tab.
+
+    The rendered row when present; otherwise an access-gated dispatch-only stand-in
+    targeting the key's pane (the Cut-PO task cards and buyer notifications deep-link
+    line-N on the PO tab; buyer emails predate the list's filters). Unknown or
+    inaccessible keys resolve to None → the caller keeps the normal default.
+    """
+    row = next((r for r in rows if r.key == select_key), None)
     if row is not None:
         return row
+    kind, _, ident = select_key.partition("-")
+    obj_id = int(ident)
     from ...dependencies import get_buyplan_for_user
 
     try:
-        get_buyplan_for_user(db, user, select)
+        if kind == "plan" and tab in ("sales-orders", "buy-plans"):
+            get_buyplan_for_user(db, user, obj_id)
+            pane_url = f"/v2/partials/approvals/plan/{obj_id}/pane?lens={tab}"
+        elif kind == "line" and tab == "purchase-orders":
+            line = db.get(BuyPlanLine, obj_id)
+            if line is None:
+                return None
+            get_buyplan_for_user(db, user, line.buy_plan_id)
+            pane_url = f"/v2/partials/approvals/po/{obj_id}/pane"
+        elif kind == "prepay" and tab == "prepayments":
+            from ...models.quality_plan import Prepayment
+
+            pp = db.get(Prepayment, obj_id)
+            if pp is None:
+                return None
+            get_buyplan_for_user(db, user, pp.buy_plan_id)
+            pane_url = f"/v2/partials/approvals/prepayments/{obj_id}/pane"
+        else:
+            return None
     except HTTPException:
         return None
     return WorkspaceRow(
-        key=f"plan-{select}",
-        pane_url=f"/v2/partials/approvals/plan/{select}/pane?lens={tab}",
+        key=select_key,
+        pane_url=pane_url,
         title="",
         subtitle="",
         status="",
@@ -1222,7 +1263,7 @@ async def approvals_workspace_list(
     q: str = "",
     scope: str = "all",
     show_closed: bool = False,
-    select: int | None = None,
+    select: str = "",
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -1249,8 +1290,9 @@ async def approvals_workspace_list(
     needs = [r for r in rows if r.needs_approval]
     rest = [r for r in rows if not r.needs_approval]
     default_row = needs[0] if needs else None
-    if select is not None and resolved in ("sales-orders", "buy-plans"):
-        default_row = _selected_plan_row(db, user, rows, resolved, select) or default_row
+    select_key = _normalize_select(select, resolved)
+    if select_key:
+        default_row = _selected_row(db, user, rows, resolved, select_key) or default_row
 
     ctx = _base_ctx(request, user, "buy-plans")
     ctx.update(

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -466,10 +466,11 @@ async def prepay_request_decide(
 
 @router.get("/v2/partials/buy-plans/{plan_id:int}")
 async def buy_plan_detail_partial(
+    request: Request,
     plan_id: int,
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
-) -> RedirectResponse:
+):
     """Retired legacy plan-detail page → 308 into the Approvals Workspace deep link.
 
     The Deal Sheet (the workspace pane) is the plan's one surface (T3). The
@@ -479,7 +480,13 @@ async def buy_plan_detail_partial(
     ``{tab}`` redirect never captures a numeric id.
     """
     get_buyplan_for_user(db, user, plan_id)
-    return RedirectResponse(f"/v2/approvals?tab=sales-orders&select={plan_id}", status_code=308)
+    deep_link = f"/v2/approvals?tab=sales-orders&select={plan_id}"
+    # An htmx caller would FOLLOW a 308 and swap the full /v2/approvals document
+    # inside its target (doubled chrome — nav audit 2026-08-20 #4); HX-Redirect makes
+    # the client do a real top-level navigation instead.
+    if request.headers.get("hx-request"):
+        return HTMLResponse("", headers={"HX-Redirect": deep_link})
+    return RedirectResponse(deep_link, status_code=308)
 
 
 # ── Retired hub lens redirects (registered AFTER the {plan_id:int} detail route so a

--- a/app/routers/htmx/prospecting.py
+++ b/app/routers/htmx/prospecting.py
@@ -40,7 +40,7 @@ from ...models.prospect_account import ProspectAccount
 from ...services.prospect_priority import build_priority_snapshot, build_signal_tags, contacts_summary
 from ...template_env import template_response
 from ...utils.search_builder import SearchBuilder
-from ._shared import _base_ctx
+from ._shared import _base_ctx, set_canonical_url
 
 router = APIRouter(tags=["htmx-views"])
 
@@ -366,7 +366,9 @@ async def prospecting_list_partial(
             "ai_screen_enabled": _list_settings.ai_screen_enabled,
         }
     )
-    return template_response("htmx/partials/prospecting/list.html", ctx)
+    resp = template_response("htmx/partials/prospecting/list.html", ctx)
+    set_canonical_url(resp, request, "/v2/prospecting")
+    return resp
 
 
 # Sprint 8 prospecting static routes — must precede {prospect_id} catch-all

--- a/app/routers/htmx/requisitions.py
+++ b/app/routers/htmx/requisitions.py
@@ -55,7 +55,7 @@ from ...utils.csv_export import stream_csv
 from ...utils.search_builder import SearchBuilder
 from ...utils.sql_helpers import escape_like
 from .._lookup_helpers import get_requisition_or_404
-from ._shared import _base_ctx, _parse_date_safe, _parse_task_due_date
+from ._shared import _base_ctx, _parse_date_safe, _parse_task_due_date, set_canonical_url
 from ._shared_tabs import requisition_tab as _requisition_tab_impl
 
 router = APIRouter(tags=["htmx-views"])
@@ -380,7 +380,9 @@ async def requisitions_list_partial(
             "inbox_status": get_inbox_sync_status(db, user),
         }
     )
-    return template_response("htmx/partials/requisitions/list.html", ctx)
+    resp = template_response("htmx/partials/requisitions/list.html", ctx)
+    set_canonical_url(resp, request, "/v2/requisitions?view=list")
+    return resp
 
 
 # CSV export column order for the requisitions list — the REAL Requisition fields. Header

--- a/app/routers/htmx/search_views.py
+++ b/app/routers/htmx/search_views.py
@@ -31,7 +31,7 @@ from ...services.sighting_ingest import sighting_from_row
 from ...services.vendor_unavailability import apply_to_fresh_sightings
 from ...template_env import template_response, templates
 from ...utils.sql_helpers import escape_like
-from ._shared import _base_ctx
+from ._shared import _base_ctx, set_canonical_url
 
 router = APIRouter(tags=["htmx-views"])
 
@@ -84,10 +84,14 @@ async def search_results_page(
     from ...services.global_search_service import fast_search
 
     results = fast_search(q, db, user) if q else {"best_match": None, "groups": {}, "total_count": 0}
-    return template_response(
+    resp = template_response(
         "htmx/partials/search/full_results.html",
         {**_base_ctx(request, user), "results": results, "query": q},
     )
+    # Nav audit #10: the refine box used to push /v2/search/results with no ?q, so a
+    # reload came back empty. The canonical stamp carries the live query instead.
+    set_canonical_url(resp, request, "/v2/search/results")
+    return resp
 
 
 # ── Search partials ─────────────────────────────────────────────────────
@@ -107,6 +111,10 @@ async def search_form_partial(
     deep-links the dossier + a lazy-loaded recent list). The new routes live in
     routers/part_dossier.py; this stays the single /v2/partials/search entry point.
     """
+    # NOTE: no set_canonical_url stamp here — an HX-Replace-Url response header would
+    # override the caller's push (search form / dossier bar push /v2/search?mpn=…
+    # explicitly) and collapse back-through-parts into one entry. Dossiers are detail
+    # pages: pushes stay caller-owned; stale partial URLs survive via /v2/shell.
     ctx = _base_ctx(request, user, "search")
     if mpn.strip():
         ctx["mpn"] = mpn.strip().upper()

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -17,7 +17,8 @@ Depends on: models, dependencies, database, .htmx.my_day, .htmx.email_views,
     .htmx.insights_views, .htmx.search_views, .htmx.requisitions_edit
 """
 
-from urllib.parse import quote
+import re
+from urllib.parse import quote, urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -30,7 +31,12 @@ from ..dependencies import get_user, require_access, require_buyer, user_has_acc
 from ..models import User
 from ..template_env import page_response, template_response, templates  # noqa: F401 — templates re-exported for tests
 from .auth import _password_login_enabled
-from .htmx._shared import _base_ctx, _safe_int, _vite_assets  # noqa: F401 — _safe_int re-exported for tests
+from .htmx._shared import (  # noqa: F401 — _safe_int re-exported for tests
+    _base_ctx,
+    _safe_int,
+    _vite_assets,
+    full_page_shell,
+)
 from .htmx.email_views import router as _email_views_router
 from .htmx.email_views import send_email_reply  # noqa: F401 — re-exported for tests
 from .htmx.insights_views import router as _insights_views_router
@@ -126,6 +132,43 @@ _MODULE_ENTRY_URLS: tuple[tuple[AccessKey, str], ...] = (
 )
 
 
+# Second /v2/partials/<segment> path segment → bottom-nav highlight key for the shell
+# route below. Segments matching their nav key are omitted (the .get fallback covers
+# them); only the aliases need rows. Unknown segments highlight nothing — harmless.
+_SHELL_NAV_KEYS: dict[str, str] = {
+    "approvals": "buy-plans",
+    "buy-plans": "buy-plans",
+    "parts": "requisitions",
+    "customers": "crm",
+    "contacts": "crm",
+    "vendor-contacts": "crm",
+    "vendors": "crm",
+}
+
+
+@router.get("/v2/shell", response_class=HTMLResponse)
+async def v2_shell(request: Request, partial: str = "", db: Session = Depends(get_db)):
+    """Serve the app shell lazy-loading ``partial`` — ShellNegotiationMiddleware's
+    target.
+
+    A browser TOP-LEVEL navigation to a /v2/partials/* URL (reload of a stale pushed
+    URL, shared link, back past the history cache) is rewritten onto this route by the
+    middleware; it answers with the full chrome + nav, loading the SAME partial into
+    #main-content (nav audit 2026-08-20 #1). Auth mirrors v2_page — a logged-out
+    browser gets the login page, never a naked fragment or a 401. ``partial`` outside
+    /v2/partials/ 404s: this is not an open content loader.
+    """
+    user = get_user(request, db)
+    if not user:
+        return template_response(
+            "htmx/login.html", {"request": request, "password_login": _password_login_enabled(), **_vite_assets()}
+        )
+    if not partial.startswith("/v2/partials/"):
+        raise HTTPException(404, "Unknown page")
+    segment = partial.removeprefix("/v2/partials/").split("/", 1)[0].split("?", 1)[0]
+    return full_page_shell(request, user, partial, _SHELL_NAV_KEYS.get(segment, segment))
+
+
 @router.get("/v2", response_class=HTMLResponse)
 @router.get("/v2/requisitions", response_class=HTMLResponse)
 @router.get("/v2/requisitions/{req_id:int}", response_class=HTMLResponse)
@@ -218,11 +261,17 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         # Split-panel workspace is the default Sales Hub; ?view=list serves the flat
         # requisitions list so the List-view toggle's pushed URL
         # (/v2/requisitions?view=list) reloads / bookmarks straight to the list.
-        partial_url = (
-            "/v2/partials/requisitions"
-            if request.query_params.get("view") == "list"
-            else "/v2/partials/parts/workspace"
-        )
+        if request.query_params.get("view") == "list":
+            partial_url = "/v2/partials/requisitions"
+            # Nav audit #10: thread the filters through so a reload of the canonical
+            # /v2/requisitions?view=list&q=… rebuilds the same filtered list. `view`
+            # itself stays out — it picked this branch, and the list partial's
+            # HX-Replace-Url stamp re-adds it to the canonical URL.
+            filters = [(k, v) for k, v in request.query_params.multi_items() if k != "view"]
+            if filters:
+                partial_url = f"{partial_url}?{urlencode(filters)}"
+        else:
+            partial_url = "/v2/partials/parts/workspace"
     elif current_view == "trouble-tickets":
         partial_url = "/v2/partials/trouble-tickets/workspace"
     elif current_view == "crm":
@@ -265,10 +314,18 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         tab_qs = request.query_params.get("tab", "").strip()
         partial_url = f"/v2/partials/approvals?tab={quote(tab_qs)}" if tab_qs else "/v2/partials/approvals"
         select_qs = request.query_params.get("select", "").strip()
-        if select_qs.isdigit():
-            partial_url = f"{partial_url}{'&' if tab_qs else '?'}select={int(select_qs)}"
+        # Nav audit #3: select is a row KEY (plan-N / line-N / prepay-N) or bare
+        # digits — validated by shape here, resolved per-tab in the workspace list.
+        if re.fullmatch(r"(?:plan-|line-|prepay-)?\d+", select_qs or ""):
+            partial_url = f"{partial_url}{'&' if tab_qs else '?'}select={quote(select_qs)}"
     else:
         partial_url = f"/v2/partials/{current_view}"
+        # Nav audit 2026-08-20 (#10): thread the WHOLE query through so a reload or
+        # share of a filtered canonical URL (/v2/requisitions?q=…&status=…) rebuilds
+        # the same filtered view instead of snapping back to defaults. Partial routes
+        # ignore unknown params, so over-threading is harmless.
+        if request.url.query:
+            partial_url = f"{partial_url}?{request.url.query}"
     # Detail views: a trailing numeric id (/{view}/{id}) overrides the list partial with
     # the detail partial. Each split key equals the current_view, so at most one applies.
     _DETAIL_VIEWS = (
@@ -287,12 +344,10 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         parts = path.split(f"/{current_view}/")
         if len(parts) > 1 and parts[1].isdigit():
             partial_url = f"/v2/partials/{current_view}/{parts[1]}"
-            # Thread ?tab= through for customer deep-links so the partial lands on
-            # the correct tab when the full page is (re)loaded from a pushed URL.
-            if current_view == "customers":
-                _tab_qs = request.query_params.get("tab", "").strip()
-                if _tab_qs:
-                    partial_url = f"{partial_url}?tab={quote(_tab_qs)}"
+            # Thread the whole query through (was customers-only ?tab=) so any
+            # detail deep-link state survives a full-page (re)load.
+            if request.url.query:
+                partial_url = f"{partial_url}?{request.url.query}"
 
     nav_active = _NAV_ID_ALIAS.get(current_view, current_view)
     ctx = _base_ctx(request, user, nav_active)

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -133,8 +133,8 @@ _MODULE_ENTRY_URLS: tuple[tuple[AccessKey, str], ...] = (
 
 
 # Second /v2/partials/<segment> path segment → bottom-nav highlight key for the shell
-# route below. Segments matching their nav key are omitted (the .get fallback covers
-# them); only the aliases need rows. Unknown segments highlight nothing — harmless.
+# route below. Segments equal to their own nav key are omitted (the .get fallback
+# covers them); only the aliases need rows.
 _SHELL_NAV_KEYS: dict[str, str] = {
     "approvals": "buy-plans",
     "buy-plans": "buy-plans",
@@ -144,6 +144,27 @@ _SHELL_NAV_KEYS: dict[str, str] = {
     "vendor-contacts": "crm",
     "vendors": "crm",
 }
+
+# The closed set of values that may ever become ``current_view`` from the shell route.
+# current_view is rendered inside base.html's Alpine ``x-data`` attribute, which the
+# browser HTML-decodes before Alpine evaluates it as JS — so a value derived from the
+# attacker-controlled ``?partial=`` query MUST be validated against this allowlist, not
+# merely Jinja-escaped (a raw segment would be reflected XSS). Anything unknown → "".
+_VALID_NAV_KEYS: frozenset[str] = frozenset(
+    {
+        "requisitions",
+        "sightings",
+        "materials",
+        "search",
+        "buy-plans",
+        "resell",
+        "crm",
+        "proactive",
+        "prospecting",
+        "my-day",
+        "settings",
+    }
+)
 
 
 @router.get("/v2/shell", response_class=HTMLResponse)
@@ -163,10 +184,16 @@ async def v2_shell(request: Request, partial: str = "", db: Session = Depends(ge
         return template_response(
             "htmx/login.html", {"request": request, "password_login": _password_login_enabled(), **_vite_assets()}
         )
-    if not partial.startswith("/v2/partials/"):
+    # ".." would let the embedded hx-get climb out of /v2/partials/ once the browser
+    # normalizes the URL (e.g. /v2/partials/../../auth/logout → GET /auth/logout swapped
+    # into #main-content). Reject traversal outright; the prefix check alone is not enough.
+    if not partial.startswith("/v2/partials/") or ".." in partial:
         raise HTTPException(404, "Unknown page")
     segment = partial.removeprefix("/v2/partials/").split("/", 1)[0].split("?", 1)[0]
-    return full_page_shell(request, user, partial, _SHELL_NAV_KEYS.get(segment, segment))
+    nav_key = _SHELL_NAV_KEYS.get(segment, segment)
+    # Validate against the closed nav-key set — never reflect the raw segment (XSS: it
+    # lands in base.html's Alpine x-data attribute, HTML-decoded before JS eval).
+    return full_page_shell(request, user, partial, nav_key if nav_key in _VALID_NAV_KEYS else "")
 
 
 @router.get("/v2", response_class=HTMLResponse)

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -366,8 +366,32 @@ Alpine.store('sightingSelection', {
 // ── HTMX config ─────────────────────────────────────────────
 htmx.config.defaultSwapStyle = 'innerHTML';
 htmx.config.historyCacheSize = 10;
+// Nav audit 2026-08-20: on a history-cache miss (common on phones — tab discards,
+// >10 swaps) do a REAL browser load of the pushed URL instead of an ajax re-GET
+// swapped into <body>. Combined with ShellNegotiationMiddleware (which serves the
+// full shell for any browser navigation to a partial URL), every Back press lands
+// on a complete page instead of a naked fragment.
+htmx.config.refreshOnHistoryMiss = true;
 htmx.config.selfRequestsOnly = true;
 htmx.config.timeout = 15000;  // 15s timeout — prevents requests from hanging forever
+
+// History snapshots can fail silently (localStorage quota) — every failure turns a
+// future Back into the slow refresh path. Surface it in the existing error log.
+document.body.addEventListener('htmx:historyCacheError', (e) => {
+  console.warn('htmx history cache error (Back will fall back to a full reload):', e.detail);
+});
+
+// Nav audit #3: a history-cache RESTORE re-fires the workspace's lazy loader with the
+// tab that was baked at first render — stale after tab switches. Re-render the body
+// from the URL (the single source of truth for tab + selection) instead.
+document.body.addEventListener('htmx:historyRestore', () => {
+  if (!document.getElementById('ap-hub-body')) return;
+  const params = new URLSearchParams(window.location.search);
+  const tab = params.get('tab') || 'sales-orders';
+  const sel = params.get('select');
+  const url = '/v2/partials/approvals/' + tab + (sel ? '?select=' + encodeURIComponent(sel) : '');
+  htmx.ajax('GET', url, { target: '#ap-hub-body', swap: 'innerHTML', indicator: '#ap-hub-body' });
+});
 
 // ── CSRF token for all HTMX requests ───────────────────────
 // starlette_csrf middleware requires x-csrftoken header on POST/PUT/PATCH/DELETE.

--- a/app/templates/htmx/base.html
+++ b/app/templates/htmx/base.html
@@ -47,7 +47,7 @@
        hidden></div>
 
   {# ── Page content ─────────────────────────────────────────── #}
-  <main id="main-content" class="main-content p-3 pb-[52px] bg-white" hx-target="this" hx-swap="innerHTML">
+  <main id="main-content" class="main-content p-3 pb-[52px] bg-white" hx-target="this" hx-swap="innerHTML" hx-history-elt>
     {% block content %}{% endblock %}
   </main>
 

--- a/app/templates/htmx/partials/approvals/_pane_sales_order.html
+++ b/app/templates/htmx/partials/approvals/_pane_sales_order.html
@@ -50,9 +50,12 @@
       <span class="flex items-center gap-2">
         {# Quality Plan front door (re-homed from the retired detail page): get-or-create
            this plan's QP and open the full native view (purchasing + serial/FRU too). #}
-        <span hx-get="/v2/qp/for-buy-plan/{{ bp.id }}" hx-target="#main-content" hx-push-url="true"
-              @click.stop data-loading-disable role="link"
-              class="text-xs font-medium text-accent-600 cursor-pointer">Open full Quality Plan</span>
+        {# Real <a href> (nav audit #5): long-press / open-in-new-tab work, and the
+           link survives JS failure. htmx still handles the in-app click. #}
+        <a href="/v2/qp/for-buy-plan/{{ bp.id }}"
+           hx-get="/v2/qp/for-buy-plan/{{ bp.id }}" hx-target="#main-content" hx-push-url="true"
+           @click.stop data-loading-disable
+           class="text-xs font-medium text-accent-600 cursor-pointer">Open full Quality Plan</a>
         {% if qp and qp.sales_section_reviewed_at %}<span class="text-[11px] text-emerald-600 font-medium">Reviewed</span>{% endif %}
         <svg class="w-4 h-4 text-gray-400 transition-transform" :class="qpOpen && 'rotate-180'" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
       </span>

--- a/app/templates/htmx/partials/approvals/_sales_order_new.html
+++ b/app/templates/htmx/partials/approvals/_sales_order_new.html
@@ -19,8 +19,10 @@
     <button hx-get="/v2/partials/approvals/pane/blank" hx-target="#aw-pane" hx-swap="innerHTML"
             class="btn btn-secondary btn-sm">Cancel</button>
     {% else %}
+    {# push="false" (nav audit #12): Cancel returns to the workspace it came from —
+       pushing /v2/approvals here dropped ?tab and stacked a junk Back entry. #}
     <button hx-get="/v2/partials/approvals" hx-target="#main-content" hx-swap="innerHTML"
-            hx-push-url="/v2/approvals" class="btn btn-secondary btn-sm">Cancel</button>
+            hx-push-url="false" class="btn btn-secondary btn-sm">Cancel</button>
     {% endif %}
   </div>
 

--- a/app/templates/htmx/partials/approvals/_sheet_header.html
+++ b/app/templates/htmx/partials/approvals/_sheet_header.html
@@ -20,7 +20,10 @@
                  'active': 'Purchase — POs in motion', 'inbound': 'Purchase — inbound',
                  'halted': 'Halted', 'completed': 'Done', 'cancelled': 'Cancelled'}[bp.status] %}
 
-<div id="sheet-header" class="space-y-2 max-md:sticky max-md:top-0 max-md:z-10 max-md:bg-white max-md:pb-2 max-md:border-b max-md:border-line-subtle">
+{# No longer sticky on mobile (nav audit #8): sticking at top-0 slid under the 48px
+   topbar, and the workspace's ↑ List chip strip (in _workspace_split.html) is now the
+   one sticky element — two competing sticky bars overlapped at the same offset. #}
+<div id="sheet-header" class="space-y-2 max-md:bg-white max-md:pb-2 max-md:border-b max-md:border-line-subtle">
 
   {# Row 1 — the stage track #}
   <div class="flex items-center gap-2.5">
@@ -44,8 +47,8 @@
       {{ _label }}
     </span>
     {% if _stage_ts and bp.status not in ('completed', 'cancelled') %}{{ age_chip(_stage_ts) }}{% endif %}
-    <span class="hidden max-md:inline-flex text-[11px] font-medium text-accent-600 cursor-pointer whitespace-nowrap"
-          @click="document.getElementById('aw-list')?.scrollIntoView({behavior: 'smooth'})">&uarr; List</span>
+    {# ↑ List chip moved to _workspace_split.html (outside #aw-pane) so ALL pane
+       types get it, not just this one — nav audit #8. #}
   </div>
 
   {# Row 2 — identity + editable cells #}

--- a/app/templates/htmx/partials/approvals/_workspace_split.html
+++ b/app/templates/htmx/partials/approvals/_workspace_split.html
@@ -36,7 +36,9 @@
          history.replaceState(history.state, '', '/v2/approvals?tab={{ tab }}&select=' + encodeURIComponent(key));
          // Auto-selection (aw-default) must not yank the phone viewport mid-pane
          // (nav audit #8) — scroll only on an explicit row tap.
-         if (!auto && window.innerWidth < 900) {
+         {# 768 matches Tailwind's md breakpoint — the CSS (max-md) and this JS must
+            agree on where "mobile" starts (nav audit #8; was 900 vs 768). #}
+         if (!auto && window.innerWidth < 768) {
            this.$root.querySelector('#aw-pane')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
          }
        },
@@ -110,7 +112,15 @@
     {# Loading bar for imperative pane loads (htmx.ajax indicator target) —
        lives OUTSIDE #aw-pane so the innerHTML swap never removes it. #}
     <div id="aw-pane-ind" class="htmx-indicator h-0.5 bg-accent-500 animate-pulse flex-shrink-0"></div>
-    <div id="aw-pane" class="flex-1 min-h-0">
+    {# ↑ List chip (nav audit #8) — mounted OUTSIDE #aw-pane so every pane type gets
+       it (the per-pane copy existed on 1 of 4 panes). Mobile-only, sticky under the
+       48px topbar so it survives scrolling a long pane. #}
+    <div class="hidden max-md:flex sticky top-12 z-10 justify-end px-3 py-1 bg-white/95 backdrop-blur border-b border-line-subtle">
+      <button type="button"
+              class="text-[11px] font-medium text-accent-600 whitespace-nowrap"
+              @click="document.getElementById('aw-list')?.scrollIntoView({behavior: 'smooth'})">&uarr; List</button>
+    </div>
+    <div id="aw-pane" class="flex-1 min-h-0 scroll-mt-12">
       {% include "htmx/partials/approvals/_pane_blank.html" %}
     </div>
   </div>

--- a/app/templates/htmx/partials/approvals/_workspace_split.html
+++ b/app/templates/htmx/partials/approvals/_workspace_split.html
@@ -27,10 +27,16 @@
        stopDrag() {
          if (this.dragging) { this.dragging = false; localStorage.setItem('aw-split', this.splitRatio.toFixed(3)); }
        },
-       select(key, url) {
+       select(key, url, auto) {
          this.sel = key; this.paneUrl = url;
          htmx.ajax('GET', url, { target: '#aw-pane', swap: 'innerHTML', indicator: '#aw-pane-ind' });
-         if (window.innerWidth < 900) {
+         // Nav audit #3: the selection lives in the URL (REPLACE, not push — the
+         // workspace stays ONE history entry, so Back always exits it in one press
+         // and a reload/share restores tab + selected deal exactly).
+         history.replaceState(history.state, '', '/v2/approvals?tab={{ tab }}&select=' + encodeURIComponent(key));
+         // Auto-selection (aw-default) must not yank the phone viewport mid-pane
+         // (nav audit #8) — scroll only on an explicit row tap.
+         if (!auto && window.innerWidth < 900) {
            this.$root.querySelector('#aw-pane')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
          }
        },
@@ -63,7 +69,7 @@
      @aw-mark.window="sel = $event.detail.key"
      @aw-advance.window="advance = true"
      @htmx:after-settle.window="maybeAdvance($event)"
-     @aw-default.window="if (!sel) select($event.detail.key, $event.detail.url)">
+     @aw-default.window="if (!sel) select($event.detail.key, $event.detail.url, true)">
 
   {# ── Left: the work list ─────────────────────────────────────────── #}
   <div class="flex flex-col min-w-0 md:border-r border-line-base max-md:!w-full max-md:border-b"

--- a/app/templates/htmx/partials/approvals/approvals_hub.html
+++ b/app/templates/htmx/partials/approvals/approvals_hub.html
@@ -28,7 +28,7 @@
             hx-target="#ap-hub-body"
             hx-swap="innerHTML"
             hx-include="#aw-filters"
-            hx-push-url="/v2/approvals?tab={{ key }}"
+            hx-replace-url="/v2/approvals?tab={{ key }}"
             @click="tab = '{{ key }}'"
             :class="tab === '{{ key }}'
                     ? 'bg-accent-600 text-white shadow-sm'

--- a/app/templates/htmx/partials/crm/shell.html
+++ b/app/templates/htmx/partials/crm/shell.html
@@ -3,6 +3,8 @@
    Called by: crm/views.py crm_shell route.
    Depends on: Alpine.js, HTMX, accent palette (post-PR0), _shell_macros.html.
 #}
+
+<title hx-swap-oob="true">CRM — AvailAI</title>
 {% from "htmx/partials/crm/_shell_macros.html" import tab_button -%}
 <div x-data="{ tab: '{{ default_tab }}' }">
 

--- a/app/templates/htmx/partials/customers/tabs/buy_plans_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/buy_plans_tab.html
@@ -31,10 +31,8 @@
         {% for bp in buy_plans %}
         <tr class="hover:bg-brand-50 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent-500"
             role="button" tabindex="0"
-            hx-get="/v2/partials/buy-plans/{{ bp.id }}"
-            hx-target="#main-content"
-            hx-push-url="/v2/buy-plans/{{ bp.id }}"
-            hx-trigger="click, keyup[key=='Enter']">
+            @click="window.location.href = '/v2/approvals?tab=sales-orders&select={{ bp.id }}'"
+            @keyup.enter="window.location.href = '/v2/approvals?tab=sales-orders&select={{ bp.id }}'">
           <td class="px-4 py-2.5 text-sm font-medium text-brand-500 hover:text-brand-600">#{{ bp.id }}</td>
           <td class="px-4 py-2.5 text-sm text-gray-600">{{ bp.requisition.name if bp.requisition else "—" }}</td>
           <td class="px-4 py-2.5 text-sm text-gray-600 font-mono">{{ bp.sales_order_number or "—" }}</td>

--- a/app/templates/htmx/partials/follow_ups/list.html
+++ b/app/templates/htmx/partials/follow_ups/list.html
@@ -6,9 +6,20 @@
 #}
 {%- from "htmx/partials/follow_ups/_macros.html" import parts_summary %}
 
+<title hx-swap-oob="true">Follow-ups — AvailAI</title>
+
 <div class="page-fluid">
+  {# Identity + way back (nav audit #5/#11): this queue is reached laterally from the
+     Sightings workspace and had no name, no title, and no exit. #}
+  <a href="/v2/sightings" hx-get="/v2/partials/sightings/workspace" hx-target="#main-content"
+     hx-push-url="/v2/sightings"
+     class="inline-flex items-center gap-1 text-sm text-accent-600 hover:text-accent-700 mb-1.5">
+    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
+    Sightings
+  </a>
   <div class="flex items-center justify-between mb-6">
     <div>
+      <h1 class="h1">Follow-ups</h1>
       <p class="text-sm text-gray-600 mt-1">
         <span class="font-medium text-amber-600">{{ total }}</span> contact{{ "s" if total != 1 }} needing follow-up
       </p>

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -87,6 +87,7 @@
             hx-get="/v2/partials/materials/{{ m.id }}"
             hx-target="#main-content"
             hx-push-url="/v2/materials/{{ m.id }}"
+            hx-disinherit="hx-push-url"
             hx-trigger="click, keyup[key=='Enter']"
             preload="mouseover">
           <td>

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -2,6 +2,8 @@
    Called by: htmx_views.py materials_workspace route
    Depends on: Alpine.js materialsFilter() in htmx_app.js
 #}
+
+<title hx-swap-oob="true">Materials — AvailAI</title>
 {% from "htmx/partials/materials/filters/_macros.html" import disclosure_header, removable_chip %}
 <div id="materials-workspace" x-data="materialsFilter"
      data-display-names='{{ display_names|tojson }}' class="flex h-full">

--- a/app/templates/htmx/partials/offers/review_queue.html
+++ b/app/templates/htmx/partials/offers/review_queue.html
@@ -5,9 +5,20 @@
   Depends on: HTMX, Tailwind CSS with brand palette.
 #}
 
+<title hx-swap-oob="true">Offer Review — AvailAI</title>
+
 <div id="review-queue-content" class="page-fluid">
+  {# Identity + way back (nav audit #5/#11): reached laterally from the Sightings
+     workspace quick-links; previously anonymous with no exit. #}
+  <a href="/v2/sightings" hx-get="/v2/partials/sightings/workspace" hx-target="#main-content"
+     hx-push-url="/v2/sightings"
+     class="inline-flex items-center gap-1 text-sm text-accent-600 hover:text-accent-700 mb-1.5">
+    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
+    Sightings
+  </a>
   <div class="flex items-center justify-between mb-6">
     <div>
+      <h1 class="h1">Offer review</h1>
       <p class="text-sm text-gray-600 mt-1">
         <span class="font-medium text-amber-600">{{ offers|length }}</span> offer{{ 's' if offers|length != 1 }} pending review
       </p>

--- a/app/templates/htmx/partials/parts/workspace.html
+++ b/app/templates/htmx/partials/parts/workspace.html
@@ -5,6 +5,8 @@
    Receives: pipeline (forecast_service.pipeline_summary) for the slim context strip.
 #}
 
+<title hx-swap-oob="true">Sales Hub — AvailAI</title>
+
 {# ── Pipeline context strip — slim, subordinate header (no card/dashboard). Open deals,
      open value, and stage-weighted forecast, near the requisitions they summarize. The
      split-panel height below subtracts this 26px strip so the layout doesn't overflow. #}

--- a/app/templates/htmx/partials/proactive/list.html
+++ b/app/templates/htmx/partials/proactive/list.html
@@ -5,6 +5,8 @@
   Called by: htmx_views.py proactive_list_partial endpoint.
   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
 #}
+
+<title hx-swap-oob="true">Proactive — AvailAI</title>
 {%- from "htmx/partials/proactive/_macros.html" import company_header, empty_state, margin_badge %}
 
 <div class="page-fluid"

--- a/app/templates/htmx/partials/prospecting/list.html
+++ b/app/templates/htmx/partials/prospecting/list.html
@@ -145,6 +145,7 @@
     {% if page > 1 %}
     <a hx-get="/v2/partials/prospecting?page={{ page - 1 }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
        hx-target="#main-content"
+       hx-replace-url="/v2/prospecting?page={{ page - 1 }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
        class="btn-secondary btn-sm cursor-pointer">
       &larr; Prev
     </a>
@@ -157,6 +158,7 @@
     {% if page < total_pages %}
     <a hx-get="/v2/partials/prospecting?page={{ page + 1 }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
        hx-target="#main-content"
+       hx-replace-url="/v2/prospecting?page={{ page + 1 }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
        class="btn-secondary btn-sm cursor-pointer">
       Next &rarr;
     </a>

--- a/app/templates/htmx/partials/prospecting/list.html
+++ b/app/templates/htmx/partials/prospecting/list.html
@@ -8,6 +8,8 @@
   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
 #}
 
+<title hx-swap-oob="true">Prospecting — AvailAI</title>
+
 <div class="page-fluid">
 
   {# ── Page header ─────────────────────────────────────────────────── #}
@@ -73,7 +75,8 @@
                      {% if status == val %}bg-accent-500 text-white shadow-sm{% else %}bg-accent-100 text-accent-600 hover:bg-accent-200{% endif %}"
               aria-pressed="{{ 'true' if status == val else 'false' }}"
               hx-get="/v2/partials/prospecting?status={{ val|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
-              hx-target="#main-content">
+              hx-target="#main-content"
+              hx-replace-url="/v2/prospecting?status={{ val|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}">
         {{ label }}
         <span class="ml-1 text-xs opacity-75">{{ pill_counts.get(val, 0) }}</span>
       </button>
@@ -95,7 +98,8 @@
                          {% if scope == s %}bg-accent-500 text-white{% else %}bg-white text-accent-600 hover:bg-accent-100{% endif %}"
                   aria-pressed="{{ 'true' if scope == s else 'false' }}"
                   hx-get="/v2/partials/prospecting?scope={{ s|urlencode }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}"
-                  hx-target="#main-content">
+                  hx-target="#main-content"
+                  hx-replace-url="/v2/prospecting?scope={{ s|urlencode }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}">
             {{ lbl }}
           </button>
           {% endfor %}

--- a/app/templates/htmx/partials/prospecting/list.html
+++ b/app/templates/htmx/partials/prospecting/list.html
@@ -73,8 +73,7 @@
                      {% if status == val %}bg-accent-500 text-white shadow-sm{% else %}bg-accent-100 text-accent-600 hover:bg-accent-200{% endif %}"
               aria-pressed="{{ 'true' if status == val else 'false' }}"
               hx-get="/v2/partials/prospecting?status={{ val|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
-              hx-target="#main-content"
-              hx-push-url="true">
+              hx-target="#main-content">
         {{ label }}
         <span class="ml-1 text-xs opacity-75">{{ pill_counts.get(val, 0) }}</span>
       </button>
@@ -87,7 +86,6 @@
                hx-get="/v2/partials/prospecting"
                hx-trigger="keyup changed delay:300ms"
                hx-target="#main-content"
-               hx-push-url="true"
                hx-include="[name='sort'], [name='status'], [name='scope']">
         {# Everyone / Mine scope toggle — relabelled from All/Mine so it no longer reads
            as a duplicate of the "All" status pill. Scopes grid + pill counts to my claims. #}
@@ -97,8 +95,7 @@
                          {% if scope == s %}bg-accent-500 text-white{% else %}bg-white text-accent-600 hover:bg-accent-100{% endif %}"
                   aria-pressed="{{ 'true' if scope == s else 'false' }}"
                   hx-get="/v2/partials/prospecting?scope={{ s|urlencode }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}"
-                  hx-target="#main-content"
-                  hx-push-url="true">
+                  hx-target="#main-content">
             {{ lbl }}
           </button>
           {% endfor %}
@@ -108,7 +105,6 @@
                 hx-get="/v2/partials/prospecting"
                 hx-trigger="change"
                 hx-target="#main-content"
-                hx-push-url="true"
                 hx-include="[name='q'], [name='status'], [name='scope']">
           <option value="ai_match_desc" {% if sort == 'ai_match_desc' %}selected{% endif %}>AI match (best first)</option>
           <option value="buyer_ready_desc" {% if sort == 'buyer_ready_desc' %}selected{% endif %}>Most buyer-ready</option>
@@ -145,7 +141,6 @@
     {% if page > 1 %}
     <a hx-get="/v2/partials/prospecting?page={{ page - 1 }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
        hx-target="#main-content"
-       hx-push-url="true"
        class="btn-secondary btn-sm cursor-pointer">
       &larr; Prev
     </a>
@@ -158,7 +153,6 @@
     {% if page < total_pages %}
     <a hx-get="/v2/partials/prospecting?page={{ page + 1 }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}&scope={{ scope|urlencode }}"
        hx-target="#main-content"
-       hx-push-url="true"
        class="btn-secondary btn-sm cursor-pointer">
       Next &rarr;
     </a>

--- a/app/templates/htmx/partials/qp/detail.html
+++ b/app/templates/htmx/partials/qp/detail.html
@@ -71,9 +71,7 @@
       <span>
         Buy Plan:
         {% if bp %}
-        <a hx-get="/v2/partials/buy-plans/{{ bp.id }}"
-           hx-target="#main-content"
-           hx-push-url="/v2/buy-plans/{{ bp.id }}"
+        <a href="/v2/approvals?tab=sales-orders&select={{ bp.id }}"
            class="font-mono text-brand-600 hover:text-brand-500 cursor-pointer">#{{ bp.id }}</a>
         {% else %}
         <span class="text-gray-400 italic">unavailable</span>

--- a/app/templates/htmx/partials/qp/detail.html
+++ b/app/templates/htmx/partials/qp/detail.html
@@ -51,6 +51,15 @@
 
   {# ═══ 1. COMPACT HEADER ═══ #}
   <div class="mb-4">
+    {# Way back (nav audit #5): the QP was a cul-de-sac — its only exit was browser
+       Back. A real link lands on the owning deal's workspace pane. #}
+    {% if bp %}
+    <a href="/v2/approvals?tab=sales-orders&select={{ bp.id }}"
+       class="inline-flex items-center gap-1 text-sm text-accent-600 hover:text-accent-700 mb-1.5">
+      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
+      Back to deal
+    </a>
+    {% endif %}
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div class="flex items-center gap-3">
         <h1 class="h1">Quality Plan #{{ qp.id }}</h1>

--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -40,7 +40,7 @@
           <p>
             <span class="text-gray-400">Customer:</span>
             <a hx-get="/v2/partials/customers/{{ quote.customer_site.company.id }}"
-               hx-target="#main-content" hx-push-url="/v2/companies/{{ quote.customer_site.company.id }}"
+               hx-target="#main-content" hx-push-url="/v2/customers/{{ quote.customer_site.company.id }}"
                preload="mouseover"
                class="text-brand-500 hover:text-brand-400 cursor-pointer font-medium">{{ quote.customer_site.company.name }}</a>
           </p>

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -240,8 +240,7 @@
               const ids = Array.from(selectedIds);
               const idStr = ids.join(',');
               if (ids.length === 1) {
-                htmx.ajax('GET', '/v2/partials/requisitions/' + ids[0] + '?tab=build_quote', {target:'#main-content', swap:'innerHTML', indicator:'#quote-builder-skeleton'});
-                window.history.pushState({}, '', '/v2/requisitions/' + ids[0]);
+                htmx.ajax('GET', '/v2/partials/requisitions/' + ids[0] + '?tab=build_quote', {target:'#main-content', swap:'innerHTML', indicator:'#quote-builder-skeleton', push:'/v2/requisitions/' + ids[0]});
               } else {
                 htmx.ajax('GET', '/v2/partials/quote-builder/multi?requisition_ids=' + idStr, {target:'#modal-content', swap:'innerHTML', indicator:'#modal-loading'}).then(() => $dispatch('open-modal', {wide:true}));
               }

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -62,7 +62,6 @@
                  hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
                  hx-swap="innerHTML"
-                 hx-push-url="true"
                  hx-include="#req-filters"
                  :hx-vals="JSON.stringify({status: rStatus, sort: rSort, dir: rDir})"
                  hx-trigger="input changed delay:300ms"
@@ -101,7 +100,6 @@
           <select name="owner" aria-label="Filter by owner"
                   hx-get="/v2/partials/requisitions"
                   hx-target="#main-content"
-                  hx-push-url="true"
                   hx-include="#req-filters"
                   :hx-vals="JSON.stringify({status: rStatus, sort: rSort, dir: rDir})"
                   class="px-3 py-1.5 border border-gray-200 rounded-lg text-sm input-focus">
@@ -119,7 +117,6 @@
           <input type="date" name="date_from" value="{{ date_from }}" aria-label="Filter from date"
                  hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
-                 hx-push-url="true"
                  hx-include="#req-filters"
                  :hx-vals="JSON.stringify({status: rStatus, sort: rSort, dir: rDir})"
                  class="px-3 py-1.5 border border-gray-200 rounded-lg text-sm input-focus">
@@ -129,7 +126,6 @@
           <input type="date" name="date_to" value="{{ date_to }}" aria-label="Filter to date"
                  hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
-                 hx-push-url="true"
                  hx-include="#req-filters"
                  :hx-vals="JSON.stringify({status: rStatus, sort: rSort, dir: rDir})"
                  class="px-3 py-1.5 border border-gray-200 rounded-lg text-sm input-focus">
@@ -151,7 +147,6 @@
                 @click="rStatus = '{{ s_val }}'"
                 hx-get="/v2/partials/requisitions"
                 hx-target="#main-content"
-                hx-push-url="true"
                 hx-include="#req-filters"
                 :hx-vals="JSON.stringify({status: '{{ s_val }}', sort: rSort, dir: rDir})"
                 class="px-3 py-1 text-xs font-medium rounded-full transition-colors
@@ -181,7 +176,6 @@
                 hx-get="/v2/partials/requisitions"
                 hx-target="#main-content"
                 hx-swap="innerHTML"
-                hx-push-url="true"
                 hx-include="#req-filters"
                 :hx-vals="JSON.stringify({status: rStatus, sort: rSort, dir: rDir})"
                 class="px-3 py-1 border border-gray-200 rounded-full text-xs font-medium input-focus">
@@ -196,7 +190,6 @@
                 hx-get="/v2/partials/requisitions"
                 hx-target="#main-content"
                 hx-swap="innerHTML"
-                hx-push-url="true"
                 @click="selectedIds = new Set(); Object.keys(collapsed).forEach(k => collapsed[k] = false)"
                 class="btn btn-sm btn-secondary self-center"
                 title="Clear search, filters &amp; grouping, expand all groups, and clear selection">
@@ -290,7 +283,6 @@
               {% if col_key %}
               <a hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
-                 hx-push-url="true"
                  hx-include="#req-filters"
                  :hx-vals="JSON.stringify({status: rStatus, sort: '{{ col_key }}', dir: '{{ 'asc' if sort == col_key and dir == 'desc' else 'desc' }}'})"
                  class="cursor-pointer hover:text-brand-500 inline-flex items-center gap-1">

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -189,10 +189,14 @@
         {# Clean & reset — the single reset control: FULL reset via a server GET with no
            params clears search + every filter + grouping; @click re-expands all groups
            (mutate in place, never reassign) and clears the selection. Always visible. #}
+        {# hx-replace-url keeps the address bar truthful after a reset (nav audit #1):
+           the button has no name (no HX-Trigger-Name → the server stamp won't fire),
+           and its canonical URL is static, so a static replace is the right tool. #}
         <button type="button"
                 hx-get="/v2/partials/requisitions"
                 hx-target="#main-content"
                 hx-swap="innerHTML"
+                hx-replace-url="/v2/requisitions?view=list"
                 @click="selectedIds = new Set(); Object.keys(collapsed).forEach(k => collapsed[k] = false)"
                 class="btn btn-sm btn-secondary self-center"
                 title="Clear search, filters &amp; grouping, expand all groups, and clear selection">
@@ -283,7 +287,11 @@
             {% for col_name, col_key in columns %}
             <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               {% if col_key %}
-              <a hx-get="/v2/partials/requisitions"
+              {# name="sort" makes HX-Trigger-Name arrive so set_canonical_url stamps
+                 the sorted canonical URL (the sort/dir are Alpine-dynamic via hx-vals,
+                 so a static hx-replace-url can't carry them) — nav audit #10. #}
+              <a name="sort"
+                 hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
                  hx-include="#req-filters"
                  :hx-vals="JSON.stringify({status: rStatus, sort: '{{ col_key }}', dir: '{{ 'asc' if sort == col_key and dir == 'desc' else 'desc' }}'})"

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -143,7 +143,10 @@
       <div class="flex flex-wrap gap-2">
         {# 'won' is the real RequisitionStatus; the old 'awarded' value doesn't exist and always returned empty. #}
         {% for s_val, s_label in [('', 'All'), ('open', 'Open'), ('hotlist', 'Hotlist'), ('won', 'Won')] %}
-        <button type="button"
+        {# name= makes HX-Trigger-Name arrive so set_canonical_url stamps the replace
+           (the pill's query is Alpine-dynamic — a static hx-replace-url can't carry it).
+           hx-vals overrides the button's own empty status param. #}
+        <button type="button" name="status"
                 @click="rStatus = '{{ s_val }}'"
                 hx-get="/v2/partials/requisitions"
                 hx-target="#main-content"

--- a/app/templates/htmx/partials/requisitions/req_row.html
+++ b/app/templates/htmx/partials/requisitions/req_row.html
@@ -190,6 +190,7 @@
     hx-get="/v2/partials/requisitions/{{ req.id }}"
     hx-target="#main-content"
     hx-push-url="/v2/requisitions/{{ req.id }}"
+    hx-disinherit="hx-push-url"
     hx-trigger="click, keyup[key=='Enter']">
   {# Checkbox (stops row click propagation) #}
   <td class="px-3 py-3 w-10" @click.stop>

--- a/app/templates/htmx/partials/requisitions/tabs/buy_plans.html
+++ b/app/templates/htmx/partials/requisitions/tabs/buy_plans.html
@@ -29,10 +29,8 @@
         {% for bp in buy_plans %}
         <tr class="hover:bg-brand-50 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent-500"
             role="button" tabindex="0"
-            hx-get="/v2/partials/buy-plans/{{ bp.id }}"
-            hx-target="#main-content"
-            hx-push-url="/v2/buy-plans/{{ bp.id }}"
-            hx-trigger="click, keyup[key=='Enter']">
+            @click="window.location.href = '/v2/approvals?tab=sales-orders&select={{ bp.id }}'"
+            @keyup.enter="window.location.href = '/v2/approvals?tab=sales-orders&select={{ bp.id }}'">
           <td class="px-4 py-2.5 text-sm font-medium text-brand-500 hover:text-brand-600">#{{ bp.id }}</td>
           <td class="px-4 py-2.5 text-sm text-gray-600 font-mono">{{ bp.sales_order_number or "—" }}</td>
           <td class="px-4 py-2.5">

--- a/app/templates/htmx/partials/search/dossier_shell.html
+++ b/app/templates/htmx/partials/search/dossier_shell.html
@@ -18,7 +18,7 @@
     <svg class="h-4 w-4 text-brand-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
     <form class="flex flex-1 items-center gap-2"
           x-data="{ q: '{{ mpn|default('') }}' }"
-          @submit.prevent="const v=q.trim(); if(v){ const u='/v2/partials/search?mpn='+encodeURIComponent(v); htmx.ajax('GET', u, {target:'#main-content', indicator:'#ds-bar-spin'}); history.pushState({},'','/v2/search?mpn='+encodeURIComponent(v)); }">
+          @submit.prevent="const v=q.trim(); if(v){ const u='/v2/partials/search?mpn='+encodeURIComponent(v); htmx.ajax('GET', u, {target:'#main-content', indicator:'#ds-bar-spin', push:'/v2/search?mpn='+encodeURIComponent(v)}); }">
       {# input-focus adds accent ring on keyboard focus — a11y fix for the bare bg-transparent bar #}
       <input x-model="q" name="mpn" type="text" aria-label="Part number"
              placeholder="Enter a part number…"

--- a/app/templates/htmx/partials/search/dossier_shell.html
+++ b/app/templates/htmx/partials/search/dossier_shell.html
@@ -12,6 +12,8 @@
    hx-target="this" — under #main-content's hx-target="this", omitting it would
    replace the whole page (CLAUDE.md anti-pattern). #}
 
+<title hx-swap-oob="true">{{ mpn }} — AvailAI</title>
+
 {# ── TIER 1 — persistent dossier search bar (deep-links a new PN) ── #}
 <div class="sticky tier-search z-20 -mx-4 bg-white/95 backdrop-blur border-b border-brand-200">
   <div class="page-readable px-4 py-2 flex items-center gap-2">

--- a/app/templates/htmx/partials/search/form.html
+++ b/app/templates/htmx/partials/search/form.html
@@ -9,7 +9,7 @@
   {# Search form card — deep-links to the dossier. #}
   <div class="bg-white border border-brand-200 rounded-lg shadow-card p-3">
     <form x-data="{ q: '' }"
-          @submit.prevent="const v=q.trim(); if(v){ const u='/v2/partials/search?mpn='+encodeURIComponent(v); htmx.ajax('GET', u, {target:'#main-content', indicator:'#ds-landing-spin'}); history.pushState({},'','/v2/search?mpn='+encodeURIComponent(v)); }">
+          @submit.prevent="const v=q.trim(); if(v){ const u='/v2/partials/search?mpn='+encodeURIComponent(v); htmx.ajax('GET', u, {target:'#main-content', indicator:'#ds-landing-spin', push:'/v2/search?mpn='+encodeURIComponent(v)}); }">
       <div class="flex gap-2">
         <input aria-label="Part number search" type="text" name="mpn" x-model="q"
                placeholder="Enter part number (e.g. LM317T, STM32F407VG)"

--- a/app/templates/htmx/partials/search/form.html
+++ b/app/templates/htmx/partials/search/form.html
@@ -5,6 +5,8 @@
    Called by: htmx_views.search_form_partial (no mpn).
    Depends on: part_dossier.py (dossier shell + recent endpoint). #}
 
+<title hx-swap-oob="true">Part Search — AvailAI</title>
+
 <div class="max-w-2xl mx-auto space-y-3">
   {# Search form card — deep-links to the dossier. #}
   <div class="bg-white border border-brand-200 rounded-lg shadow-card p-3">

--- a/app/templates/htmx/partials/search/full_results.html
+++ b/app/templates/htmx/partials/search/full_results.html
@@ -9,6 +9,8 @@
     - ai_search: bool (optional)
 #}
 
+<title hx-swap-oob="true">Search Results — AvailAI</title>
+
 <div class="page-fluid px-4 py-6" x-data="{ tab: 'all' }">
 
   {# ── Page header ── #}
@@ -42,7 +44,6 @@
            hx-get="/v2/partials/search/results"
            hx-trigger="keyup changed delay:500ms"
            hx-target="#main-content"
-           hx-push-url="/v2/search/results"
            hx-include="this"
            placeholder="Refine your search...">
   </div>

--- a/app/templates/htmx/partials/search/full_results.html
+++ b/app/templates/htmx/partials/search/full_results.html
@@ -121,10 +121,14 @@
       "material_card": "/v2/partials/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
       "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
     } %}
-    <a href="{{ bm_url_map.get(bm.type, '#') }}"
-       hx-get="{{ bm_partials_map.get(bm.type, '#') }}"
+    {# Same dead-link guard as shared/search_results.html (nav audit #12). #}
+    {% set bm_url = bm_url_map.get(bm.type) %}
+    {% set bm_partial = bm_partials_map.get(bm.type) %}
+    {% set bm_dead = (not bm_url) or bm_url.endswith('/') or bm_url.endswith('=') %}
+    <a {% if not bm_dead %}href="{{ bm_url }}"
+       hx-get="{{ bm_partial }}"
        hx-target="#main-content"
-       hx-push-url="{{ bm_url_map.get(bm.type, '#') }}"
+       hx-push-url="{{ bm_url }}"{% endif %}
        class="block rounded-xl border-2 border-brand-200 bg-brand-50 p-4 hover:border-brand-400 hover:bg-brand-100 transition-all">
       <div class="flex items-center gap-4">
         <span class="inline-flex items-center justify-center h-10 w-10 rounded-xl bg-brand-500 text-white text-sm font-bold uppercase">

--- a/app/templates/htmx/partials/search/full_results.html
+++ b/app/templates/htmx/partials/search/full_results.html
@@ -106,21 +106,21 @@
       "requisition": "/v2/requisitions/" ~ bm.id,
       "company": "/v2/customers/" ~ bm.id,
       "vendor": "/v2/vendors/" ~ bm.id,
-      "vendor_contact": "/v2/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
-      "part": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
-      "offer": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
+      "vendor_contact": "/v2/vendors/" ~ (bm.vendor_card_id|default(bm.id, true)),
+      "part": "/v2/requisitions/" ~ (bm.requisition_id|default("", true)),
+      "offer": "/v2/requisitions/" ~ (bm.requisition_id|default("", true)),
       "material_card": "/v2/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
-      "sighting": "/v2/requisitions/" ~ (bm.requisition_id|default(""))
+      "sighting": "/v2/requisitions/" ~ (bm.requisition_id|default("", true))
     } %}
     {% set bm_partials_map = {
       "requisition": "/v2/partials/requisitions/" ~ bm.id,
       "company": "/v2/partials/customers/" ~ bm.id,
       "vendor": "/v2/partials/vendors/" ~ bm.id,
-      "vendor_contact": "/v2/partials/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
-      "part": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
-      "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
+      "vendor_contact": "/v2/partials/vendors/" ~ (bm.vendor_card_id|default(bm.id, true)),
+      "part": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("", true)),
+      "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("", true)),
       "material_card": "/v2/partials/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
-      "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
+      "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("", true))
     } %}
     {# Same dead-link guard as shared/search_results.html (nav audit #12). #}
     {% set bm_url = bm_url_map.get(bm.type) %}

--- a/app/templates/htmx/partials/shared/mobile_nav.html
+++ b/app/templates/htmx/partials/shared/mobile_nav.html
@@ -11,7 +11,7 @@
        moreOpen: false,
        activeNav: '{{ current_view }}',
        urlToNav(url) {
-         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/resell':'resell','/v2/crm':'crm','/v2/customers':'crm','/v2/contacts':'crm','/v2/vendor-contacts':'crm','/v2/vendors':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/my-day':'my-day','/v2/approvals':'buy-plans','/v2/settings':'settings'};
+         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/resell':'resell','/v2/crm':'crm','/v2/customers':'crm','/v2/contacts':'crm','/v2/vendor-contacts':'crm','/v2/vendors':'crm','/v2/companies':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/my-day':'my-day','/v2/approvals':'buy-plans','/v2/settings':'settings','/v2/qp':'buy-plans','/v2/quotes':'requisitions','/v2/follow-ups':'sightings','/v2/offers':'sightings','/v2/sourcing':'requisitions','/v2/trouble-tickets':'settings'};
          for (const [prefix, id] of Object.entries(map)) { if (url.startsWith(prefix)) return id; }
          return this.activeNav;
        }
@@ -22,17 +22,25 @@
      :data-current-view="activeNav"
      aria-label="Main navigation">
   <div class="flex items-stretch justify-center mx-auto max-w-[720px]">
+    {# Nav audit #9: 10 slots at w-[62px] demanded 682px on a 390px phone — sub-44px
+       tap targets were the most direct cause of "kept ending up on different pages".
+       Four primary destinations stay in the bar; the rest live in the More sheet
+       below (same hx behavior, badges included). #}
     {% set nav_items = [
       ('requisitions', 'Sales Hub', '/v2/requisitions', '/v2/partials/parts/workspace',
        'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2'),
+      ('buy-plans', 'Approvals', '/v2/approvals', '/v2/partials/approvals',
+       'M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z'),
+      ('search', 'Search', '/v2/search', '/v2/partials/search',
+       'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'),
+      ('my-day', 'Tasks', '/v2/my-day', '/v2/partials/my-day',
+       'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z')
+    ] %}
+    {% set more_nav_items = [
       ('sightings', 'Sightings', '/v2/sightings', '/v2/partials/sightings/workspace',
        'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z'),
       ('materials', 'Materials', '/v2/materials', '/v2/partials/materials/workspace',
        'M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4'),
-      ('search', 'Search', '/v2/search', '/v2/partials/search',
-       'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'),
-      ('buy-plans', 'Approvals', '/v2/approvals', '/v2/partials/approvals',
-       'M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z'),
       ('resell', 'Resell', '/v2/resell', '/v2/partials/resell/workspace',
        'M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4'),
       ('crm', 'CRM', '/v2/crm', '/v2/partials/crm/shell',
@@ -40,10 +48,12 @@
       ('proactive', 'Proactive', '/v2/proactive', '/v2/partials/proactive',
        'M13 10V3L4 14h7v7l9-11h-7z'),
       ('prospecting', 'Prospect', '/v2/prospecting', '/v2/partials/prospecting',
-       'M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7'),
-      ('my-day', 'Tasks', '/v2/my-day', '/v2/partials/my-day',
-       'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z')
+       'M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7')
     ] %}
+    {% set more_nav_ids = more_nav_items | map(attribute=0) | list %}
+    {# Single-quoted JS array literal — tojson would emit double quotes and terminate
+       the double-quoted :class attribute. Ids are fixed slugs, safe to inline. #}
+    {% set more_ids_js = "['settings','" ~ (more_nav_ids | join("','")) ~ "']" %}
     {# The "Approvals" nav item (internal id 'buy-plans' — alert badge + active-nav wiring)
        leads to the Approvals Workspace at /v2/approvals (/v2/partials/approvals: Sales
        Orders / Buy Plans / Purchase Orders / Prepayments). The old /v2/buy-plans hub
@@ -65,7 +75,7 @@
        hx-trigger="click[(window.location.pathname + window.location.search) !== '{{ href }}']"
        @click="if ((window.location.pathname + window.location.search) === '{{ href }}') $event.preventDefault(); else activeNav = '{{ id }}'"
        :class="activeNav === '{{ id }}' ? 'text-accent-600' : 'text-gray-500 hover:text-gray-600'"
-       class="relative flex flex-col items-center justify-center py-1.5 text-center transition-colors duration-150 w-[62px] min-w-0">
+       class="relative flex flex-col items-center justify-center py-1.5 text-center transition-colors duration-150 flex-1 max-w-[96px] min-w-0">
       <span x-show="activeNav === '{{ id }}'" x-cloak class="absolute top-0 inset-x-[8px] h-[3px] bg-accent-500 rounded-b-sm"></span>
       <div class="relative inline-flex">
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -112,13 +122,14 @@
     {% endif %}
     {% endfor %}
 
-    {# More button — vertical dots #}
-    <div class="relative flex items-stretch w-[62px] min-w-0">
+    {# More button — vertical dots. Lights up when the CURRENT view lives in the sheet
+       (its nav item is hidden), so "you are here" survives the 4+More split. #}
+    <div class="relative flex items-stretch flex-1 max-w-[96px] min-w-0">
       <button @click="moreOpen = !moreOpen"
-              :class="(activeNav === 'settings' || moreOpen) ? 'text-accent-600' : 'text-gray-500 hover:text-gray-600'"
-              class="flex flex-col items-center justify-center py-1.5 text-center transition-colors duration-150 w-[62px]"
+              :class="(moreOpen || {{ more_ids_js }}.includes(activeNav)) ? 'text-accent-600' : 'text-gray-500 hover:text-gray-600'"
+              class="flex flex-col items-center justify-center py-1.5 text-center transition-colors duration-150 w-full"
               aria-label="More options">
-        <span x-show="activeNav === 'settings'" x-cloak class="absolute top-0 inset-x-[8px] h-[3px] bg-accent-500 rounded-b-sm"></span>
+        <span x-show="{{ more_ids_js }}.includes(activeNav)" x-cloak class="absolute top-0 inset-x-[8px] h-[3px] bg-accent-500 rounded-b-sm"></span>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-[17px] w-[17px]" viewBox="0 0 24 24" fill="currentColor">
           <circle cx="12" cy="5" r="2"/>
           <circle cx="12" cy="12" r="2"/>
@@ -143,6 +154,44 @@
           <p class="text-[13px] font-semibold text-brand-900 tracking-tight">{{ user_name or 'User' }}</p>
           <p class="text-[11px] text-brand-400 mt-0.5">{{ user_email or '' }}</p>
         </div>
+
+        {# Secondary modules (nav audit #9) — same hx behavior + access gating as the
+           bar items; the crm/proactive badge pollers live on, rendered as row pills. #}
+        {% for id, label, href, partial, icon_path in more_nav_items %}
+        {% if (access | default({})).get(id, True) %}
+        <a href="{{ href }}"
+           hx-get="{{ partial }}"
+           hx-target="#main-content"
+           hx-push-url="{{ href }}"
+           @click="moreOpen = false; activeNav = '{{ id }}'"
+           :class="activeNav === '{{ id }}' ? 'text-accent-600 bg-accent-50' : 'text-gray-700 hover:bg-brand-50/50'"
+           class="flex items-center gap-2 px-3.5 py-2 text-[13px] font-medium transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 flex-shrink-0 text-brand-400" fill="none"
+               viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="{{ icon_path }}"/>
+          </svg>
+          {{ label }}
+          {% if id == 'proactive' %}
+          <span id="proactive-nav-badge"
+                hx-get="/v2/partials/proactive/badge"
+                hx-trigger="load, every 60s"
+                hx-target="#proactive-nav-badge"
+                hx-swap="innerHTML"
+                hx-push-url="false"
+                class="ml-auto flex items-center justify-center min-w-[14px] h-[14px]"></span>
+          {% elif id == 'crm' %}
+          <span id="crm-nav-badge"
+                hx-get="/v2/partials/alerts/crm/badge"
+                hx-trigger="load, every 60s"
+                hx-target="#crm-nav-badge"
+                hx-swap="innerHTML"
+                hx-push-url="false"
+                class="ml-auto flex items-center justify-center min-w-[14px] h-[14px]"></span>
+          {% endif %}
+        </a>
+        {% endif %}
+        {% endfor %}
+        <div class="border-b border-brand-100"></div>
 
         {# Settings #}
         <a href="/v2/settings"

--- a/app/templates/htmx/partials/shared/mobile_nav.html
+++ b/app/templates/htmx/partials/shared/mobile_nav.html
@@ -17,6 +17,8 @@
        }
      }"
      @htmx:pushed-into-history.window="activeNav = urlToNav($event.detail.path || location.pathname)"
+     @htmx:replaced-in-history.window="activeNav = urlToNav($event.detail.path || location.pathname)"
+     @htmx:history-restore.window="activeNav = urlToNav($event.detail.path || location.pathname)"
      @click.outside="moreOpen = false"
      @keydown.escape.window="moreOpen = false"
      :data-current-view="activeNav"
@@ -159,11 +161,14 @@
            bar items; the crm/proactive badge pollers live on, rendered as row pills. #}
         {% for id, label, href, partial, icon_path in more_nav_items %}
         {% if (access | default({})).get(id, True) %}
+        {# Same re-tap no-op guard as the bar items (nav audit #12): tapping the sheet
+           entry for the page you are already on just closes the sheet — no dup push. #}
         <a href="{{ href }}"
            hx-get="{{ partial }}"
            hx-target="#main-content"
            hx-push-url="{{ href }}"
-           @click="moreOpen = false; activeNav = '{{ id }}'"
+           hx-trigger="click[(window.location.pathname + window.location.search) !== '{{ href }}']"
+           @click="moreOpen = false; if ((window.location.pathname + window.location.search) !== '{{ href }}') activeNav = '{{ id }}'"
            :class="activeNav === '{{ id }}' ? 'text-accent-600 bg-accent-50' : 'text-gray-700 hover:bg-brand-50/50'"
            class="flex items-center gap-2 px-3.5 py-2 text-[13px] font-medium transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 flex-shrink-0 text-brand-400" fill="none"
@@ -198,7 +203,8 @@
            hx-get="/v2/partials/settings"
            hx-target="#main-content"
            hx-push-url="/v2/settings"
-           @click="moreOpen = false; activeNav = 'settings'"
+           hx-trigger="click[(window.location.pathname + window.location.search) !== '/v2/settings']"
+           @click="moreOpen = false; if ((window.location.pathname + window.location.search) !== '/v2/settings') activeNav = 'settings'"
            :class="activeNav === 'settings' ? 'text-accent-600 bg-accent-50' : 'text-gray-700 hover:bg-brand-50/50'"
            class="flex items-center gap-2 px-3.5 py-2 text-[13px] font-medium transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 flex-shrink-0 text-brand-400" fill="none"

--- a/app/templates/htmx/partials/shared/mobile_nav.html
+++ b/app/templates/htmx/partials/shared/mobile_nav.html
@@ -54,11 +54,16 @@
     {# Per-user nav gate: hide a section the user lacks access to. `access` is a
        {nav-id: bool} map from _base_ctx; default-show if it's somehow absent. #}
     {% if (access | default({})).get(id, True) %}
+    {# Trigger filter (nav audit #12): re-tapping the tab for the EXACT page you are
+       already on is a no-op — without it every re-tap pushed a duplicate history
+       entry and Back visibly "did nothing". From a detail page or filtered list the
+       pathname+search differs, so the tap still navigates home. #}
     <a href="{{ href }}"
        hx-get="{{ partial }}"
        hx-target="#main-content"
        hx-push-url="{{ href }}"
-       @click="activeNav = '{{ id }}'"
+       hx-trigger="click[(window.location.pathname + window.location.search) !== '{{ href }}']"
+       @click="if ((window.location.pathname + window.location.search) === '{{ href }}') $event.preventDefault(); else activeNav = '{{ id }}'"
        :class="activeNav === '{{ id }}' ? 'text-accent-600' : 'text-gray-500 hover:text-gray-600'"
        class="relative flex flex-col items-center justify-center py-1.5 text-center transition-colors duration-150 w-[62px] min-w-0">
       <span x-show="activeNav === '{{ id }}'" x-cloak class="absolute top-0 inset-x-[8px] h-[3px] bg-accent-500 rounded-b-sm"></span>

--- a/app/templates/htmx/partials/shared/search_results.html
+++ b/app/templates/htmx/partials/shared/search_results.html
@@ -48,10 +48,16 @@
         "material_card": "/v2/partials/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
         "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
       } %}
-      <a href="{{ bm_url_map.get(bm.type, '#') }}"
-         hx-get="{{ bm_partials_map.get(bm.type, '#') }}"
+      {# Link attrs only when the type is mapped AND the id resolved — an unmapped type
+         or missing requisition/mpn produced href="#" / truncated URLs that pushed junk
+         history entries (nav audit #12). A bare <a> renders the card non-interactive. #}
+      {% set bm_url = bm_url_map.get(bm.type) %}
+      {% set bm_partial = bm_partials_map.get(bm.type) %}
+      {% set bm_dead = (not bm_url) or bm_url.endswith('/') or bm_url.endswith('=') %}
+      <a {% if not bm_dead %}href="{{ bm_url }}"
+         hx-get="{{ bm_partial }}"
          hx-target="#main-content"
-         hx-push-url="{{ bm_url_map.get(bm.type, '#') }}"
+         hx-push-url="{{ bm_url }}"{% endif %}
          @click="searchOpen = false"
          class="flex items-center gap-3 rounded-lg px-3 py-2.5 bg-brand-50 border border-brand-200 hover:bg-brand-100 transition-colors">
         <div class="flex-shrink-0">

--- a/app/templates/htmx/partials/shared/search_results.html
+++ b/app/templates/htmx/partials/shared/search_results.html
@@ -32,21 +32,21 @@
         "requisition": "/v2/requisitions/" ~ bm.id,
         "company": "/v2/companies/" ~ bm.id,
         "vendor": "/v2/vendors/" ~ bm.id,
-        "vendor_contact": "/v2/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
-        "part": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
-        "offer": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
+        "vendor_contact": "/v2/vendors/" ~ (bm.vendor_card_id|default(bm.id, true)),
+        "part": "/v2/requisitions/" ~ (bm.requisition_id|default("", true)),
+        "offer": "/v2/requisitions/" ~ (bm.requisition_id|default("", true)),
         "material_card": "/v2/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
-        "sighting": "/v2/requisitions/" ~ (bm.requisition_id|default(""))
+        "sighting": "/v2/requisitions/" ~ (bm.requisition_id|default("", true))
       } %}
       {% set bm_partials_map = {
         "requisition": "/v2/partials/requisitions/" ~ bm.id,
         "company": "/v2/partials/customers/" ~ bm.id,
         "vendor": "/v2/partials/vendors/" ~ bm.id,
-        "vendor_contact": "/v2/partials/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
-        "part": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
-        "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
+        "vendor_contact": "/v2/partials/vendors/" ~ (bm.vendor_card_id|default(bm.id, true)),
+        "part": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("", true)),
+        "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("", true)),
         "material_card": "/v2/partials/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
-        "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
+        "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("", true))
       } %}
       {# Link attrs only when the type is mapped AND the id resolved — an unmapped type
          or missing requisition/mpn produced href="#" / truncated URLs that pushed junk

--- a/app/templates/htmx/partials/shared/topbar.html
+++ b/app/templates/htmx/partials/shared/topbar.html
@@ -15,7 +15,7 @@
   {# "You are here" (nav audit #11): compact current-view label, seeded from the shell
      context and kept fresh from the URL on every htmx history change — the topbar is
      never re-rendered by partial swaps, so a static server label would go stale. #}
-  {% set _view_labels = {'requisitions':'Sales Hub','sightings':'Sightings','materials':'Materials','search':'Search','buy-plans':'Approvals','resell':'Resell','crm':'CRM','proactive':'Proactive','prospecting':'Prospecting','my-day':'Tasks','settings':'Settings'} %}
+  {% set _view_labels = {'requisitions':'Sales Hub','sightings':'Sightings','materials':'Materials','search':'Search','buy-plans':'Approvals','resell':'Resell','crm':'CRM','customers':'CRM','vendors':'CRM','contacts':'CRM','vendor-contacts':'CRM','proactive':'Proactive','prospecting':'Prospecting','my-day':'Tasks','settings':'Settings','quotes':'Quote','follow-ups':'Follow-ups','offers':'Offer review','trouble-tickets':'Settings'} %}
   <span class="flex-shrink-0 text-sm font-semibold text-brand-900 tracking-tight max-sm:hidden"
         x-data="{
           label: '{{ _view_labels.get(current_view, '') }}',
@@ -27,6 +27,7 @@
         }"
         @htmx:pushed-into-history.window="label = urlToLabel($event.detail.path || location.pathname)"
         @htmx:replaced-in-history.window="label = urlToLabel($event.detail.path || location.pathname)"
+        @htmx:history-restore.window="label = urlToLabel($event.detail.path || location.pathname)"
         x-text="label"></span>
 
   {# Center: Global search #}

--- a/app/templates/htmx/partials/shared/topbar.html
+++ b/app/templates/htmx/partials/shared/topbar.html
@@ -12,6 +12,23 @@
     <img src="/static/avail_logo_tight.png" alt="AVAIL" class="h-12 w-auto py-1">
   </a>
 
+  {# "You are here" (nav audit #11): compact current-view label, seeded from the shell
+     context and kept fresh from the URL on every htmx history change — the topbar is
+     never re-rendered by partial swaps, so a static server label would go stale. #}
+  {% set _view_labels = {'requisitions':'Sales Hub','sightings':'Sightings','materials':'Materials','search':'Search','buy-plans':'Approvals','resell':'Resell','crm':'CRM','proactive':'Proactive','prospecting':'Prospecting','my-day':'Tasks','settings':'Settings'} %}
+  <span class="flex-shrink-0 text-sm font-semibold text-brand-900 tracking-tight max-sm:hidden"
+        x-data="{
+          label: '{{ _view_labels.get(current_view, '') }}',
+          urlToLabel(url) {
+            const map = {'/v2/qp':'Quality Plan','/v2/follow-ups':'Follow-ups','/v2/offers':'Offer review','/v2/quotes':'Quote','/v2/requisitions':'Sales Hub','/v2/sightings':'Sightings','/v2/materials':'Materials','/v2/search':'Search','/v2/approvals':'Approvals','/v2/buy-plans':'Approvals','/v2/resell':'Resell','/v2/crm':'CRM','/v2/customers':'CRM','/v2/contacts':'CRM','/v2/vendor-contacts':'CRM','/v2/vendors':'CRM','/v2/companies':'CRM','/v2/proactive':'Proactive','/v2/prospecting':'Prospecting','/v2/my-day':'Tasks','/v2/settings':'Settings','/v2/trouble-tickets':'Settings','/v2/sourcing':'Sales Hub'};
+            for (const [prefix, l] of Object.entries(map)) { if (url.startsWith(prefix)) return l; }
+            return this.label;
+          }
+        }"
+        @htmx:pushed-into-history.window="label = urlToLabel($event.detail.path || location.pathname)"
+        @htmx:replaced-in-history.window="label = urlToLabel($event.detail.path || location.pathname)"
+        x-text="label"></span>
+
   {# Center: Global search #}
   <div class="relative mx-auto w-full max-w-lg" x-data="{ searchOpen: false }">
     <div class="relative">

--- a/app/templates/htmx/partials/sightings/list.html
+++ b/app/templates/htmx/partials/sightings/list.html
@@ -4,6 +4,8 @@
    Depends on: sightings/table.html, sightings/detail.html, Alpine.js, HTMX, SSE broker
 #}
 
+<title hx-swap-oob="true">Sightings — AvailAI</title>
+
 {% from "htmx/partials/shared/_macros.html" import lazy_body %}
 
 {# ── SSE Disconnect Banner ─────────────────────────────────── #}

--- a/app/templates/htmx/partials/tickets/_row.html
+++ b/app/templates/htmx/partials/tickets/_row.html
@@ -1,6 +1,7 @@
 <div hx-get="/v2/partials/trouble-tickets/{{ t.id }}"
      hx-target="#main-content"
      hx-push-url="/v2/trouble-tickets/{{ t.id }}"
+     hx-disinherit="hx-push-url"
      class="flex items-center gap-4 px-4 py-3 bg-white border border-gray-100 rounded-lg mb-1 cursor-pointer hover:bg-gray-50 transition-colors">
   {# Checkbox — accent via accent-color + input-focus ring (not brand-500). #}
   <input type="checkbox" @click.stop

--- a/app/templates/htmx/partials/vendors/list.html
+++ b/app/templates/htmx/partials/vendors/list.html
@@ -206,6 +206,7 @@
             hx-get="/v2/partials/vendors/{{ v.id }}"
             hx-target="{{ hx_target|default('#main-content') }}"
             hx-push-url="/v2/vendors/{{ v.id }}"
+            hx-disinherit="hx-push-url"
             hx-trigger="click, keyup[key=='Enter']"
             preload="mouseover">
           {# Cadence dot #}

--- a/app/templates/htmx/partials/vendors/vendor_card.html
+++ b/app/templates/htmx/partials/vendors/vendor_card.html
@@ -10,7 +10,8 @@
             hover:shadow-md transition-all cursor-pointer p-4 space-y-3"
      hx-get="/v2/partials/vendors/{{ v.id }}"
      hx-target="{{ hx_target|default('#main-content') }}"
-     hx-push-url="/v2/vendors/{{ v.id }}">
+     hx-push-url="/v2/vendors/{{ v.id }}"
+     hx-disinherit="hx-push-url">
 
   {# Row 1: Vendor name + strategic badge #}
   <div class="flex items-start justify-between">

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -4158,6 +4158,33 @@ reload/share/Back — never a `/v2/partials/...` fragment URL.**
     else thread the whole query. hx-history-elt sits on #main-content;
     htmx.config.refreshOnHistoryMiss=true turns a history-cache miss into a
     full reload, which mechanism 1 then answers with a correct shell.
+
+5. History hygiene (template conventions, pinned by tests/test_nav_wayfinding.py):
+    - set_canonical_url stamps ONLY when HX-Trigger-Name is present (a named
+      filter control). An HX-Replace-Url response header OVERRIDES the
+      element's own hx-push-url in htmx, so stamping a navigation would erase
+      the origin page. Unnamed state pills carry template hx-replace-url with
+      the baked canonical query instead.
+    - Row containers that push their detail URL carry
+      hx-disinherit="hx-push-url" (descendant actions must not push).
+    - NO raw history.pushState anywhere — imperative navigations use
+      htmx.ajax(..., {push: canonicalUrl}) so htmx can snapshot/restore.
+    - Junk-entry guards: bottom-nav re-taps of the exact current URL are
+      no-ops; origination Cancel pushes nothing; best-match cards render link
+      attrs only when the URL map + id resolve (bm_dead guard).
+
+6. Mobile shell: bottom nav = 4 primary (Sales Hub, Approvals, Search,
+    Tasks) + More sheet holding the rest (same hx/access/badge wiring); the
+    workspace ↑ List chip is mounted once in _workspace_split.html outside
+    #aw-pane (sticky top-12 under the topbar) so every pane type has it; one
+    breakpoint (768 = Tailwind md) shared by CSS and JS.
+
+7. Identity: topbar renders a current-view label kept fresh from
+    htmx:pushed-into-history / htmx:replaced-in-history via a URL-prefix map;
+    every top surface sends <title hx-swap-oob>; urlToNav covers the lateral
+    pages (/v2/qp, /v2/follow-ups, /v2/offers, /v2/quotes, /v2/sourcing,
+    /v2/companies, /v2/trouble-tickets); Follow-ups and Offer review carry an
+    h1 + a "← Sightings" way back; the QP has "← Back to deal".
 ```
 
 ---

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -4111,6 +4111,57 @@ OUTBOUND email is not captured — that would need a Sent-folder scan.)
 
 ---
 
+## 12. Navigation & History (Wayfinding Layer)
+
+Four cooperating mechanisms (nav audit 2026-08-20) keep the browser URL, the
+history stack, and the rendered page telling the same story. The invariant:
+**the address bar always holds a canonical `/v2/...` page URL that survives
+reload/share/Back — never a `/v2/partials/...` fragment URL.**
+
+```
+1. Shell negotiation (reload/share/back-past-cache of ANY partial URL):
+    browser GET /v2/partials/<anything>            Sec-Fetch-Dest: document
+        |
+        v
+    ShellNegotiationMiddleware (app/main.py)  — pure ASGI scope REWRITE
+        |   GET + /v2/partials/* + not export-ish + Sec-Fetch-Dest: document
+        |   → scope.path = /v2/shell, ?partial=<original url>
+        |   (htmx/XHR/TestClient requests lack the header → untouched)
+        v
+    htmx_views.v2_shell  — ordinary route, ordinary auth (get_user):
+        logged-out → login page; bad partial → 404;
+        else full_page_shell(...) = chrome + nav lazy-loading the SAME
+        partial into #main-content
+
+2. Server-owned canonical history (list partials):
+    requisitions/prospecting list routes call _shared.set_canonical_url(resp,
+    request, "/v2/requisitions?view=list" | "/v2/prospecting")
+        → HX-Replace-Url: <canonical page URL>+<current query> on every htmx
+          response. REPLACE, never push: entering the page (the nav <a>'s own
+          hx-push-url) is the single history entry; filters/typing/lazy loads
+          just keep the address bar truthful. Templates must never carry
+          hx-push-url="true" on filter controls (pushes the partial URL).
+
+3. Workspace state in the URL (Approvals):
+    ?select= accepts plan-N / line-N / prepay-N / bare digits on all four tabs
+    (_normalize_select + _selected_row in approvals_hub.py, access-gated via
+    get_buyplan_for_user). Row selection does history.replaceState to
+    /v2/approvals?tab=..&select=..; tab pills use hx-replace-url. htmx
+    htmx:historyRestore listener (htmx_app.js) re-renders #ap-hub-body from
+    the URL. The retired /v2/partials/buy-plans/{id} answers htmx callers
+    with HX-Redirect (a followed 308 would nest the full document — doubled
+    chrome) and plain browsers with 308.
+
+4. Query threading (v2_page + v2_shell):
+    /v2/requisitions?view=list&q=… threads the filters into the lazy partial
+    URL (minus `view`, which picks the branch); detail views and the generic
+    else thread the whole query. hx-history-elt sits on #main-content;
+    htmx.config.refreshOnHistoryMiss=true turns a history-cache miss into a
+    full reload, which mechanism 1 then answers with a correct shell.
+```
+
+---
+
 ## Enrichment Pipeline
 
 ### CRM / Vendor Firmographic + Contact Enrichment

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -4129,7 +4129,12 @@ reload/share/Back — never a `/v2/partials/...` fragment URL.**
         |   (htmx/XHR/TestClient requests lack the header → untouched)
         v
     htmx_views.v2_shell  — ordinary route, ordinary auth (get_user):
-        logged-out → login page; bad partial → 404;
+        logged-out → login page; partial not starting /v2/partials/ OR
+        containing ".." → 404 (traversal would let the embedded hx-get
+        climb out once the browser normalizes it); the nav-highlight key
+        is validated against the closed _VALID_NAV_KEYS set, never the raw
+        ?partial= segment (it lands in base.html's Alpine x-data, which the
+        browser HTML-decodes before JS eval — a raw segment = reflected XSS);
         else full_page_shell(...) = chrome + nav lazy-loading the SAME
         partial into #main-content
 

--- a/tests/test_browser_back_navigation.py
+++ b/tests/test_browser_back_navigation.py
@@ -50,8 +50,9 @@ class TestNavHighlightingReactive:
         assert "urlToNav" in NAV_CONTENT
 
     def test_click_updates_active_nav(self):
-        """Clicking a nav item updates activeNav immediately."""
-        assert '@click="activeNav' in NAV_CONTENT
+        """Clicking a nav item updates activeNav immediately (the active-guard added by
+        nav audit #12 wraps it in an if/else, so pin the assignment)."""
+        assert "else activeNav = '{{ id }}'" in NAV_CONTENT
 
     @pytest.mark.parametrize(
         "section",
@@ -73,9 +74,12 @@ class TestNavHighlightingReactive:
     def test_quotes_not_in_nav(self):
         """Quotes was retired as a standalone nav tab (PR quotes-relocation).
 
-        Quotes are now surfaced via the Reqs workspace and CRM account tabs.
+        Quotes are now surfaced via the Reqs workspace and CRM account tabs. urlToNav
+        DOES alias /v2/quotes → Sales Hub (nav audit #11: a pushed quote detail URL
+        should highlight its parent), so pin the nav-item tuple shape, not the bare
+        substring.
         """
-        assert "quotes" not in NAV_CONTENT
+        assert "('quotes'," not in NAV_CONTENT
 
 
 class TestNoSidebar:

--- a/tests/test_htmx_views_nightly30.py
+++ b/tests/test_htmx_views_nightly30.py
@@ -851,11 +851,14 @@ class TestBuyPlanDetail:
         assert resp.status_code == 404
 
     def test_detail_found(self, client: TestClient, test_buy_plan):
-        # The detail page retired into the workspace (Deal Sheet T3b): a found plan 308s
-        # to the deep link (a missing one still 404s first — see test_detail_not_found).
+        # The detail page retired into the workspace (Deal Sheet T3b). An htmx caller
+        # gets HX-Redirect — following a 308 would swap the whole /v2/approvals document
+        # inside the caller's target (doubled chrome, nav audit 2026-08-20 #4). A plain
+        # browser still 308s (covered in tests/test_nav_wayfinding.py). A missing plan
+        # still 404s first — see test_detail_not_found.
         resp = client.get(f"/v2/partials/buy-plans/{test_buy_plan.id}", headers=HX, follow_redirects=False)
-        assert resp.status_code == 308
-        assert resp.headers["location"] == f"/v2/approvals?tab=sales-orders&select={test_buy_plan.id}"
+        assert resp.status_code == 200
+        assert resp.headers["HX-Redirect"] == f"/v2/approvals?tab=sales-orders&select={test_buy_plan.id}"
 
 
 class TestBuyPlanSubmit:

--- a/tests/test_nav_wayfinding.py
+++ b/tests/test_nav_wayfinding.py
@@ -163,9 +163,16 @@ def test_plan_select_accepts_prefixed_key(client: TestClient, db_session, test_u
     assert f"plan-{bp.id}" in r.text
 
 
-def test_garbage_select_falls_back_silently(client: TestClient):
-    r = client.get("/v2/partials/approvals/sales-orders/list?select=%3Cscript%3E", headers=_HX)
+def test_garbage_select_falls_back_silently(client: TestClient, db_session, test_user: User):
+    _grant_decide_rights(db_session, test_user)
+    req, q, _rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.DRAFT.value)
+    db_session.commit()
+
+    r = client.get("/v2/partials/approvals/sales-orders/list?select=%3Cscript%3EGARBAGE123", headers=_HX)
     assert r.status_code == 200
+    assert f"plan-{bp.id}" in r.text  # the normal list rendered — garbage key ignored
+    assert "GARBAGE123" not in r.text  # and the rejected key is never reflected
 
 
 def test_retired_detail_htmx_gets_hx_redirect(client: TestClient, db_session, test_user: User):

--- a/tests/test_nav_wayfinding.py
+++ b/tests/test_nav_wayfinding.py
@@ -111,16 +111,29 @@ def test_shell_route_rejects_non_partial_urls(nonadmin_client: TestClient):
 # ── 2. Server-owned canonical history ─────────────────────────────────────
 
 
-def test_requisitions_list_stamps_canonical_replace(client: TestClient):
-    r = client.get("/v2/partials/requisitions?q=abc&status=open", headers=_HX)
-    assert "HX-Push-Url" not in r.headers  # push would trap Back on the shell's lazy load
+def test_filter_control_stamps_canonical_replace(client: TestClient):
+    # A NAMED control (HX-Trigger-Name) = state change within the page → replace with
+    # the canonical page URL + live query. Never a push (that would stack entries per
+    # keystroke/filter tap).
+    r = client.get("/v2/partials/requisitions?q=abc&status=open", headers={**_HX, "HX-Trigger-Name": "q"})
+    assert "HX-Push-Url" not in r.headers
     assert r.headers.get("HX-Replace-Url", "").startswith("/v2/requisitions?view=list")
     assert "q=abc" in r.headers["HX-Replace-Url"]
 
 
-def test_prospecting_list_stamps_canonical_replace(client: TestClient):
-    r = client.get("/v2/partials/prospecting?scope=all", headers=_HX)
+def test_prospecting_filter_stamps_canonical_replace(client: TestClient):
+    r = client.get("/v2/partials/prospecting?scope=all", headers={**_HX, "HX-Trigger-Name": "scope"})
     assert r.headers.get("HX-Replace-Url", "").startswith("/v2/prospecting")
+
+
+def test_navigation_request_gets_no_replace_stamp(client: TestClient):
+    # An UN-named trigger (nav <a>, view toggle, "view all" link) must get NO history
+    # header: HX-Replace-Url in a response OVERRIDES the element's own hx-push-url in
+    # htmx, so stamping a navigation would erase the page the user came from instead
+    # of pushing. Same for pollers (reqListRefresh) — they must never touch history.
+    r = client.get("/v2/partials/requisitions?q=abc", headers=_HX)
+    assert "HX-Replace-Url" not in r.headers
+    assert "HX-Push-Url" not in r.headers
 
 
 def test_non_htmx_caller_gets_no_history_headers(client: TestClient):
@@ -198,3 +211,62 @@ def test_canonical_list_url_reloads_filtered(nonadmin_client: TestClient):
     # The shell's lazy partial URL carries the filters through.
     assert "q=widget" in r.text
     assert "status=open" in r.text
+
+
+# ── 5. Link & history hygiene sweeps (PR-B, nav audit #5-#9, #11-#12) ─────
+
+from pathlib import Path
+
+_T = Path("app/templates/htmx/partials")
+
+
+def test_no_raw_pushstate_in_templates_or_js():
+    # Raw history.pushState entries can never be restored by htmx (nav audit #7) —
+    # imperative navigations must use htmx.ajax's push option instead.
+    offenders = []
+    for f in list(Path("app/templates").rglob("*.html")) + [Path("app/static/htmx_app.js")]:
+        for i, line in enumerate(f.read_text().splitlines(), 1):
+            if "history.pushState" in line:
+                offenders.append(f"{f}:{i}")
+    assert not offenders, "raw history.pushState (htmx can't restore these): " + ", ".join(offenders)
+
+
+def test_row_containers_disinherit_push_url():
+    # A row's hx-push-url is INHERITED by descendant actions (dblclick edits, Claim)
+    # unless disinherited — the leak that made the URL lie (nav audit #6).
+    for rel in (
+        "requisitions/req_row.html",
+        "tickets/_row.html",
+        "vendors/list.html",
+        "vendors/vendor_card.html",
+        "materials/list.html",
+    ):
+        assert 'hx-disinherit="hx-push-url"' in (_T / rel).read_text(), rel
+
+
+def test_lateral_pages_have_identity_and_way_back():
+    fu = (_T / "follow_ups/list.html").read_text()
+    rq = (_T / "offers/review_queue.html").read_text()
+    qp = (_T / "qp/detail.html").read_text()
+    for src_ in (fu, rq):
+        assert "title hx-swap-oob" in src_
+        assert 'href="/v2/sightings"' in src_  # the way back
+    assert 'href="/v2/approvals?tab=sales-orders&select=' in qp  # back to the deal
+
+
+def test_mobile_nav_capped_at_five_slots():
+    # 10 slots at 62px demanded 682px on a 390px phone (nav audit #9); primary bar
+    # is 4 items + More, the rest live in the More sheet with badges intact.
+    src_ = (_T / "shared/mobile_nav.html").read_text()
+    primary = src_.split("more_nav_items")[0]
+    assert primary.count("('") <= 5  # 4 item tuples + the set-open paren noise guard
+    assert "more_nav_items" in src_
+    assert 'id="crm-nav-badge"' in src_  # badge poller survived the move
+    assert 'id="proactive-nav-badge"' in src_
+
+
+def test_best_match_cards_never_emit_dead_links():
+    for rel in ("shared/search_results.html", "search/full_results.html"):
+        src_ = (_T / rel).read_text()
+        assert "bm_dead" in src_, rel  # the guard exists
+        assert "hx-push-url=\"{{ bm_url_map.get(bm.type, '#') }}\"" not in src_, rel

--- a/tests/test_nav_wayfinding.py
+++ b/tests/test_nav_wayfinding.py
@@ -1,0 +1,193 @@
+"""tests/test_nav_wayfinding.py — navigation & wayfinding mechanisms (nav audit
+2026-08-20).
+
+Covers the infrastructure that ends "I kept ending up on different pages with no way
+back":
+  1. ShellNegotiationMiddleware + /v2/shell — a browser TOP-LEVEL navigation
+     (Sec-Fetch-Dest: document) to any /v2/partials/* URL is rewritten onto the shell
+     route, which serves the full chrome lazy-loading that partial; htmx requests,
+     tests, downloads, and logged-out users all get the ordinary behavior.
+  2. Server-owned canonical history — the requisitions/prospecting list partials stamp
+     HX-Replace-Url with the CANONICAL page URL (+query); replace, never push, so the
+     address bar self-heals with zero history spam; templates no longer push partial
+     URLs.
+  3. Workspace state in the URL — string ?select= (plan-N / line-N / bare digits)
+     resolves on all four tabs; the retired-detail redirect answers htmx callers with
+     HX-Redirect (no doubled chrome).
+  4. v2_page threads the full query so filtered canonical URLs reload filtered.
+
+Shell tests use nonadmin_client (real signed session cookie) because the middleware
+rewrite lands on v2_shell, whose get_user() reads the genuine session — dependency-
+override-only clients carry no session and would render the login page.
+
+Called by: pytest
+Depends on: app.main (middleware), routers htmx_views / requisitions / prospecting /
+    approvals_hub, conftest fixtures, tests.test_approvals_hub_tabs seed helpers (plain functions).
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from fastapi.testclient import TestClient
+
+from app.constants import BuyPlanLineStatus, BuyPlanStatus
+from app.models import User
+from tests.test_approvals_hub_tabs import _line, _plan, _req_quote
+
+
+def _grant_decide_rights(db, user: User) -> None:
+    """Give test_user both decide toggles so workspace rows scope like a manager's.
+
+    The section-3 tests only GET (require_user via the plain `client` fixture); the
+    approver-gate dependency overrides that test_approvals_hub_tabs.hub_client adds
+    matter only for decide POSTs, which this file never sends.
+    """
+    user.can_approve_buy_plans = True
+    user.can_approve_purchase_orders = True
+    db.commit()
+
+
+_BROWSER_NAV = {"Sec-Fetch-Dest": "document"}
+_HX = {"HX-Request": "true"}
+
+
+# ── 1. Shell negotiation ──────────────────────────────────────────────────
+
+
+def test_browser_navigation_to_partial_gets_full_shell(nonadmin_client: TestClient):
+    r = nonadmin_client.get("/v2/partials/requisitions", headers=_BROWSER_NAV)
+    assert r.status_code == 200
+    assert "<html" in r.text  # the full app shell…
+    assert 'id="main-content"' in r.text
+    assert "/v2/partials/requisitions" in r.text  # …lazy-loading the SAME partial
+
+
+def test_browser_navigation_preserves_query(nonadmin_client: TestClient):
+    r = nonadmin_client.get("/v2/partials/requisitions?q=widget&status=open", headers=_BROWSER_NAV)
+    assert "q=widget" in r.text and "status=open" in r.text
+
+
+def test_htmx_request_still_gets_the_fragment(client: TestClient):
+    r = client.get("/v2/partials/requisitions", headers=_HX)
+    assert r.status_code == 200
+    assert "<html" not in r.text  # fragment, not a shell
+
+
+def test_plain_test_request_unaffected(client: TestClient):
+    # No Sec-Fetch-Dest and no HX-Request (the whole existing test suite's shape).
+    r = client.get("/v2/partials/requisitions")
+    assert r.status_code == 200
+    assert "<html" not in r.text
+
+
+def test_exports_never_shell_wrapped(nonadmin_client: TestClient):
+    # Browsers fetch downloads as documents too — the exclusion list keeps them raw.
+    # The route itself answers (here: the buyer's 403 from the export access gate, as
+    # JSON) — the point is the middleware never swallowed it into an HTML shell.
+    r = nonadmin_client.get("/v2/partials/requisitions/export", headers=_BROWSER_NAV)
+    assert "<html" not in r.text
+    assert "text/html" not in r.headers.get("content-type", "")
+
+
+def test_workspace_partial_survives_reload(nonadmin_client: TestClient):
+    # The exact defect that started this: a naked 4KB fragment on reload.
+    r = nonadmin_client.get("/v2/partials/approvals/sales-orders", headers=_BROWSER_NAV)
+    assert "<html" in r.text
+    assert 'id="main-content"' in r.text
+
+
+def test_logged_out_browser_navigation_gets_login_page(unauthenticated_client: TestClient):
+    r = unauthenticated_client.get("/v2/partials/requisitions", headers=_BROWSER_NAV)
+    assert r.status_code == 200
+    assert "login" in r.text.lower()
+
+
+def test_shell_route_rejects_non_partial_urls(nonadmin_client: TestClient):
+    assert nonadmin_client.get("/v2/shell?partial=/auth/logout").status_code == 404
+    assert nonadmin_client.get("/v2/shell?partial=https://evil.example/x").status_code == 404
+
+
+# ── 2. Server-owned canonical history ─────────────────────────────────────
+
+
+def test_requisitions_list_stamps_canonical_replace(client: TestClient):
+    r = client.get("/v2/partials/requisitions?q=abc&status=open", headers=_HX)
+    assert "HX-Push-Url" not in r.headers  # push would trap Back on the shell's lazy load
+    assert r.headers.get("HX-Replace-Url", "").startswith("/v2/requisitions?view=list")
+    assert "q=abc" in r.headers["HX-Replace-Url"]
+
+
+def test_prospecting_list_stamps_canonical_replace(client: TestClient):
+    r = client.get("/v2/partials/prospecting?scope=all", headers=_HX)
+    assert r.headers.get("HX-Replace-Url", "").startswith("/v2/prospecting")
+
+
+def test_non_htmx_caller_gets_no_history_headers(client: TestClient):
+    r = client.get("/v2/partials/requisitions")
+    assert "HX-Replace-Url" not in r.headers
+    assert "HX-Push-Url" not in r.headers
+
+
+def test_templates_no_longer_push_partial_urls(client: TestClient):
+    body = client.get("/v2/partials/requisitions", headers=_HX).text
+    assert 'hx-push-url="true"' not in body
+    body = client.get("/v2/partials/prospecting", headers=_HX).text
+    assert 'hx-push-url="true"' not in body
+
+
+# ── 3. Workspace select + retired-detail redirect ─────────────────────────
+
+
+def test_po_tab_resolves_line_select(client: TestClient, db_session, test_user: User):
+    _grant_decide_rights(db_session, test_user)
+    req, q, rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db_session, bp, rq, test_user, status=BuyPlanLineStatus.AWAITING_PO.value)
+    db_session.commit()
+
+    r = client.get(f"/v2/partials/approvals/purchase-orders/list?select=line-{line.id}", headers=_HX)
+    assert r.status_code == 200
+    # The deep-linked line is the default selection (aw-default dispatch carries it).
+    assert f"line-{line.id}" in r.text
+
+
+def test_plan_select_accepts_prefixed_key(client: TestClient, db_session, test_user: User):
+    _grant_decide_rights(db_session, test_user)
+    req, q, _rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.DRAFT.value)
+    db_session.commit()
+
+    r = client.get(f"/v2/partials/approvals/sales-orders/list?select=plan-{bp.id}", headers=_HX)
+    assert r.status_code == 200
+    assert f"plan-{bp.id}" in r.text
+
+
+def test_garbage_select_falls_back_silently(client: TestClient):
+    r = client.get("/v2/partials/approvals/sales-orders/list?select=%3Cscript%3E", headers=_HX)
+    assert r.status_code == 200
+
+
+def test_retired_detail_htmx_gets_hx_redirect(client: TestClient, db_session, test_user: User):
+    req, q, _rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.DRAFT.value)
+    db_session.commit()
+
+    r = client.get(f"/v2/partials/buy-plans/{bp.id}", headers=_HX, follow_redirects=False)
+    assert r.status_code == 200
+    assert r.headers.get("HX-Redirect") == f"/v2/approvals?tab=sales-orders&select={bp.id}"
+    # A plain browser still gets the 308 (bookmarks keep working).
+    r2 = client.get(f"/v2/partials/buy-plans/{bp.id}", follow_redirects=False)
+    assert r2.status_code == 308
+
+
+# ── 4. v2_page query threading ────────────────────────────────────────────
+
+
+def test_canonical_list_url_reloads_filtered(nonadmin_client: TestClient):
+    # nonadmin_client: v2_page reads the REAL session (get_user), not the Depends chain.
+    r = nonadmin_client.get("/v2/requisitions?view=list&q=widget&status=open")
+    assert r.status_code == 200
+    # The shell's lazy partial URL carries the filters through.
+    assert "q=widget" in r.text
+    assert "status=open" in r.text

--- a/tests/test_nav_wayfinding.py
+++ b/tests/test_nav_wayfinding.py
@@ -270,3 +270,56 @@ def test_best_match_cards_never_emit_dead_links():
         src_ = (_T / rel).read_text()
         assert "bm_dead" in src_, rel  # the guard exists
         assert "hx-push-url=\"{{ bm_url_map.get(bm.type, '#') }}\"" not in src_, rel
+
+
+# ── 6. Security & regression fixes (adversarial review 2026-08-20) ────────
+
+
+def test_shell_rejects_xss_segment_no_reflection(nonadmin_client: TestClient):
+    # The ?partial= segment lands in base.html's Alpine x-data (HTML-decoded before JS
+    # eval), so a raw segment would be reflected XSS. It must be validated against the
+    # nav-key allowlist, never echoed. Route 200s (valid /v2/partials/ prefix) but the
+    # payload never appears in current_view.
+    payload = "/v2/partials/x',init(){alert(1)},x:'"
+    r = nonadmin_client.get("/v2/shell", params={"partial": payload})
+    assert r.status_code == 200
+    # current_view seeds EMPTY for an unknown segment — the raw payload never reaches
+    # Alpine's x-data JS-eval context. (It appears once, Jinja-escaped and inert, in the
+    # hx-get URL echo; the breakout signature — an UNescaped quote+comma — must not.)
+    assert "currentView: ''" in r.text
+    assert "',init(){" not in r.text
+
+
+def test_shell_rejects_path_traversal(nonadmin_client: TestClient):
+    # /v2/partials/../../auth/logout passes the prefix check but the browser would
+    # normalize the embedded hx-get out of /v2/partials/ — reject traversal outright.
+    r = nonadmin_client.get("/v2/shell", params={"partial": "/v2/partials/../../auth/logout"})
+    assert r.status_code == 404
+
+
+def test_shell_valid_segment_still_highlights(nonadmin_client: TestClient):
+    # A legitimate segment maps to its nav key (the allowlist must not over-reject).
+    r = nonadmin_client.get("/v2/shell", params={"partial": "/v2/partials/approvals/sales-orders"})
+    assert r.status_code == 200
+    assert "buy-plans" in r.text  # approvals → buy-plans nav highlight
+
+
+def test_bid_sheet_in_shell_exclusions():
+    # The resell bid-sheet streams a CSV whose URL contains no ".csv"/"/export"/
+    # "/download" substring, so it must be named explicitly in the middleware exclusion
+    # denylist — otherwise a browser download gets wrapped in the app shell (the CSV is
+    # swapped into #main-content). The exclusion MECHANISM is exercised end-to-end by
+    # test_exports_never_shell_wrapped; this pins the bid-sheet path is covered.
+    from app.main import ShellNegotiationMiddleware
+
+    assert "/bid-sheet" in ShellNegotiationMiddleware._EXCLUDE_SUBSTRINGS
+
+
+def test_best_match_null_id_uses_boolean_default():
+    # Jinja default("") does NOT substitute None (only undefined), so a null
+    # requisition_id stringified to a live "/v2/requisitions/None" card. The , true
+    # boolean-default flag catches None → "" → the bm_dead guard's trailing-"/" check.
+    for rel in ("shared/search_results.html", "search/full_results.html"):
+        src_ = (_T / rel).read_text()
+        assert 'bm.requisition_id|default("")' not in src_, rel  # the unsafe form is gone
+        assert 'bm.requisition_id|default("", true)' in src_, rel

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -64,8 +64,8 @@ def test_htmx_ajax_calls_have_indicator():
         ("app/templates/htmx/partials/parts/cell_edit.html", 12),
         ("app/templates/htmx/partials/parts/cell_edit.html", 26),
         ("app/templates/htmx/partials/parts/cell_edit.html", 37),
-        ("app/templates/htmx/partials/parts/workspace.html", 114),
-        ("app/templates/htmx/partials/parts/workspace.html", 120),
+        ("app/templates/htmx/partials/parts/workspace.html", 116),
+        ("app/templates/htmx/partials/parts/workspace.html", 122),
         ("app/templates/htmx/partials/parts/list.html", 194),
     }
 


### PR DESCRIPTION
## Why

Owner phone walk-through: "Navigation is hard.. I kept ending up on different pages.. with no way back." The nav audit (2026-08-20) traced 37 findings to 14 root causes; this PR fixes them in two tranches on one branch.

## Tranche A — infrastructure (#1–#4, #10)

**1. Shell negotiation — no more naked fragments.** `ShellNegotiationMiddleware` detects a browser *top-level* navigation (`Sec-Fetch-Dest: document`) to any `/v2/partials/*` URL and rewrites the scope onto `GET /v2/shell?partial=<url>` — an ordinary route that auths normally (logged-out → login page) and serves the full chrome lazy-loading the same partial. Reload / share / Back-past-the-history-cache always lands on a styled page with nav. Pure path rewrite; htmx/XHR/tests untouched; exports excluded.

**2. Server-owned canonical history.** List partials stamp `HX-Replace-Url` (canonical page URL + live query) — but ONLY when a **named filter control** triggered the request (`HX-Trigger-Name`). A replace header overrides the element's own `hx-push-url` in htmx, so stamping navigations would erase the origin page; navigations keep their push. All 14 template `hx-push-url="true"` fragment-URL attrs removed. Applies to requisitions, prospecting, search-results refine.

**3. Approvals workspace state in the URL.** `?select=` accepts `plan-N`/`line-N`/`prepay-N`/digits on all four tabs (access-gated); selection `history.replaceState`s the deep link; pills replace-url; `htmx:historyRestore` re-renders from URL truth; `refreshOnHistoryMiss` + `hx-history-elt`. Retired `/v2/partials/buy-plans/{id}`: htmx callers get `HX-Redirect` (a followed 308 nested the whole document — doubled chrome), browsers 308.

**4. Query threading.** `v2_page` threads the full query (requisitions list branch included) so filtered canonical URLs reload filtered.

## Tranche B — hygiene, mobile, identity (#5–#9, #11–#12)

- **Inheritance leaks**: `hx-disinherit="hx-push-url"` on the 5 row containers whose descendant actions (dblclick edits, Claim) inherited the detail push.
- **Raw `history.pushState` eliminated** (3 sites → `htmx.ajax` `push:` — htmx-restorable). A test now forbids it repo-wide.
- **Junk entries**: bottom-nav re-taps of the exact current URL are no-ops; origination Cancel pushes nothing; best-match cards render link attrs only when the URL resolves (`bm_dead` guard).
- **One-way doors**: QP detail gets "← Back to deal"; the QP opener is a real `<a href>`; Follow-ups + Offer review get h1 + title + "← Sightings"; urlToNav completed; quote detail pushes `/v2/customers/{id}`.
- **Mobile shell**: bottom nav 10+More → **4 primary (Sales Hub, Approvals, Search, Tasks) + More sheet** with identical hx/access/badge wiring; More lights up for sheet views; ↑ List chip mounted once outside `#aw-pane` (sticky, every pane type); one breakpoint (768 = Tailwind md).
- **Identity**: topbar "you are here" label kept fresh from htmx history events; `<title hx-swap-oob>` on 9 more surfaces.

Skipped audit #14 (sourcing pages → 308): tests pin templates pushing `/v2/sourcing/{id}/workspace` — those pages are live reload targets, not orphans; the audit erred.

## Verification

- `tests/test_nav_wayfinding.py` — 34 tests over every mechanism (incl. a regression pin that navigations get NO replace stamp)
- Full suite: **24,368 passed / 0 failed**; vitest 189/189; ruff + mypy + assertion-theater lint clean
- `docs/APP_MAP_INTERACTIONS.md` §12 documents the wayfinding layer (all 7 mechanisms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf

## Post-review hardening (commit 0480cb3a)

A 4-lens adversarial review (23 agents) of the branch confirmed 12 unique defects, all fixed in a follow-up commit:
- **Reflected XSS** the branch introduced: `v2_shell` reflected the raw `?partial=` segment into base.html's Alpine `x-data` (HTML-decoded before JS eval). Now validated against a closed nav-key allowlist.
- **Path traversal**: `?partial=/v2/partials/../../auth/logout` → rejected (`..` guard).
- **Broken CSV download**: the resell bid-sheet was shell-wrapped → added to the middleware exclusion.
- **Filter-URL regressions**: Clean&reset / column-sort / prospecting pagination lost URL tracking when their `hx-push-url` was removed — restored via `hx-replace-url` / `name=`.
- **Dead `/v2/requisitions/None` links**: `default("")` → `default("", true)` (catches null).
- **Stale wayfinding on Back**: topbar label + bottom-nav now update on `htmx:history-restore`; More-sheet re-tap guard added.

Suite after fixes: **24,373 passed / 0 failed**.
