### PR TITLE
Rename create action "New Sales Order" → "New Buy Plan"

### DIFF
--- a/app/templates/htmx/partials/approvals/_pane_blank.html
+++ b/app/templates/htmx/partials/approvals/_pane_blank.html
@@ -8,5 +8,5 @@
   Select an item from the list — or start a
   <button class="text-accent-600 font-medium mx-1"
           hx-get="/v2/partials/buy-plans/sales-orders/new?embed=aw"
-          hx-target="#aw-pane" hx-swap="innerHTML" hx-indicator="#aw-pane-ind">new sales order</button>.
+          hx-target="#aw-pane" hx-swap="innerHTML" hx-indicator="#aw-pane-ind">new buy plan</button>.
 </div>

--- a/app/templates/htmx/partials/approvals/_sales_order_new.html
+++ b/app/templates/htmx/partials/approvals/_sales_order_new.html
@@ -14,7 +14,7 @@
 #}
 <div id="so-origination" class="{{ 'p-4' if embed == 'aw' else 'page-fluid' }}">
   <div class="flex items-center justify-between mb-3">
-    <h2 class="{{ 'text-base font-semibold text-gray-900' if embed == 'aw' else 'h2' }}">New Sales Order</h2>
+    <h2 class="{{ 'text-base font-semibold text-gray-900' if embed == 'aw' else 'h2' }}">New Buy Plan</h2>
     {% if embed == 'aw' %}
     <button hx-get="/v2/partials/approvals/pane/blank" hx-target="#aw-pane" hx-swap="innerHTML"
             class="btn btn-secondary btn-sm">Cancel</button>

--- a/app/templates/htmx/partials/approvals/_workspace_list.html
+++ b/app/templates/htmx/partials/approvals/_workspace_list.html
@@ -79,8 +79,8 @@
      and the pane becomes its sheet. #}
   <a hx-get="/v2/partials/buy-plans/sales-orders/new?embed=aw" hx-target="#aw-pane"
      hx-swap="innerHTML" hx-indicator="#aw-pane-ind"
-     class="btn-primary btn-sm flex-shrink-0 cursor-pointer whitespace-nowrap" title="Start a new sales order">
-    New sales order
+     class="btn-primary btn-sm flex-shrink-0 cursor-pointer whitespace-nowrap" title="Start a new buy plan">
+    New buy plan
   </a>
   {% endif %}
   {# Export CSV — a REAL browser download (hx-boost=false opts out of nav-boost). #}

--- a/tests/test_buy_plan_epic.py
+++ b/tests/test_buy_plan_epic.py
@@ -100,7 +100,7 @@ def test_approvals_buy_plan_list_has_new_sales_order_link(client: TestClient):
     T3)."""
     resp = client.get("/v2/partials/approvals/buy-plans/list")
     assert resp.status_code == 200
-    assert "New sales order" in resp.text
+    assert "New buy plan" in resp.text
     assert 'hx-get="/v2/partials/buy-plans/sales-orders/new?embed=aw"' in resp.text
     assert 'hx-target="#aw-pane"' in resp.text
 

--- a/tests/test_sales_order_origination.py
+++ b/tests/test_sales_order_origination.py
@@ -224,7 +224,7 @@ def test_builder_labels_say_sales_order(nonadmin_client: TestClient, so_setup):
     req, _requirement, _offer = so_setup
     r = nonadmin_client.get("/v2/partials/buy-plans/sales-orders/new")
     assert r.status_code == 200
-    assert "New Sales Order" in r.text  # heading
+    assert "New Buy Plan" in r.text  # heading
     assert "Start" in r.text  # per-row primary action (creates the draft directly)
 
 


### PR DESCRIPTION
## Why

Sales orders live in the ERP (Acctivate); AVAIL owns the **buy plan** and only stores the SO# as a reference. The origination action reading "New Sales Order" implied AVAIL cuts the SO — it doesn't.

## What

Renamed the three user-facing labels on the create action to **New Buy Plan**:
- the origination heading (`_sales_order_new.html`)
- the work-list button + its tooltip (`_workspace_list.html`)
- the blank-pane inline link (`_pane_blank.html`)

Left unchanged (not a model rename, and not asked for): the route, the template filename, the code comments, and the **"Sales Orders" workspace tab** (a lens on the SO-rooted pipeline). The SO# reference field keeps its name.

Full suite **24,374 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf