### PR TITLE
AI-assisted qualification & risk screening (offer + buy-plan)

### DIFF
--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -482,7 +482,13 @@ def _sheet_ctx(db: Session, user: User, bp: BuyPlan, *, is_sourcing: bool) -> di
                         "best": best_cost is not None
                         and off.unit_price is not None
                         and float(off.unit_price) == best_cost,
-                        "flags": len(ai_flags_by_line.get(ln.id, [])) if ln else 0,
+                        # Count only RISK flags (warning/critical) for the rose chip —
+                        # info signals (better_offer/geo_mismatch) aren't risk.
+                        "flags": (
+                            sum(1 for f in ai_flags_by_line.get(ln.id, []) if f["severity"] in ("warning", "critical"))
+                            if ln
+                            else 0
+                        ),
                     }
                 )
             sell = next((float(ln.unit_sell) for ln in group_lines if ln.unit_sell is not None), None)

--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -421,10 +421,21 @@ def _sheet_ctx(db: Session, user: User, bp: BuyPlan, *, is_sourcing: bool) -> di
     """
     from ...constants import OfferStatus
     from ...models import Offer, Requirement
+    from ...services.buyplan_builder import generate_ai_flags
     from ...services.buyplan_workflow import _owns_plan, can_edit_plan
     from ...services.stale_guard import stale_token
 
     lines = bp.lines or []
+
+    # Compute the AI flags FRESH on every render — the stored bp.ai_flags is a build-time
+    # snapshot never refreshed by workspace edits/re-picks, so reading it here would show
+    # stale flags with orphaned line ids at the approval moment. generate_ai_flags is
+    # read-only (returns a list, persists nothing) and re-queries the live lines/offers.
+    ai_flags = generate_ai_flags(bp, db)
+    ai_flags_by_line: dict[int, list[dict]] = {}
+    for _f in ai_flags:
+        if _f.get("line_id"):
+            ai_flags_by_line.setdefault(_f["line_id"], []).append(_f)
     can_edit = can_edit_plan(user, bp)
     is_owner = _owns_plan(user, bp)
 
@@ -471,6 +482,7 @@ def _sheet_ctx(db: Session, user: User, bp: BuyPlan, *, is_sourcing: bool) -> di
                         "best": best_cost is not None
                         and off.unit_price is not None
                         and float(off.unit_price) == best_cost,
+                        "flags": len(ai_flags_by_line.get(ln.id, [])) if ln else 0,
                     }
                 )
             sell = next((float(ln.unit_sell) for ln in group_lines if ln.unit_sell is not None), None)
@@ -512,6 +524,9 @@ def _sheet_ctx(db: Session, user: User, bp: BuyPlan, *, is_sourcing: bool) -> di
         # UNKNOWN to it — unknown lines are left untouched, never silently removed.
         "picker_known_line_ids": sorted(rendered_line_ids),
         "readiness_missing": [r for r in checklist if not r["ok"]],
+        # Fresh-computed AI flags for the review header strip + per-line counts.
+        "ai_flags": ai_flags,
+        "ai_flags_by_line": ai_flags_by_line,
     }
 
 

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -221,10 +221,29 @@ RFQ_DATASHEETS_DROPPED_HEADER = "X-RFQ-Datasheets-Dropped"  # oversized datashee
 
 def _render_offers_panel(request: Request, requirement: Requirement, db: Session) -> HTMLResponse:
     """Render the part-centric Offers panel for swap into #sightings-offers-panel."""
+    from ..services.offer_language_screen import screen_offer_language
+    from ..services.sourcing_leads import vendor_safety_for_card
+
+    part_offers = part_offers_for(requirement, db)
+    # Offer Pre-check: the SAME vendor-safety computation the buy-plan flags use, so an
+    # offer and its plan never read differently. Deduped per vendor to avoid an N+1
+    # across the offer list; only vendors that appear get computed.
+    _safety_by_vendor: dict[int, dict] = {}
+    safety_by_offer: dict[int, dict] = {}
+    for o in part_offers:
+        vcid = o.vendor_card_id
+        if vcid is None:
+            continue
+        if vcid not in _safety_by_vendor:
+            _safety_by_vendor[vcid] = vendor_safety_for_card(db, o.vendor_card)
+        safety_by_offer[o.id] = _safety_by_vendor[vcid]
+    language_by_offer = {o.id: screen_offer_language(o) for o in part_offers}
     ctx = {
         "request": request,
         "requirement": requirement,
-        "part_offers": part_offers_for(requirement, db),
+        "part_offers": part_offers,
+        "safety_by_offer": safety_by_offer,
+        "language_by_offer": language_by_offer,
     }
     resp = template_response("htmx/partials/sightings/offers_panel.html", ctx)
     resp.headers["X-Rendered-Req-Id"] = str(requirement.id)

--- a/app/services/buyplan_builder.py
+++ b/app/services/buyplan_builder.py
@@ -587,11 +587,52 @@ def generate_ai_flags(plan: BuyPlan, db: Session, customer_region: str | None = 
                 }
             )
 
+        # ── Vendor risk (shared with the offer Pre-check — one computation, so the
+        #    same vendor can't read differently on the offer vs here). Surfaces only the
+        #    high-signal caution codes as a flag; the full band lives on the Pre-check.
+        if offer is not None:
+            _check_vendor_risk(line, offer, flags, db)
+
     # ── Quantity gap check (plan-level)
     if plan.lines:
         _check_quantity_gaps(plan, flags, db)
 
     return flags
+
+
+# Vendor caution codes worth raising as a buy-plan flag, with their severity. A
+# standing do-not-contact / blacklist is critical; cancellation/feedback history warns.
+_VENDOR_RISK_CODES: dict[str, str] = {
+    "internal_do_not_contact_history": "critical",
+    "buyer_marked_do_not_contact": "critical",
+    "high_cancellation_rate": "warning",
+    "repeated_bad_feedback": "warning",
+}
+
+
+def _check_vendor_risk(line: BuyPlanLine, offer: Offer, flags: list[dict], db: Session):
+    """Append a vendor_risk flag when the line's vendor carries high-signal caution
+    codes.
+
+    Reads the SHARED vendor-safety computation (sourcing_leads.vendor_safety_for_card)
+    so the flag can never disagree with the offer Pre-check for the same vendor.
+    """
+    from .sourcing_leads import vendor_safety_for_card
+
+    vc = offer.vendor_card or (db.get(VendorCard, offer.vendor_card_id) if offer.vendor_card_id else None)
+    caution = vendor_safety_for_card(db, vc)["caution"]
+    hits = [c for c in caution if c in _VENDOR_RISK_CODES]
+    if not hits:
+        return
+    severity = "critical" if any(_VENDOR_RISK_CODES[c] == "critical" for c in hits) else "warning"
+    flags.append(
+        {
+            "type": "vendor_risk",
+            "severity": severity,
+            "line_id": line.id,
+            "message": "Vendor risk: " + ", ".join(c.replace("_", " ") for c in hits),
+        }
+    )
 
 
 def _check_better_offer(

--- a/app/services/buyplan_builder.py
+++ b/app/services/buyplan_builder.py
@@ -566,9 +566,10 @@ def generate_ai_flags(plan: BuyPlan, db: Session, customer_region: str | None = 
                 }
             )
 
-        # ── Better offer available check
+        # ── Better offer available check + below-market ("too cheap") risk check
         if offer and line.requirement_id:
             _check_better_offer(line, offer, better_pct, flags, db)
+            _check_below_market(line, offer, flags, db)
 
         # ── Geography mismatch check
         if offer and customer_region:
@@ -592,6 +593,15 @@ def generate_ai_flags(plan: BuyPlan, db: Session, customer_region: str | None = 
         #    high-signal caution codes as a flag; the full band lives on the Pre-check.
         if offer is not None:
             _check_vendor_risk(line, offer, flags, db)
+
+        # ── Offer communication red flags (deterministic language/contradiction screen)
+        if offer is not None:
+            from .offer_language_screen import screen_offer_language
+
+            for lf in screen_offer_language(offer):
+                flags.append(
+                    {"type": "offer_language", "severity": "warning", "line_id": line.id, "message": lf["note"]}
+                )
 
     # ── Quantity gap check (plan-level)
     if plan.lines:
@@ -674,6 +684,50 @@ def _check_better_offer(
                 }
             )
             break  # one flag per line is enough
+
+
+_BELOW_MARKET_PCT = 25.0  # picked offer this % under the median of sibling offers → "too cheap"
+
+
+def _check_below_market(line: BuyPlanLine, selected: Offer, flags: list[dict], db: Session):
+    """Flag an offer priced SUSPICIOUSLY BELOW the market of its sibling offers.
+
+    The counterfeit-relevant "too good to be true" signal — distinct from better_offer
+    (which flags a cheaper alternative you did NOT pick). Uses only the active offers
+    already recorded for this requirement: no market sweep, no new data. Needs a real
+    cluster (>=2 comparators) before it will call a "market".
+    """
+    if not selected.unit_price or float(selected.unit_price) <= 0:
+        return
+    others = sorted(
+        float(o.unit_price)
+        for o in db.query(Offer)
+        .filter(
+            Offer.requirement_id == line.requirement_id,
+            Offer.status == OfferStatus.ACTIVE.value,
+            Offer.id != selected.id,
+        )
+        .all()
+        if o.unit_price and float(o.unit_price) > 0
+    )
+    if len(others) < 2:
+        return
+    n = len(others)
+    median = others[n // 2] if n % 2 else (others[n // 2 - 1] + others[n // 2]) / 2
+    selected_price = float(selected.unit_price)
+    if median > 0 and selected_price < median * (1 - _BELOW_MARKET_PCT / 100):
+        pct = round((1 - selected_price / median) * 100, 1)
+        flags.append(
+            {
+                "type": "below_market",
+                "severity": "warning",
+                "line_id": line.id,
+                "message": (
+                    f"Priced {pct}% below the median of {n} other offers "
+                    f"(${selected_price:.4f} vs ${median:.4f}) — verify authenticity"
+                ),
+            }
+        )
 
 
 def _check_geo_mismatch(

--- a/app/services/buyplan_builder.py
+++ b/app/services/buyplan_builder.py
@@ -528,6 +528,10 @@ def generate_ai_flags(plan: BuyPlan, db: Session, customer_region: str | None = 
     """
     flags = []
     now = datetime.now(UTC)
+    # Memo so the vendor-safety computation (a DB round-trip via
+    # get_vendor_feedback_adjustment) runs once per distinct vendor, not once per line —
+    # this function is recomputed fresh on EVERY approval-pane render.
+    safety_memo: dict[int | None, dict] = {}
     stale_days = settings.buyplan_stale_offer_days
     min_margin = settings.buyplan_min_margin_pct
     better_pct = settings.buyplan_better_offer_pct
@@ -592,7 +596,7 @@ def generate_ai_flags(plan: BuyPlan, db: Session, customer_region: str | None = 
         #    same vendor can't read differently on the offer vs here). Surfaces only the
         #    high-signal caution codes as a flag; the full band lives on the Pre-check.
         if offer is not None:
-            _check_vendor_risk(line, offer, flags, db)
+            _check_vendor_risk(line, offer, flags, db, safety_memo)
 
         # ── Offer communication red flags (deterministic language/contradiction screen)
         if offer is not None:
@@ -620,17 +624,22 @@ _VENDOR_RISK_CODES: dict[str, str] = {
 }
 
 
-def _check_vendor_risk(line: BuyPlanLine, offer: Offer, flags: list[dict], db: Session):
+def _check_vendor_risk(line: BuyPlanLine, offer: Offer, flags: list[dict], db: Session, memo: dict):
     """Append a vendor_risk flag when the line's vendor carries high-signal caution
     codes.
 
-    Reads the SHARED vendor-safety computation (sourcing_leads.vendor_safety_for_card)
-    so the flag can never disagree with the offer Pre-check for the same vendor.
+    Reads the SHARED vendor-safety computation (sourcing_leads.vendor_safety_for_card) so
+    the flag can never disagree with the offer Pre-check for the same vendor. ``memo``
+    caches the result per vendor_card_id so the underlying DB round-trip runs once per
+    distinct vendor, not once per line.
     """
     from .sourcing_leads import vendor_safety_for_card
 
     vc = offer.vendor_card or (db.get(VendorCard, offer.vendor_card_id) if offer.vendor_card_id else None)
-    caution = vendor_safety_for_card(db, vc)["caution"]
+    key = vc.id if vc is not None else None
+    if key not in memo:
+        memo[key] = vendor_safety_for_card(db, vc)
+    caution = memo[key]["caution"]
     hits = [c for c in caution if c in _VENDOR_RISK_CODES]
     if not hits:
         return
@@ -699,6 +708,9 @@ def _check_below_market(line: BuyPlanLine, selected: Offer, flags: list[dict], d
     """
     if not selected.unit_price or float(selected.unit_price) <= 0:
         return
+    # Compare only LIKE offers: same condition (a legit refurb/pull prices far below new)
+    # and same currency (raw prices aren't comparable across currencies). Otherwise the
+    # expected new-vs-used delta would fire a false "too cheap" alarm.
     others = sorted(
         float(o.unit_price)
         for o in db.query(Offer)
@@ -706,6 +718,8 @@ def _check_below_market(line: BuyPlanLine, selected: Offer, flags: list[dict], d
             Offer.requirement_id == line.requirement_id,
             Offer.status == OfferStatus.ACTIVE.value,
             Offer.id != selected.id,
+            Offer.condition == selected.condition,
+            Offer.currency == selected.currency,
         )
         .all()
         if o.unit_price and float(o.unit_price) > 0

--- a/app/services/offer_language_screen.py
+++ b/app/services/offer_language_screen.py
@@ -1,0 +1,68 @@
+"""app/services/offer_language_screen.py — deterministic red-flag screen of an offer's
+vendor communication.
+
+Reliable phrase/structure checks (no LLM: no cost, no hallucination, fully testable) for
+the two "communication" red flags on the qualification checklist — vague/hedging vendor
+language ("New & Original") and the claims-in-stock-but-quotes-a-lead-time contradiction.
+Returns advisory flags with the matched evidence; nothing gates. A fuzzier LLM tone pass
+can layer on later without changing callers.
+
+Called by: app/services/buyplan_builder.py (generate_ai_flags, per line) and the sightings
+offer Pre-check (app/routers/sightings.py).
+"""
+
+from __future__ import annotations
+
+# Counterfeit-adjacent hedging phrases that read as reassurance but carry no verifiable
+# meaning — the "vague communication" red flag (David's checklist names "New & Original").
+_VAGUE_PHRASES: tuple[str, ...] = (
+    "new & original",
+    "new and original",
+    "100% original",
+    "genuine original",
+    "as-is",
+    "as is",
+    "no returns",
+    "no coo",
+    "no c of o",
+    "no cofo",
+    "no test",
+    "no testing",
+    "sold as-is",
+    "unverified",
+)
+
+# lead_time strings that actually mean "in stock, no wait" — not a contradiction.
+_IN_STOCK_LEAD = {"", "in stock", "stock", "0", "0 days", "immediate", "same day", "ready"}
+
+
+def _offer_text(offer) -> str:
+    parts = [offer.notes or ""]
+    q = offer.qualification or {}
+    for k in ("provenance_story", "terms", "lead_time_reason"):
+        if q.get(k):
+            parts.append(str(q[k]))
+    return " ".join(parts).lower()
+
+
+def screen_offer_language(offer) -> list[dict]:
+    """Advisory communication red flags for one offer. Each item: ``{code, note}``.
+
+    - ``vague_language``: the vendor's wording contains counterfeit-adjacent hedges.
+    - ``stock_leadtime_conflict``: claims stock on hand yet quotes a real lead time.
+    """
+    flags: list[dict] = []
+
+    hits = sorted({p for p in _VAGUE_PHRASES if p in _offer_text(offer)})
+    if hits:
+        flags.append({"code": "vague_language", "note": "Vague vendor wording: " + ", ".join(hits)})
+
+    lead = (offer.lead_time or "").strip().lower()
+    if offer.qty_available and offer.qty_available > 0 and lead not in _IN_STOCK_LEAD:
+        flags.append(
+            {
+                "code": "stock_leadtime_conflict",
+                "note": f"Claims {offer.qty_available} in stock but quotes lead time '{offer.lead_time}'",
+            }
+        )
+    return flags

--- a/app/services/offer_language_screen.py
+++ b/app/services/offer_language_screen.py
@@ -13,6 +13,10 @@ offer Pre-check (app/routers/sightings.py).
 
 from __future__ import annotations
 
+import re
+
+from ..utils.normalization import normalize_lead_time
+
 # Counterfeit-adjacent hedging phrases that read as reassurance but carry no verifiable
 # meaning — the "vague communication" red flag (David's checklist names "New & Original").
 _VAGUE_PHRASES: tuple[str, ...] = (
@@ -32,8 +36,8 @@ _VAGUE_PHRASES: tuple[str, ...] = (
     "unverified",
 )
 
-# lead_time strings that actually mean "in stock, no wait" — not a contradiction.
-_IN_STOCK_LEAD = {"", "in stock", "stock", "0", "0 days", "immediate", "same day", "ready"}
+# Match phrases on WORD BOUNDARIES so "as is" does not fire inside "was issued", etc.
+_VAGUE_RE = re.compile(r"\b(?:" + "|".join(re.escape(p) for p in _VAGUE_PHRASES) + r")\b")
 
 
 def _offer_text(offer) -> str:
@@ -53,12 +57,15 @@ def screen_offer_language(offer) -> list[dict]:
     """
     flags: list[dict] = []
 
-    hits = sorted({p for p in _VAGUE_PHRASES if p in _offer_text(offer)})
+    hits = sorted(set(_VAGUE_RE.findall(_offer_text(offer))))
     if hits:
         flags.append({"code": "vague_language", "note": "Vague vendor wording: " + ", ".join(hits)})
 
-    lead = (offer.lead_time or "").strip().lower()
-    if offer.qty_available and offer.qty_available > 0 and lead not in _IN_STOCK_LEAD:
+    # Only a POSITIVE parsed lead time contradicts an in-stock claim. Reuse the canonical
+    # normalizer: "in stock"/"from stock"/"immediate" → 0 (no conflict), ambiguous
+    # ("ex-stock", "available", "ARO") → None (don't guess), "2-3 weeks" → a positive.
+    days = normalize_lead_time(offer.lead_time)
+    if offer.qty_available and offer.qty_available > 0 and days is not None and days > 0:
         flags.append(
             {
                 "code": "stock_leadtime_conflict",

--- a/app/services/sourcing_leads.py
+++ b/app/services/sourcing_leads.py
@@ -379,6 +379,40 @@ def _compute_vendor_safety(
     return score, flags, summary
 
 
+def vendor_safety_for_card(db: Session, vendor_card: VendorCard | None) -> dict:
+    """Vendor safety band + caution/positive signals computed from a VendorCard alone.
+
+    The single shared vendor-risk computation used by BOTH the offer Pre-check and the
+    buy-plan flag generator, so the same vendor can never show two different risk reads
+    on two screens. Reuses ``_compute_vendor_safety`` (the vendor-page model) with a
+    card-only contactability floor (no Sighting in scope) and the vendor-wide,
+    time-decayed buyer-feedback rollup.
+
+    Returns ``{band, score, summary, caution, positives}``: ``caution`` is the list of
+    non-positive signal codes (the "red flags"); ``positives`` strips the ``positive:``
+    prefix. ``band`` is "unknown" when there is no vendor card.
+    """
+    contactability = 0.0
+    if vendor_card is not None:
+        if vendor_card.emails:
+            contactability = 70.0
+        elif vendor_card.phones:
+            contactability = 60.0
+        if vendor_card.website or vendor_card.domain:
+            contactability = min(100.0, contactability + 20.0)
+    fb = get_vendor_feedback_adjustment(db, vendor_card.id if vendor_card is not None else None)
+    score, flags, summary = _compute_vendor_safety(vendor_card, contactability, fb.safety_penalty, fb.do_not_contact)
+    caution = [f for f in flags if not f.startswith("positive:")]
+    positives = [f.removeprefix("positive:") for f in flags if f.startswith("positive:")]
+    return {
+        "band": _safety_band(score, has_vendor_data=vendor_card is not None),
+        "score": score,
+        "summary": summary,
+        "caution": caution,
+        "positives": positives,
+    }
+
+
 def _source_category(source_type: str) -> str:
     """Map a connector source_type to a handoff-spec source category.
 

--- a/app/services/sourcing_leads.py
+++ b/app/services/sourcing_leads.py
@@ -379,6 +379,35 @@ def _compute_vendor_safety(
     return score, flags, summary
 
 
+# Human-readable, caution-language labels for the vendor-safety signal codes — feeds
+# the reusable safety_review.html signal lists (which want display strings, not codes).
+_SAFETY_FLAG_LABELS: dict[str, str] = {
+    "internal_do_not_contact_history": "On the internal do-not-contact list",
+    "buyer_marked_do_not_contact": "A buyer flagged this vendor do-not-contact",
+    "high_cancellation_rate": "History of order cancellations",
+    "repeated_bad_feedback": "Repeated unfavorable buyer feedback",
+    "no_business_footprint": "No verifiable business footprint (no site/domain)",
+    "limited_business_footprint": "Limited business footprint",
+    "unverifiable_address": "No verifiable business address",
+    "conflicting_contact_info": "No verified contact channels on file",
+    "limited_verified_contact_channels": "Few verified contact channels",
+    "new_domain": "New to us — no internal history",
+    "no_internal_vendor_profile": "No internal vendor profile",
+    "marketplace_trust_unknown": "Marketplace trust unknown",
+    "verified_business_footprint": "Verified business footprint",
+    "business_website_exists": "Business website on file",
+    "email_domain_matches_website": "Email domain matches the website",
+    "contact_channels_present": "Contact channels present",
+    "established_relationship": "Established relationship",
+    "proven_success_history": "Proven success history",
+    "marketplace_listing_found": "Marketplace listing found",
+}
+
+
+def _safety_label(code: str) -> str:
+    return _SAFETY_FLAG_LABELS.get(code, code.replace("_", " ").capitalize())
+
+
 def vendor_safety_for_card(db: Session, vendor_card: VendorCard | None) -> dict:
     """Vendor safety band + caution/positive signals computed from a VendorCard alone.
 
@@ -410,6 +439,9 @@ def vendor_safety_for_card(db: Session, vendor_card: VendorCard | None) -> dict:
         "summary": summary,
         "caution": caution,
         "positives": positives,
+        # Human-readable versions for the safety_review.html signal lists.
+        "caution_labels": [_safety_label(c) for c in caution],
+        "positive_labels": [_safety_label(p) for p in positives],
     }
 
 

--- a/app/templates/htmx/partials/approvals/_sheet_header.html
+++ b/app/templates/htmx/partials/approvals/_sheet_header.html
@@ -137,4 +137,25 @@
   </span>
   {% endif %}
   {% endif %}
+
+  {# AI flags — computed FRESH on every render (never the stale stored bp.ai_flags).
+     Informational risk signals for this plan; tap to expand. Never gates approval. #}
+  {% if ai_flags %}
+  {% set _crit = ai_flags | selectattr('severity', 'equalto', 'critical') | list %}
+  <div class="mt-1.5" x-data="{ flagsOpen: false }">
+    <button type="button" @click="flagsOpen = !flagsOpen"
+            class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium {{ 'border-rose-300 bg-rose-50 text-rose-700' if _crit else 'border-amber-300 bg-amber-50 text-amber-700' }}">
+      &#9873; {{ ai_flags | length }} flag{{ 's' if ai_flags | length != 1 }}
+      <svg class="w-3 h-3 transition-transform" :class="flagsOpen && 'rotate-180'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div x-show="flagsOpen" x-collapse x-cloak class="mt-1 space-y-1">
+      {% for f in ai_flags %}
+      <div class="flex items-start gap-1.5 text-[11px]">
+        <span class="mt-1 inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 {{ 'bg-rose-500' if f.severity == 'critical' else 'bg-amber-500' }}"></span>
+        <span class="text-gray-600">{{ f.message }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
 </div>

--- a/app/templates/htmx/partials/approvals/_sheet_header.html
+++ b/app/templates/htmx/partials/approvals/_sheet_header.html
@@ -140,18 +140,22 @@
 
   {# AI flags — computed FRESH on every render (never the stale stored bp.ai_flags).
      Informational risk signals for this plan; tap to expand. Never gates approval. #}
-  {% if ai_flags %}
-  {% set _crit = ai_flags | selectattr('severity', 'equalto', 'critical') | list %}
+  {# Header chip counts only RISK flags (warning/critical); info signals like
+     better_offer/geo_mismatch show in the expansion with a gray dot, never as a
+     rose risk count. #}
+  {% set _risk = ai_flags | rejectattr('severity', 'equalto', 'info') | list %}
+  {% if _risk %}
+  {% set _crit = _risk | selectattr('severity', 'equalto', 'critical') | list %}
   <div class="mt-1.5" x-data="{ flagsOpen: false }">
     <button type="button" @click="flagsOpen = !flagsOpen"
             class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium {{ 'border-rose-300 bg-rose-50 text-rose-700' if _crit else 'border-amber-300 bg-amber-50 text-amber-700' }}">
-      &#9873; {{ ai_flags | length }} flag{{ 's' if ai_flags | length != 1 }}
+      &#9873; {{ _risk | length }} flag{{ 's' if _risk | length != 1 }}
       <svg class="w-3 h-3 transition-transform" :class="flagsOpen && 'rotate-180'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
     </button>
     <div x-show="flagsOpen" x-collapse x-cloak class="mt-1 space-y-1">
       {% for f in ai_flags %}
       <div class="flex items-start gap-1.5 text-[11px]">
-        <span class="mt-1 inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 {{ 'bg-rose-500' if f.severity == 'critical' else 'bg-amber-500' }}"></span>
+        <span class="mt-1 inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 {{ 'bg-rose-500' if f.severity == 'critical' else ('bg-amber-500' if f.severity == 'warning' else 'bg-gray-300') }}"></span>
         <span class="text-gray-600">{{ f.message }}</span>
       </div>
       {% endfor %}

--- a/app/templates/htmx/partials/approvals/_sheet_lines.html
+++ b/app/templates/htmx/partials/approvals/_sheet_lines.html
@@ -61,6 +61,11 @@
               <span class="text-gray-400" x-text="o.condition"></span>
               <span class="text-gray-400 tabular-nums" x-show="o.avail">avail <span x-text="(o.avail || 0).toLocaleString()"></span></span>
               <span x-show="o.locked" class="inline-flex items-center rounded border border-amber-200 bg-amber-50 px-1 text-[10px] font-medium text-amber-700" title="A PO is cut on this line — vendor/qty locked; sell stays editable">PO cut</span>
+              {# AI flag count for this picked line (fresh) — @click.stop so reading it
+                 doesn't pick/unpick the offer; the full list is in the header strip. #}
+              <span x-show="o.flags" @click.stop
+                    class="inline-flex items-center gap-0.5 rounded border border-rose-200 bg-rose-50 px-1 text-[11px] font-medium text-rose-700"
+                    title="This line has AI flags — see the header">&#9873; <span x-text="o.flags"></span></span>
               <span class="ml-auto flex items-center gap-1">
                 qty &rarr;
                 <input type="text" inputmode="numeric" x-model="o.qty"
@@ -110,7 +115,10 @@
         {% for line in lines %}
         <tr>
           <td class="px-3 py-1.5 font-mono text-gray-900">{{ (line.requirement.primary_mpn if line.requirement else none) or (line.offer.mpn if line.offer else none) or '—' }}</td>
-          <td class="px-3 py-1.5 text-gray-700">{{ line.offer.vendor_name if line.offer else '—' }}</td>
+          <td class="px-3 py-1.5 text-gray-700">{{ line.offer.vendor_name if line.offer else '—' }}
+            {% set _lf = (ai_flags_by_line | default({})).get(line.id) %}
+            {% if _lf %}<span class="ml-1 inline-flex items-center gap-0.5 rounded border border-rose-200 bg-rose-50 px-1 text-[11px] font-medium text-rose-700" title="AI flags on this line — see the header">&#9873; {{ _lf | length }}</span>{% endif %}
+          </td>
           <td class="px-3 py-1.5 text-right tabular-nums">{{ line.quantity }} × ${{ '{:,.4f}'.format(line.unit_cost | float) if line.unit_cost is not none else '—' }}</td>
           <td class="px-3 py-1.5 text-right tabular-nums">{% if line.unit_sell is not none %}${{ '{:,.4f}'.format(line.unit_sell | float) }}{% else %}—{% endif %}</td>
           <td class="px-3 py-1.5">{% if line.po_number %}{{ copy_chip(line.po_number) }}{% else %}<span class="text-gray-300">—</span>{% endif %}</td>

--- a/app/templates/htmx/partials/approvals/_sheet_lines.html
+++ b/app/templates/htmx/partials/approvals/_sheet_lines.html
@@ -116,8 +116,8 @@
         <tr>
           <td class="px-3 py-1.5 font-mono text-gray-900">{{ (line.requirement.primary_mpn if line.requirement else none) or (line.offer.mpn if line.offer else none) or '—' }}</td>
           <td class="px-3 py-1.5 text-gray-700">{{ line.offer.vendor_name if line.offer else '—' }}
-            {% set _lf = (ai_flags_by_line | default({})).get(line.id) %}
-            {% if _lf %}<span class="ml-1 inline-flex items-center gap-0.5 rounded border border-rose-200 bg-rose-50 px-1 text-[11px] font-medium text-rose-700" title="AI flags on this line — see the header">&#9873; {{ _lf | length }}</span>{% endif %}
+            {% set _lf = (ai_flags_by_line | default({})).get(line.id, []) | rejectattr('severity', 'equalto', 'info') | list %}
+            {% if _lf %}<span class="ml-1 inline-flex items-center gap-0.5 rounded border border-rose-200 bg-rose-50 px-1 text-[11px] font-medium text-rose-700" title="Risk flags on this line — see the header">&#9873; {{ _lf | length }}</span>{% endif %}
           </td>
           <td class="px-3 py-1.5 text-right tabular-nums">{{ line.quantity }} × ${{ '{:,.4f}'.format(line.unit_cost | float) if line.unit_cost is not none else '—' }}</td>
           <td class="px-3 py-1.5 text-right tabular-nums">{% if line.unit_sell is not none %}${{ '{:,.4f}'.format(line.unit_sell | float) }}{% else %}—{% endif %}</td>

--- a/app/templates/htmx/partials/sightings/_offer_row.html
+++ b/app/templates/htmx/partials/sightings/_offer_row.html
@@ -85,16 +85,22 @@
        flags use (sourcing_leads.vendor_safety_for_card), so offer and plan agree.
        Compact by design; the full vendor detail is one click away. #}
     {% set _s = (safety_by_offer | default({})).get(o.id) %}
-    {% if _s and _s.band != 'unknown' %}
+    {% set _lang = (language_by_offer | default({})).get(o.id) %}
+    {% set _has_band = _s and _s.band != 'unknown' %}
+    {% set _caution = (_s.caution_labels if _s else []) %}
+    {# Show the Pre-check when there is a real vendor band OR any language flag — the
+       language flags must NOT be hidden just because the vendor has no card. #}
+    {% if _has_band or _caution or _lang %}
     {% set _band_pill = {'low_risk': 'border-emerald-200 bg-emerald-50 text-emerald-700', 'medium_risk': 'border-amber-200 bg-amber-50 text-amber-700', 'high_risk': 'border-rose-200 bg-rose-50 text-rose-700'} %}
     {% set _band_label = {'low_risk': 'Low risk', 'medium_risk': 'Medium risk', 'high_risk': 'High risk'} %}
     <div class="pb-0.5">
       <span class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Pre-check</span>
+      {% if _has_band %}
       <span class="ml-1 inline-flex items-center rounded-full border px-1.5 py-0.5 text-[11px] font-medium {{ _band_pill.get(_s.band, 'border-gray-200 bg-gray-50 text-gray-600') }}">{{ _band_label.get(_s.band, 'Unknown') }}</span>
-      {% set _lang = (language_by_offer | default({})).get(o.id) %}
-      {% if _s.caution_labels or _lang %}
+      {% endif %}
+      {% if _caution or _lang %}
       <ul class="mt-0.5 space-y-0.5">
-        {% for sig in _s.caution_labels %}<li class="flex items-start gap-1 text-amber-700"><span>&#9888;</span><span>{{ sig }}</span></li>{% endfor %}
+        {% for sig in _caution %}<li class="flex items-start gap-1 text-amber-700"><span>&#9888;</span><span>{{ sig }}</span></li>{% endfor %}
         {% for lf in _lang %}<li class="flex items-start gap-1 text-amber-700"><span>&#9888;</span><span>{{ lf.note }}</span></li>{% endfor %}
       </ul>
       {% endif %}

--- a/app/templates/htmx/partials/sightings/_offer_row.html
+++ b/app/templates/htmx/partials/sightings/_offer_row.html
@@ -81,6 +81,25 @@
   </div>
   {# Qualification detail — expands on vendor-name click #}
   <div x-show="expand" x-cloak class="mt-1.5 ml-1 pb-1 text-[11px] text-gray-600 space-y-1 border-l-2 border-gray-100 pl-2">
+    {# Pre-check: the vendor risk read for this offer — SAME computation the buy-plan
+       flags use (sourcing_leads.vendor_safety_for_card), so offer and plan agree.
+       Compact by design; the full vendor detail is one click away. #}
+    {% set _s = (safety_by_offer | default({})).get(o.id) %}
+    {% if _s and _s.band != 'unknown' %}
+    {% set _band_pill = {'low_risk': 'border-emerald-200 bg-emerald-50 text-emerald-700', 'medium_risk': 'border-amber-200 bg-amber-50 text-amber-700', 'high_risk': 'border-rose-200 bg-rose-50 text-rose-700'} %}
+    {% set _band_label = {'low_risk': 'Low risk', 'medium_risk': 'Medium risk', 'high_risk': 'High risk'} %}
+    <div class="pb-0.5">
+      <span class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Pre-check</span>
+      <span class="ml-1 inline-flex items-center rounded-full border px-1.5 py-0.5 text-[11px] font-medium {{ _band_pill.get(_s.band, 'border-gray-200 bg-gray-50 text-gray-600') }}">{{ _band_label.get(_s.band, 'Unknown') }}</span>
+      {% set _lang = (language_by_offer | default({})).get(o.id) %}
+      {% if _s.caution_labels or _lang %}
+      <ul class="mt-0.5 space-y-0.5">
+        {% for sig in _s.caution_labels %}<li class="flex items-start gap-1 text-amber-700"><span>&#9888;</span><span>{{ sig }}</span></li>{% endfor %}
+        {% for lf in _lang %}<li class="flex items-start gap-1 text-amber-700"><span>&#9888;</span><span>{{ lf.note }}</span></li>{% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    {% endif %}
     {% set q = o.qualification or {} %}
     {% if o.qualification_note %}
     <p class="text-gray-700">{{ o.qualification_note }}</p>

--- a/tests/test_qualification_signals.py
+++ b/tests/test_qualification_signals.py
@@ -244,3 +244,54 @@ def test_language_flags_reach_generate_ai_flags(db_session: Session):
     db_session.flush()
     types = {f["type"] for f in generate_ai_flags(plan, db_session)}
     assert "offer_language" in types
+
+
+# ── review-fix regressions (false positives caught by adversarial review) ──
+
+
+def test_language_no_false_positive_on_was_issued(db_session: Session):
+    from app.services.offer_language_screen import screen_offer_language
+
+    user = _make_user(db_session)
+    company = _make_company(db_session)
+    site = _make_site(db_session, company)
+    req = _make_requisition(db_session, user, site)
+    requirement = _make_requirement(db_session, req)
+    offer = _make_offer(db_session, req, requirement, _make_vendor(db_session))
+    offer.notes = "Certificate of Conformance was issued by the OEM."  # 'as is' inside 'was issued'
+    db_session.flush()
+    assert {f["code"] for f in screen_offer_language(offer)} == set()
+
+
+def test_language_no_conflict_on_from_stock(db_session: Session):
+    from app.services.offer_language_screen import screen_offer_language
+
+    user = _make_user(db_session)
+    company = _make_company(db_session)
+    site = _make_site(db_session, company)
+    req = _make_requisition(db_session, user, site)
+    requirement = _make_requirement(db_session, req)
+    for lt in ("from stock", "ex-stock", "available"):
+        offer = _make_offer(db_session, req, requirement, _make_vendor(db_session, name=f"v {lt}"), qty=500)
+        offer.lead_time = lt
+        db_session.flush()
+        assert "stock_leadtime_conflict" not in {f["code"] for f in screen_offer_language(offer)}, lt
+
+
+def test_below_market_ignores_different_condition(db_session: Session):
+    # legit refurb far below NEW siblings must NOT flag "too cheap"
+    user = _make_user(db_session)
+    company = _make_company(db_session)
+    site = _make_site(db_session, company)
+    req = _make_requisition(db_session, user, site)
+    requirement = _make_requirement(db_session, req)
+    picked = _make_offer(db_session, req, requirement, _make_vendor(db_session, name="Refurb"), price=0.30)
+    picked.condition = "refurb"
+    for i, p in enumerate([1.00, 1.05]):
+        o = _make_offer(db_session, req, requirement, _make_vendor(db_session, name=f"New {i}"), price=p)
+        o.condition = "new"
+    quote = _make_quote(db_session, req, site, user)
+    plan, _ = _make_plan_with_line(db_session, quote, req, requirement, picked, buyer_id=user.id)
+    db_session.flush()
+    bm = [f for f in generate_ai_flags(plan, db_session) if f["type"] == "below_market"]
+    assert not bm  # cross-condition comparison suppressed

--- a/tests/test_qualification_signals.py
+++ b/tests/test_qualification_signals.py
@@ -1,0 +1,138 @@
+"""tests/test_qualification_signals.py — vendor-risk flags + fresh ai_flags at review.
+
+Phase 1 of the Part/Offer Qualification build (spec v5): the buy-plan review must show
+vendor/offer red flags computed FRESH (not the stale build-time snapshot), and vendor
+risk must come from ONE shared computation so the offer Pre-check and the plan flags
+can't disagree.
+
+Covers:
+  - vendor_safety_for_card: the shared card-only vendor-risk computation.
+  - generate_ai_flags: emits a vendor_risk flag for a blacklisted / high-cancellation
+    vendor, keyed to the line.
+  - _sheet_ctx (render context): ai_flags are recomputed on render (compute-on-read),
+    so a change after build is reflected — the freshness fix.
+
+Called by: pytest
+Depends on: app.services.sourcing_leads, app.services.buyplan_builder,
+    app.routers.htmx.approvals_hub, the builders in tests.test_buyplan_builder_extra.
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from sqlalchemy.orm import Session
+
+from app.services.buyplan_builder import generate_ai_flags
+from app.services.sourcing_leads import vendor_safety_for_card
+from tests.test_buyplan_builder_extra import (
+    _make_company,
+    _make_offer,
+    _make_plan_with_line,
+    _make_quote,
+    _make_requirement,
+    _make_requisition,
+    _make_site,
+    _make_user,
+    _make_vendor,
+)
+
+# ── vendor_safety_for_card (the shared computation) ───────────────────────
+
+
+def test_safety_flags_high_cancellation(db_session: Session):
+    v = _make_vendor(db_session)
+    v.cancellation_rate = 0.5  # > 0.2 threshold
+    db_session.flush()
+    out = vendor_safety_for_card(db_session, v)
+    assert "high_cancellation_rate" in out["caution"]
+    assert out["band"] in ("low_risk", "medium_risk", "high_risk")
+
+
+def test_safety_flags_blacklist_do_not_contact(db_session: Session):
+    v = _make_vendor(db_session)
+    v.is_blacklisted = True
+    db_session.flush()
+    out = vendor_safety_for_card(db_session, v)
+    assert "internal_do_not_contact_history" in out["caution"]
+
+
+def test_safety_no_card_is_unknown(db_session: Session):
+    out = vendor_safety_for_card(db_session, None)
+    assert out["band"] == "unknown"
+    assert "no_internal_vendor_profile" in out["caution"]
+
+
+def test_safety_positives_stripped_from_caution(db_session: Session):
+    v = _make_vendor(db_session, name="Good Vendor")
+    v.website = "https://goodvendor.com"
+    v.domain = "goodvendor.com"
+    v.emails = ["sales@goodvendor.com"]
+    db_session.flush()
+    out = vendor_safety_for_card(db_session, v)
+    # positives are reported separately, never as caution codes
+    assert all(not c.startswith("positive:") for c in out["caution"])
+    assert any("website" in p or "footprint" in p or "channels" in p for p in out["positives"])
+
+
+# ── generate_ai_flags emits a per-line vendor_risk flag ───────────────────
+
+
+def _plan_with_vendor(db, *, blacklisted=False, cancel=None):
+    user = _make_user(db)
+    company = _make_company(db)
+    site = _make_site(db, company)
+    req = _make_requisition(db, user, site)
+    requirement = _make_requirement(db, req)
+    vendor = _make_vendor(db, name="Risk Vendor")
+    if blacklisted:
+        vendor.is_blacklisted = True
+    if cancel is not None:
+        vendor.cancellation_rate = cancel
+    db.flush()
+    offer = _make_offer(db, req, requirement, vendor)
+    quote = _make_quote(db, req, site, user)
+    plan, line = _make_plan_with_line(db, quote, req, requirement, offer, buyer_id=user.id)
+    return plan, line
+
+
+def test_generate_flags_emits_vendor_risk_for_blacklist(db_session: Session):
+    plan, line = _plan_with_vendor(db_session, blacklisted=True)
+    flags = generate_ai_flags(plan, db_session)
+    vr = [f for f in flags if f["type"] == "vendor_risk"]
+    assert vr, "expected a vendor_risk flag for a blacklisted vendor"
+    assert vr[0]["severity"] == "critical"
+    assert vr[0]["line_id"] == line.id
+
+
+def test_generate_flags_vendor_risk_for_high_cancellation(db_session: Session):
+    plan, line = _plan_with_vendor(db_session, cancel=0.6)
+    vr = [f for f in generate_ai_flags(plan, db_session) if f["type"] == "vendor_risk"]
+    assert vr and vr[0]["severity"] == "warning"
+
+
+def test_generate_flags_no_vendor_risk_for_clean_vendor(db_session: Session):
+    plan, _ = _plan_with_vendor(db_session)  # clean vendor
+    vr = [f for f in generate_ai_flags(plan, db_session) if f["type"] == "vendor_risk"]
+    assert not vr
+
+
+# ── freshness: _sheet_ctx recomputes on render (compute-on-read) ──────────
+
+
+def test_sheet_ctx_ai_flags_are_fresh(db_session: Session, test_user):
+    from app.routers.htmx.approvals_hub import _sheet_ctx
+
+    plan, line = _plan_with_vendor(db_session)
+    # Stored snapshot is deliberately WRONG/empty; the render must ignore it.
+    plan.ai_flags = [{"type": "stale_snapshot", "severity": "warning", "line_id": 0, "message": "old"}]
+    db_session.flush()
+    # Now make the vendor risky AFTER "build" — a fresh render must catch it.
+    line.offer.vendor_card.is_blacklisted = True
+    db_session.flush()
+
+    ctx = _sheet_ctx(db_session, test_user, plan, is_sourcing=True)
+    types = {f["type"] for f in ctx["ai_flags"]}
+    assert "vendor_risk" in types, "fresh compute should catch the post-build risk"
+    assert "stale_snapshot" not in types, "must not read the stale stored ai_flags"
+    assert ctx["ai_flags_by_line"].get(line.id), "flags indexed per line for the row count"

--- a/tests/test_qualification_signals.py
+++ b/tests/test_qualification_signals.py
@@ -136,3 +136,111 @@ def test_sheet_ctx_ai_flags_are_fresh(db_session: Session, test_user):
     assert "vendor_risk" in types, "fresh compute should catch the post-build risk"
     assert "stale_snapshot" not in types, "must not read the stale stored ai_flags"
     assert ctx["ai_flags_by_line"].get(line.id), "flags indexed per line for the row count"
+
+
+# ── below-market ("too cheap") flag — from sibling offers only ────────────
+
+
+def _plan_priced(db, picked_price, sibling_prices):
+    user = _make_user(db)
+    company = _make_company(db)
+    site = _make_site(db, company)
+    req = _make_requisition(db, user, site)
+    requirement = _make_requirement(db, req)
+    v0 = _make_vendor(db, name="Picked Vendor")
+    picked = _make_offer(db, req, requirement, v0, price=picked_price)
+    for i, p in enumerate(sibling_prices):
+        _make_offer(db, req, requirement, _make_vendor(db, name=f"Sib {i}"), price=p)
+    quote = _make_quote(db, req, site, user)
+    plan, line = _make_plan_with_line(db, quote, req, requirement, picked, buyer_id=user.id)
+    return plan
+
+
+def test_below_market_flags_too_cheap(db_session: Session):
+    # picked $0.30 vs siblings around $1.00 → ~70% below median
+    plan = _plan_priced(db_session, 0.30, [1.00, 1.10, 0.95])
+    bm = [f for f in generate_ai_flags(plan, db_session) if f["type"] == "below_market"]
+    assert bm and bm[0]["severity"] == "warning"
+
+
+def test_below_market_quiet_when_priced_normally(db_session: Session):
+    plan = _plan_priced(db_session, 0.95, [1.00, 1.10, 0.95])
+    bm = [f for f in generate_ai_flags(plan, db_session) if f["type"] == "below_market"]
+    assert not bm
+
+
+def test_below_market_needs_a_cluster(db_session: Session):
+    # only one sibling — not a "market", so no flag even though it's cheaper
+    plan = _plan_priced(db_session, 0.30, [1.00])
+    bm = [f for f in generate_ai_flags(plan, db_session) if f["type"] == "below_market"]
+    assert not bm
+
+
+# ── pre-check: human-readable labels for safety_review.html reuse ─────────
+
+
+def test_safety_returns_human_labels(db_session: Session):
+    v = _make_vendor(db_session)
+    v.cancellation_rate = 0.5
+    db_session.flush()
+    out = vendor_safety_for_card(db_session, v)
+    assert "caution_labels" in out and "positive_labels" in out
+    assert "History of order cancellations" in out["caution_labels"]
+    # labels are display strings, never raw codes
+    assert "high_cancellation_rate" not in out["caution_labels"]
+
+
+# ── offer language / contradiction screen (deterministic) ─────────────────
+
+
+def test_language_screen_flags_vague_wording(db_session: Session):
+    from app.services.offer_language_screen import screen_offer_language
+
+    user = _make_user(db_session)
+    company = _make_company(db_session)
+    site = _make_site(db_session, company)
+    req = _make_requisition(db_session, user, site)
+    requirement = _make_requirement(db_session, req)
+    offer = _make_offer(db_session, req, requirement, _make_vendor(db_session))
+    offer.notes = "Parts are New & Original, sold as-is, no returns."
+    db_session.flush()
+    codes = {f["code"] for f in screen_offer_language(offer)}
+    assert "vague_language" in codes
+
+
+def test_language_screen_flags_stock_leadtime_conflict(db_session: Session):
+    from app.services.offer_language_screen import screen_offer_language
+
+    user = _make_user(db_session)
+    company = _make_company(db_session)
+    site = _make_site(db_session, company)
+    req = _make_requisition(db_session, user, site)
+    requirement = _make_requirement(db_session, req)
+    offer = _make_offer(db_session, req, requirement, _make_vendor(db_session), qty=500)
+    offer.lead_time = "2-3 weeks"
+    db_session.flush()
+    codes = {f["code"] for f in screen_offer_language(offer)}
+    assert "stock_leadtime_conflict" in codes
+
+
+def test_language_screen_quiet_on_clean_offer(db_session: Session):
+    from app.services.offer_language_screen import screen_offer_language
+
+    user = _make_user(db_session)
+    company = _make_company(db_session)
+    site = _make_site(db_session, company)
+    req = _make_requisition(db_session, user, site)
+    requirement = _make_requirement(db_session, req)
+    offer = _make_offer(db_session, req, requirement, _make_vendor(db_session), qty=500)
+    offer.lead_time = "in stock"
+    offer.notes = "Factory sealed, full traceability, COO available."
+    db_session.flush()
+    assert screen_offer_language(offer) == []
+
+
+def test_language_flags_reach_generate_ai_flags(db_session: Session):
+    plan, line = _plan_with_vendor(db_session)
+    line.offer.notes = "New and Original"
+    db_session.flush()
+    types = {f["type"] for f in generate_ai_flags(plan, db_session)}
+    assert "offer_language" in types


### PR DESCRIPTION
## What

A clean, effective risk-screening layer that strengthens the existing quality process — surfaces vendor/offer risk at the moment you buy, from data AVAIL already has. **No new DB column, no migration, no approval gate.**

## The signals

- **Fresh AI flags at buy-plan review.** `BuyPlan.ai_flags` was generated once at build and rendered nowhere; it now computes **fresh on every render** (a manager who swaps an offer sees flags update — no stale snapshot with orphaned line ids). Shown as a collapsible strip in the Deal Sheet header + a rose count chip per line.
- **Vendor-risk flag** from a single shared computation (`sourcing_leads.vendor_safety_for_card`) so the offer view and the plan view can never disagree: blacklist / do-not-contact = critical, cancellation / bad-feedback history = warning.
- **Below-market ("too cheap") flag** — a picked offer priced well under the median of its **same-condition, same-currency** siblings; the counterfeit-relevant signal, computed from offers already loaded (no market sweep).
- **Offer Pre-check** in the sightings offer drawer — the same vendor-safety read + a language screen, deduped per vendor (no N+1).
- **Deterministic language/contradiction screen** (`offer_language_screen.py`, no LLM) — flags evasive wording ("New & Original", word-boundary matched) and claims-in-stock-but-quotes-a-positive-lead-time. An LLM tone pass can layer on later.

## Verification

- **Adversarial review (14 agents)** confirmed 7 issues — 1 N+1 and 6 false-positive/edge bugs — **all fixed** (word-boundary matching, `normalize_lead_time` reuse, condition+currency filter, per-vendor memo, cardless-vendor render, risk-only chip counts). This is the last commit.
- 19 tests in `tests/test_qualification_signals.py` incl. the 3 false-positive regressions.
- Full suite **24,393 passed / 0 failed**; ruff + offer-picker vitest green.

Info signals stay advisory (gray, uncounted); nothing gates approval. Scope deliberately excludes image analysis, counterfeit-AI models, and datasheet/MSL extraction (spec `specs/part-offer-qualification-2026-08-20.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf