### PR TITLE
Qualification Pre-check: show on initial part-detail load

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -219,31 +219,40 @@ RFQ_UNAVAILABLE_HEADER = "X-RFQ-Unavailable"  # vendors dropped by the active-on
 RFQ_DATASHEETS_DROPPED_HEADER = "X-RFQ-Datasheets-Dropped"  # oversized datasheets dropped before send
 
 
-def _render_offers_panel(request: Request, requirement: Requirement, db: Session) -> HTMLResponse:
-    """Render the part-centric Offers panel for swap into #sightings-offers-panel."""
+def _offer_screening_maps(part_offers: list, db: Session) -> dict:
+    """Build the offer Pre-check maps for offers_panel.html/_offer_row.html.
+
+    Returns ``{safety_by_offer, language_by_offer}``. Vendor safety uses the SAME
+    computation the buy-plan flags use (so an offer and its plan never read
+    differently), deduped per vendor to avoid an N+1 across the list. Shared by the
+    panel-refresh AND the initial detail load so the Pre-check shows in both.
+    """
     from ..services.offer_language_screen import screen_offer_language
     from ..services.sourcing_leads import vendor_safety_for_card
 
-    part_offers = part_offers_for(requirement, db)
-    # Offer Pre-check: the SAME vendor-safety computation the buy-plan flags use, so an
-    # offer and its plan never read differently. Deduped per vendor to avoid an N+1
-    # across the offer list; only vendors that appear get computed.
-    _safety_by_vendor: dict[int, dict] = {}
+    safety_by_vendor: dict[int, dict] = {}
     safety_by_offer: dict[int, dict] = {}
     for o in part_offers:
         vcid = o.vendor_card_id
         if vcid is None:
             continue
-        if vcid not in _safety_by_vendor:
-            _safety_by_vendor[vcid] = vendor_safety_for_card(db, o.vendor_card)
-        safety_by_offer[o.id] = _safety_by_vendor[vcid]
-    language_by_offer = {o.id: screen_offer_language(o) for o in part_offers}
+        if vcid not in safety_by_vendor:
+            safety_by_vendor[vcid] = vendor_safety_for_card(db, o.vendor_card)
+        safety_by_offer[o.id] = safety_by_vendor[vcid]
+    return {
+        "safety_by_offer": safety_by_offer,
+        "language_by_offer": {o.id: screen_offer_language(o) for o in part_offers},
+    }
+
+
+def _render_offers_panel(request: Request, requirement: Requirement, db: Session) -> HTMLResponse:
+    """Render the part-centric Offers panel for swap into #sightings-offers-panel."""
+    part_offers = part_offers_for(requirement, db)
     ctx = {
         "request": request,
         "requirement": requirement,
         "part_offers": part_offers,
-        "safety_by_offer": safety_by_offer,
-        "language_by_offer": language_by_offer,
+        **_offer_screening_maps(part_offers, db),
     }
     resp = template_response("htmx/partials/sightings/offers_panel.html", ctx)
     resp.headers["X-Rendered-Req-Id"] = str(requirement.id)
@@ -1102,6 +1111,9 @@ async def sightings_detail(
         "link_map": detail_link_map,
         "activities": activities,
         "user": user,
+        # Offer Pre-check maps so the risk read shows on INITIAL detail load, not just
+        # after an offer action refreshes the panel.
+        **_offer_screening_maps(part_offers, db),
     }
     resp = template_response("htmx/partials/sightings/detail.html", ctx)
     resp.headers["X-Rendered-Req-Id"] = str(requirement_id)

--- a/tests/test_qualification_signals.py
+++ b/tests/test_qualification_signals.py
@@ -295,3 +295,20 @@ def test_below_market_ignores_different_condition(db_session: Session):
     db_session.flush()
     bm = [f for f in generate_ai_flags(plan, db_session) if f["type"] == "below_market"]
     assert not bm  # cross-condition comparison suppressed
+
+
+def test_offer_screening_maps_builds_both(db_session: Session):
+    from app.routers.sightings import _offer_screening_maps
+
+    user = _make_user(db_session)
+    company = _make_company(db_session)
+    site = _make_site(db_session, company)
+    req = _make_requisition(db_session, user, site)
+    requirement = _make_requirement(db_session, req)
+    o1 = _make_offer(db_session, req, requirement, _make_vendor(db_session, name="A"))
+    o1.notes = "New & Original"
+    db_session.flush()
+    maps = _offer_screening_maps([o1], db_session)
+    assert set(maps) == {"safety_by_offer", "language_by_offer"}
+    assert o1.id in maps["safety_by_offer"]
+    assert any(f["code"] == "vague_language" for f in maps["language_by_offer"][o1.id])


### PR DESCRIPTION
Follow-up to #903 (caught during live-verify).

The offer Pre-check (vendor risk band + caution/language signals) was built only in `_render_offers_panel`, which the initial sightings `/detail` load doesn't call — so the Pre-check appeared only *after* an offer action refreshed the panel, not when you first open a part's offers.

Fix: factored the `safety_by_offer` + `language_by_offer` construction into a shared `_offer_screening_maps` helper and included it in the detail route context too.

Full suite **24,394 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173AwKgSbfzLyK8T2S4mgFf