### PR TITLE
QP serial paste: AI-parse a packing list into serial entries

### DIFF
--- a/app/routers/quality_plans.py
+++ b/app/routers/quality_plans.py
@@ -22,6 +22,7 @@ Depends on: app.services.quality_plan_service (validate_complete, validate_secti
             app.template_env (template_response).
 """
 
+import json
 from datetime import date
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
@@ -38,6 +39,7 @@ from ..models.crm import CustomerSite
 from ..models.fru_link import FruLink
 from ..models.quality_plan import QpFruLookup, QpSerialEntry, QualityPlan
 from ..models.quotes import Quote
+from ..services.qp_serial_paste_service import parse_serial_paste
 from ..services.quality_plan_service import (
     IncompleteQPError,
     create_qp,
@@ -438,10 +440,15 @@ def _render_purchasing_section(request: Request, db: Session, qp: QualityPlan, u
 
 
 def _render_serial_section(request: Request, qp: QualityPlan, user) -> HTMLResponse:
-    """Render the refreshed Serial section partial."""
+    """Render the refreshed Serial section partial.
+
+    oob_chip makes the partial append an hx-swap-oob twin of the collapsed header's "N
+    entries" chip so it can't go stale after an add/delete/bulk refresh; the full detail
+    render omits the flag (no duplicate span).
+    """
     return template_response(
         "htmx/partials/qp/_section_serial.html",
-        {"request": request, "user": user, "qp": qp},
+        {"request": request, "user": user, "qp": qp, "oob_chip": True},
     )
 
 
@@ -542,6 +549,82 @@ def qp_add_serial(
         ops_received=_coerce("bool", ops_received),
     )
     db.add(entry)
+    db.commit()
+    qp = _load_qp_for_edit(db, qp_id, user)
+    return _render_serial_section(request, qp, user)
+
+
+@router.post("/v2/qp/{qp_id}/serial/parse", response_class=HTMLResponse)
+async def qp_parse_serial_paste(
+    request: Request,
+    qp_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+    pasted_text: str = Form(""),
+) -> HTMLResponse:
+    """AI-parse pasted packing-list text → serial-row preview partial (no DB write).
+
+    The preview renders per-row checkboxes and a confirm form posting to /serial/bulk;
+    only that confirmed POST writes rows.
+    """
+    qp = _load_qp_for_edit(db, qp_id, user)
+    text = (pasted_text or "").strip()
+    rows = await parse_serial_paste(text) if text else []
+    return template_response(
+        "htmx/partials/qp/_serial_paste_preview.html",
+        {
+            "request": request,
+            "user": user,
+            "qp": qp,
+            "rows": rows,
+            "rows_json": json.dumps(rows) if rows else None,
+            "empty_paste": not text,
+        },
+    )
+
+
+# Bound above the AI parser's own row cap so a tampered rows_json can't bulk-insert
+# an unbounded payload.
+_SERIAL_BULK_MAX_ROWS = 300
+
+
+@router.post("/v2/qp/{qp_id}/serial/bulk", response_class=HTMLResponse)
+def qp_add_serial_bulk(
+    request: Request,
+    qp_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+    rows_json: str = Form(""),
+    include: list[str] = Form(default=[]),
+) -> HTMLResponse:
+    """Insert the checked preview rows as Serial entries → refreshed Serial section.
+
+    ``include`` carries the checked row indices into ``rows_json``; unchecked, junk,
+    and out-of-range indices are ignored. Values go through the same coercion as the
+    single-row add and submitted_by defaults to the acting user.
+    """
+    qp = _load_qp_for_edit(db, qp_id, user)
+    try:
+        # RecursionError: a deeply-nested array bomb escapes the C scanner as
+        # RecursionError (a RuntimeError, not a ValueError) — same 400 as bad JSON.
+        rows = json.loads(rows_json or "[]")
+    except (json.JSONDecodeError, RecursionError):
+        raise HTTPException(status_code=400, detail="Malformed rows payload") from None
+    if not isinstance(rows, list) or len(rows) > _SERIAL_BULK_MAX_ROWS:
+        raise HTTPException(status_code=400, detail="Invalid rows payload")
+
+    # isascii() + the length bound keep int() total: isdigit() alone admits Unicode
+    # digit forms ("²") and unbounded digit strings that make int() raise.
+    picked = sorted({int(i) for i in include if i.isascii() and i.isdigit() and len(i) <= 4})
+    for idx in picked:
+        if idx >= len(rows) or not isinstance(rows[idx], dict):
+            continue
+        raw = rows[idx]
+        values = {
+            field: _coerce("str", str(raw[field])[:255] if raw.get(field) is not None else None)
+            for field in ("purchase_order", "part_number", "serial_number", "seagate_sn", "tso", "customer_po")
+        }
+        db.add(QpSerialEntry(qp_id=qp.id, submitted_by_id=user.id if user else None, **values))
     db.commit()
     qp = _load_qp_for_edit(db, qp_id, user)
     return _render_serial_section(request, qp, user)

--- a/app/services/qp_serial_paste_service.py
+++ b/app/services/qp_serial_paste_service.py
@@ -1,0 +1,102 @@
+"""qp_serial_paste_service.py — AI parse of pasted packing-list text into QP serial
+rows.
+
+Purpose:
+  A buyer pastes the vendor packing list / test report text into the Quality Plan's
+  Serial section instead of hand-keying one QpSerialEntry row per submit. One
+  claude_structured call maps the text to candidate rows (PO, part #, serial #,
+  Seagate SN, TSO, customer PO). The caller renders them as a preview the human
+  confirms — this module never writes to the database.
+
+Called by: routers/quality_plans.py (POST /v2/qp/{id}/serial/parse)
+Depends on: utils/claude_client, utils/claude_errors
+"""
+
+from loguru import logger
+
+from app.utils import claude_client
+from app.utils.claude_errors import ClaudeError
+
+# Verbatim transcription fields only — mirrors QpSerialEntry's String(255) columns.
+_ROW_FIELDS = ("purchase_order", "part_number", "serial_number", "seagate_sn", "tso", "customer_po")
+
+# Both caps are generous for a real packing list; they bound one interactive call.
+_MAX_TEXT_CHARS = 20_000
+_MAX_ROWS = 300
+
+SERIAL_PASTE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "purchase_order": {"type": ["string", "null"], "description": "Our purchase order number"},
+                    "part_number": {"type": ["string", "null"], "description": "Part number"},
+                    "serial_number": {"type": ["string", "null"], "description": "Serial number, verbatim"},
+                    "seagate_sn": {"type": ["string", "null"], "description": "Seagate SN if listed"},
+                    "tso": {"type": ["string", "null"], "description": "TSO reference"},
+                    "customer_po": {"type": ["string", "null"], "description": "Customer PO number"},
+                },
+            },
+        },
+    },
+    "required": ["rows"],
+}
+
+SERIAL_PASTE_SYSTEM = """You extract serial-number tracking rows from packing list, test report, or shipment text.
+
+Context: A buyer pasted text listing serialized units (drives, cards, FRUs). Each unit becomes one row.
+
+Rules:
+- Copy every value VERBATIM — exact characters, exact case. Never invent, complete, or "fix" a value.
+- One row per serial number. If one PO/part covers many serials, repeat it on each serial's row.
+- serial_number: the unit's serial. seagate_sn: only a value explicitly labeled Seagate SN.
+- purchase_order: our PO number. customer_po: the customer's PO. tso: a TSO reference.
+- Use null for anything the text does not state. Skip header/summary lines that describe no unit."""
+
+
+async def parse_serial_paste(raw_text: str) -> list[dict] | None:
+    """Parse pasted packing-list text into sanitized QP serial-row dicts.
+
+    Returns [] for an empty paste (no AI call), None when the AI call fails, else a list
+    of dicts keyed by _ROW_FIELDS (values str|None, stripped, ≤255 chars; rows with no
+    values at all are dropped).
+    """
+    text = (raw_text or "").strip()[:_MAX_TEXT_CHARS]
+    if not text:
+        return []
+
+    try:
+        # Interactive HTMX caller: tightened single attempt so the request can't hang
+        # for the timeout × retries worst case (claude_client P2.8 pattern).
+        result = await claude_client.claude_structured(
+            text,
+            SERIAL_PASTE_SCHEMA,
+            system=SERIAL_PASTE_SYSTEM,
+            model_tier="fast",
+            max_tokens=8192,
+            timeout=60,
+            max_attempts=1,
+            cost_bucket="qp_serial_paste",
+        )
+    except ClaudeError as e:
+        logger.warning("QP serial paste parse failed: {}", e)
+        return None
+    if result is None:
+        return None
+
+    rows: list[dict] = []
+    for raw_row in (result.get("rows") or [])[:_MAX_ROWS]:
+        if not isinstance(raw_row, dict):
+            continue
+        row: dict = {}
+        for field in _ROW_FIELDS:
+            value = raw_row.get(field)
+            if value is not None:
+                value = str(value).strip()[:255] or None
+            row[field] = value
+        if any(row.values()):
+            rows.append(row)
+    return rows

--- a/app/templates/htmx/partials/qp/_section_serial.html
+++ b/app/templates/htmx/partials/qp/_section_serial.html
@@ -1,85 +1,121 @@
 {#
   qp/_section_serial.html — Quality Plan § Serial preapproval tracking (C2b).
   A compact table of QpSerialEntry rows + an "add entry" form that POSTs
-  /v2/qp/{id}/serial and swaps this partial back. Each row has a delete button
-  (DELETE /v2/qp/{id}/serial/{entry_id}). Customer-side fields stay internal — the
-  vendor share view (C2c) excludes this whole section.
+  /v2/qp/{id}/serial, and a collapsed "Paste packing list…" panel that AI-parses
+  pasted text (POST /v2/qp/{id}/serial/parse → preview → confirmed bulk add).
+  Row Delete (DELETE /v2/qp/{id}/serial/{entry_id}) and the add form narrow their
+  swap to #qp-serial-entries via hx-select so an open paste panel / unconfirmed
+  preview below is never destroyed; the bulk confirm swaps the whole section.
+  Customer-side fields stay internal — the vendor share view (C2c) excludes this
+  whole section.
 
-  Receives: qp (QualityPlan ORM, serial_entries eager-loaded), user (User).
+  Receives: qp (QualityPlan ORM, serial_entries eager-loaded), user (User),
+            oob_chip (bool — refresh responses only: append the hx-swap-oob twin of
+            the detail header's "N entries" chip so it can't go stale).
   Called by: routers/quality_plans.py (_render_serial_section, _qp_detail_response) and
              qp/detail.html ({% include %}).
-  Depends on: HTMX, Tailwind CSS. Swaps into its own #qp-section-serial wrapper.
+  Depends on: HTMX, Alpine.js, Tailwind CSS. Swaps into its own #qp-section-serial wrapper.
 #}
 <div id="qp-section-serial">
-  {% if qp.serial_entries %}
-  <div class="overflow-x-auto">
-    <table class="compact-table w-full">
-      <thead>
-        <tr>
-          <th class="text-left">PO</th>
-          <th class="text-left">Part #</th>
-          <th class="text-left">Serial #</th>
-          <th class="text-left">Seagate SN</th>
-          <th class="text-left">TSO</th>
-          <th class="text-left">Submitted By</th>
-          <th class="text-left">Submitted</th>
-          <th class="text-left">Cust. Approved</th>
-          <th class="text-left">OPS Recv.</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for e in qp.serial_entries %}
-        <tr>
-          <td class="text-xs">{{ e.purchase_order or '—' }}</td>
-          <td class="font-mono text-xs">{{ e.part_number or '—' }}</td>
-          <td class="font-mono text-xs">{{ e.serial_number or '—' }}</td>
-          <td class="font-mono text-xs">{{ e.seagate_sn or '—' }}</td>
-          <td class="text-xs">{{ e.tso or '—' }}</td>
-          <td class="text-xs">{{ e.submitted_by.name if e.submitted_by else '—' }}</td>
-          <td class="text-xs">{{ e.submitted_to_customer_date.isoformat() if e.submitted_to_customer_date else '—' }}</td>
-          <td class="text-xs">{{ 'Yes' if e.customer_approved else ('No' if e.customer_approved is false else '—') }}</td>
-          <td class="text-xs">{{ 'Yes' if e.ops_received else ('No' if e.ops_received is false else '—') }}</td>
-          <td class="text-right">
-            <button type="button"
-                    hx-delete="/v2/qp/{{ qp.id }}/serial/{{ e.id }}"
-                    hx-target="#qp-section-serial"
-                    hx-swap="outerHTML"
-                    hx-confirm="Delete this serial entry?"
-                    class="text-rose-500 hover:text-rose-700 text-xs">Delete</button>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% else %}
-  <p class="text-xs text-gray-400">No serial entries yet.</p>
-  {% endif %}
-
-  {# ── Add entry ── #}
-  <form hx-post="/v2/qp/{{ qp.id }}/serial"
-        hx-target="#qp-section-serial"
-        hx-swap="outerHTML"
-        class="mt-3 grid grid-cols-2 gap-2 md:grid-cols-4">
-    <input type="text" name="purchase_order" placeholder="PO" class="rounded border-gray-300 text-xs">
-    <input type="text" name="part_number" placeholder="Part #" class="rounded border-gray-300 text-xs">
-    <input type="text" name="serial_number" placeholder="Serial #" class="rounded border-gray-300 text-xs">
-    <input type="text" name="seagate_sn" placeholder="Seagate SN" class="rounded border-gray-300 text-xs">
-    <input type="text" name="tso" placeholder="TSO" class="rounded border-gray-300 text-xs">
-    <input type="text" name="customer_po" placeholder="Customer PO" class="rounded border-gray-300 text-xs">
-    <label class="text-xs text-gray-600">Submitted to Cust.
-      <input type="date" name="submitted_to_customer_date" class="mt-0.5 w-full rounded border-gray-300 text-xs">
-    </label>
-    <label class="text-xs text-gray-600">Cust. Approved
-      <select name="customer_approved" class="mt-0.5 w-full rounded border-gray-300 text-xs">
-        <option value="">—</option>
-        <option value="true">Yes</option>
-        <option value="false">No</option>
-      </select>
-    </label>
-    <div class="md:col-span-4">
-      <button type="submit" data-loading-disable class="btn btn-secondary btn-sm">Add Serial Entry</button>
+  <div id="qp-serial-entries">
+    {% if qp.serial_entries %}
+    <div class="overflow-x-auto">
+      <table class="compact-table w-full">
+        <thead>
+          <tr>
+            <th class="text-left">PO</th>
+            <th class="text-left">Part #</th>
+            <th class="text-left">Serial #</th>
+            <th class="text-left">Seagate SN</th>
+            <th class="text-left">TSO</th>
+            <th class="text-left">Submitted By</th>
+            <th class="text-left">Submitted</th>
+            <th class="text-left">Cust. Approved</th>
+            <th class="text-left">OPS Recv.</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for e in qp.serial_entries %}
+          <tr>
+            <td class="text-xs">{{ e.purchase_order or '—' }}</td>
+            <td class="font-mono text-xs">{{ e.part_number or '—' }}</td>
+            <td class="font-mono text-xs">{{ e.serial_number or '—' }}</td>
+            <td class="font-mono text-xs">{{ e.seagate_sn or '—' }}</td>
+            <td class="text-xs">{{ e.tso or '—' }}</td>
+            <td class="text-xs">{{ e.submitted_by.name if e.submitted_by else '—' }}</td>
+            <td class="text-xs">{{ e.submitted_to_customer_date.isoformat() if e.submitted_to_customer_date else '—' }}</td>
+            <td class="text-xs">{{ 'Yes' if e.customer_approved else ('No' if e.customer_approved is false else '—') }}</td>
+            <td class="text-xs">{{ 'Yes' if e.ops_received else ('No' if e.ops_received is false else '—') }}</td>
+            <td class="text-right">
+              <button type="button"
+                      hx-delete="/v2/qp/{{ qp.id }}/serial/{{ e.id }}"
+                      hx-target="#qp-serial-entries"
+                      hx-select="#qp-serial-entries"
+                      hx-swap="outerHTML"
+                      hx-confirm="Delete this serial entry?"
+                      class="text-rose-500 hover:text-rose-700 text-xs">Delete</button>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
-  </form>
+    {% else %}
+    <p class="text-xs text-gray-400">No serial entries yet.</p>
+    {% endif %}
+
+    {# ── Add entry ── #}
+    <form hx-post="/v2/qp/{{ qp.id }}/serial"
+          hx-target="#qp-serial-entries"
+          hx-select="#qp-serial-entries"
+          hx-swap="outerHTML"
+          class="mt-3 grid grid-cols-2 gap-2 md:grid-cols-4">
+      <input type="text" name="purchase_order" placeholder="PO" class="rounded border-gray-300 text-xs">
+      <input type="text" name="part_number" placeholder="Part #" class="rounded border-gray-300 text-xs">
+      <input type="text" name="serial_number" placeholder="Serial #" class="rounded border-gray-300 text-xs">
+      <input type="text" name="seagate_sn" placeholder="Seagate SN" class="rounded border-gray-300 text-xs">
+      <input type="text" name="tso" placeholder="TSO" class="rounded border-gray-300 text-xs">
+      <input type="text" name="customer_po" placeholder="Customer PO" class="rounded border-gray-300 text-xs">
+      <label class="text-xs text-gray-600">Submitted to Cust.
+        <input type="date" name="submitted_to_customer_date" class="mt-0.5 w-full rounded border-gray-300 text-xs">
+      </label>
+      <label class="text-xs text-gray-600">Cust. Approved
+        <select name="customer_approved" class="mt-0.5 w-full rounded border-gray-300 text-xs">
+          <option value="">—</option>
+          <option value="true">Yes</option>
+          <option value="false">No</option>
+        </select>
+      </label>
+      <div class="md:col-span-4">
+        <button type="submit" data-loading-disable class="btn btn-secondary btn-sm">Add Serial Entry</button>
+      </div>
+    </form>
+  </div>
+
+  {# ── Paste packing list (AI parse → preview → confirmed bulk add) ── #}
+  <div x-data="{ pasteOpen: false }" class="mt-3">
+    <button type="button"
+            @click="pasteOpen = !pasteOpen"
+            class="text-xs font-medium text-gray-500 hover:text-gray-700"
+            x-text="pasteOpen ? 'Hide paste import' : 'Paste packing list…'">Paste packing list…</button>
+    <div x-show="pasteOpen" x-cloak class="mt-2 space-y-2">
+      <form hx-post="/v2/qp/{{ qp.id }}/serial/parse"
+            hx-target="#qp-serial-paste-preview"
+            hx-swap="innerHTML"
+            data-loading-disable>
+        <textarea name="pasted_text" rows="6"
+                  placeholder="Paste the packing list / test report text — one unit per serial (PO, part #, serial #, Seagate SN, TSO, customer PO)"
+                  class="w-full rounded border-gray-300 font-mono text-xs"></textarea>
+        <button type="submit" class="btn btn-secondary btn-sm mt-1">Parse with AI</button>
+      </form>
+      <div id="qp-serial-paste-preview"></div>
+    </div>
+  </div>
 </div>
+{% if oob_chip %}
+{# Top-level OOB twin of the detail header's collapsed-state chip — htmx only
+   processes hx-swap-oob on top-level response elements, and it survives the row
+   actions' hx-select narrowing (OOB extraction runs on the full response). #}
+<span id="qp-serial-chip" hx-swap-oob="true" class="text-xs text-gray-400 font-normal">{{ qp.serial_entries|length }} entr{{ 'ies' if qp.serial_entries|length != 1 else 'y' }}</span>
+{% endif %}

--- a/app/templates/htmx/partials/qp/_serial_paste_preview.html
+++ b/app/templates/htmx/partials/qp/_serial_paste_preview.html
@@ -1,0 +1,65 @@
+{#
+  qp/_serial_paste_preview.html — Preview of AI-parsed packing-list serial rows.
+  Rendered by POST /v2/qp/{id}/serial/parse into #qp-serial-paste-preview (inside the
+  Serial section). Nothing is written until the confirm form POSTs the checked rows to
+  /v2/qp/{id}/serial/bulk, which swaps the whole #qp-section-serial back (preview
+  included, so it disappears on success). rows is None on AI failure.
+
+  Receives: qp (QualityPlan ORM), rows (list[dict] | None), rows_json (str | None),
+            empty_paste (bool), user (User).
+  Called by: routers/quality_plans.py (qp_parse_serial_paste).
+  Depends on: HTMX, Tailwind CSS.
+#}
+{% if empty_paste %}
+<p class="text-xs text-gray-400">Nothing to parse — paste the packing list text first.</p>
+{% elif rows is none %}
+<div class="rounded-lg border border-rose-200 bg-rose-50 p-3 text-xs text-rose-700">
+  AI could not parse that text. Try again, or trim it to just the serial table.
+</div>
+{% elif not rows %}
+<p class="text-xs text-gray-400">No serial rows found in that text.</p>
+{% else %}
+<form hx-post="/v2/qp/{{ qp.id }}/serial/bulk"
+      hx-target="#qp-section-serial"
+      hx-swap="outerHTML"
+      data-loading-disable
+      class="space-y-2">
+  <input type="hidden" name="rows_json" value="{{ rows_json }}">
+  <div class="overflow-x-auto rounded-lg border border-amber-200">
+    <table class="compact-table w-full">
+      <thead>
+        <tr>
+          <th></th>
+          <th class="text-left">PO</th>
+          <th class="text-left">Part #</th>
+          <th class="text-left">Serial #</th>
+          <th class="text-left">Seagate SN</th>
+          <th class="text-left">TSO</th>
+          <th class="text-left">Customer PO</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in rows %}
+        <tr>
+          <td><input type="checkbox" name="include" value="{{ loop.index0 }}" checked
+                     class="rounded border-gray-300"></td>
+          <td class="text-xs">{{ row.purchase_order or '—' }}</td>
+          <td class="font-mono text-xs">{{ row.part_number or '—' }}</td>
+          <td class="font-mono text-xs">{{ row.serial_number or '—' }}</td>
+          <td class="font-mono text-xs">{{ row.seagate_sn or '—' }}</td>
+          <td class="text-xs">{{ row.tso or '—' }}</td>
+          <td class="text-xs">{{ row.customer_po or '—' }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <p class="text-xs text-amber-700">AI-extracted — verify against the document, untick anything wrong.</p>
+  <div class="flex gap-2">
+    <button type="submit" class="btn btn-primary btn-sm">Add selected entries</button>
+    <button type="button"
+            @click="document.getElementById('qp-serial-paste-preview').innerHTML = ''"
+            class="btn btn-secondary btn-sm">Discard</button>
+  </div>
+</form>
+{% endif %}

--- a/app/templates/htmx/partials/qp/detail.html
+++ b/app/templates/htmx/partials/qp/detail.html
@@ -215,7 +215,7 @@
   {% endcall %}
 
   {# ── Section: Serial Numbers ── #}
-  {% set serial_chip %}<span class="text-xs text-gray-400 font-normal">{{ qp.serial_entries|length }} entr{{ 'ies' if qp.serial_entries|length != 1 else 'y' }}</span>{% endset %}
+  {% set serial_chip %}<span id="qp-serial-chip" class="text-xs text-gray-400 font-normal">{{ qp.serial_entries|length }} entr{{ 'ies' if qp.serial_entries|length != 1 else 'y' }}</span>{% endset %}
   {% call qp_section('showSerial', 'Serial Numbers', serial_chip) %}
       {% include "htmx/partials/qp/_section_serial.html" %}
   {% endcall %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -7360,6 +7360,16 @@ section partials — `qp/_section_sales.html`, `_section_purchasing.html`, `_sec
   `sales_section_approved_at`/`purchasing_section_approved_at` on approve (cleared on reject).
 - *Serial CRUD:* `POST /v2/qp/{id}/serial` adds a `QpSerialEntry` (submitted_by = acting user),
   `DELETE …/serial/{entry_id}` removes it (404 if it belongs to another QP). Cascade with the QP.
+- *Serial paste import (AI):* the Serial section carries a collapsed "Paste packing list…" panel.
+  `POST /v2/qp/{id}/serial/parse` runs `qp_serial_paste_service.parse_serial_paste` (one
+  `claude_structured` fast-tier call, interactive `max_attempts=1`; verbatim-only prompt; rows
+  sanitized to the six `String(255)` fields, capped at 300) and renders
+  `qp/_serial_paste_preview.html` into `#qp-serial-paste-preview` — per-row checked checkboxes +
+  a hidden `rows_json`, NO db write. Confirm `POST`s `/v2/qp/{id}/serial/bulk`, which re-validates
+  `rows_json` server-side (400 on malformed/oversized), inserts only the checked indices via the
+  same `_coerce` as the single add (submitted_by = acting user), and swaps the refreshed
+  `#qp-section-serial` back (the preview disappears with it). AI failure renders an inline error
+  state with no confirm form; an empty paste never calls the AI.
 - *FRU pin/unpin:* `POST /v2/qp/{id}/fru` resolves `fru_norm` via `normalize_mpn_key`, checks the
   `(qp_id, fru_norm)` unique constraint (re-pin = no-op), and the section live-joins `FruLink` by
   `fru_norm` (`_fru_rows`) to show the related model/carrier/series edges; `DELETE …/fru/{lookup_id}`

--- a/tests/test_qp_serial_paste.py
+++ b/tests/test_qp_serial_paste.py
@@ -1,0 +1,361 @@
+"""test_qp_serial_paste.py — TDD tests for QP serial paste-to-rows (packing-list
+import).
+
+Covers the paste-a-packing-list flow on the Quality Plan Serial section:
+  - parse_serial_paste service: AI extraction → sanitized row dicts (unknown keys
+    dropped, values stripped/truncated, all-empty rows removed; None on AI failure;
+    [] on empty paste without calling Claude).
+  - POST /v2/qp/{id}/serial/parse: renders the preview partial (rows table, per-row
+    checkboxes, hidden rows_json, confirm form) or an error/empty state; never writes.
+  - POST /v2/qp/{id}/serial/bulk: inserts ONLY the checked rows via the same coercion
+    as the single-row add (submitted_by = acting user), then re-renders the section.
+    Rejects malformed rows_json (400) and oversized payloads (400); authz-gated by
+    _load_qp_for_edit like every other QP mutation.
+  - _section_serial.html renders the paste affordance wired to /serial/parse.
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_qp_serial_paste.py -v)
+Depends on: app.services.qp_serial_paste_service, app.routers.quality_plans,
+            conftest (client, db_session, test_user, sales_user, test_customer_site).
+"""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.auth import User
+from app.models.buy_plan import BuyPlan
+from app.models.quality_plan import QpSerialEntry, QualityPlan
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+
+_HX = {"HX-Request": "true"}
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _seed_qp(db: Session, owner_id: int, site_id: int) -> QualityPlan:
+    """Create a requisition → quote → buy plan → QP chain owned by owner_id."""
+    req = Requisition(
+        name="QP-SER-001",
+        status="open",
+        customer_name="Acme Electronics",
+        created_by=owner_id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(req)
+    db.flush()
+    q = Quote(
+        requisition_id=req.id,
+        customer_site_id=site_id,
+        quote_number="QT-QPS-001",
+        status="sent",
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.flush()
+    bp = BuyPlan(
+        requisition_id=req.id,
+        quote_id=q.id,
+        status="draft",
+        so_status="pending",
+        sales_order_number="SO-QPS-1",
+        submitted_by_id=owner_id,
+    )
+    db.add(bp)
+    db.flush()
+    qp = QualityPlan(buy_plan_id=bp.id, created_by_id=owner_id, status="draft", order_type="new")
+    db.add(qp)
+    db.commit()
+    return qp
+
+
+def _serial_rows(db: Session, qp_id: int) -> list[QpSerialEntry]:
+    return list(
+        db.execute(select(QpSerialEntry).where(QpSerialEntry.qp_id == qp_id).order_by(QpSerialEntry.id)).scalars()
+    )
+
+
+_THREE_ROWS = [
+    {
+        "purchase_order": "PO-1001",
+        "part_number": "ST4000NM000A",
+        "serial_number": "ZC11AAAA",
+        "seagate_sn": "SG-1",
+        "tso": "TSO-77",
+        "customer_po": "CPO-5",
+    },
+    {
+        "purchase_order": "PO-1001",
+        "part_number": "ST4000NM000A",
+        "serial_number": "ZC11BBBB",
+        "seagate_sn": None,
+        "tso": None,
+        "customer_po": None,
+    },
+    {
+        "purchase_order": "PO-1002",
+        "part_number": "ST8000NM017B",
+        "serial_number": "ZC22CCCC",
+        "seagate_sn": "SG-3",
+        "tso": "TSO-78",
+        "customer_po": "CPO-6",
+    },
+]
+
+
+@pytest.fixture()
+def restricted_client(db_session: Session, sales_user: User):
+    """TestClient authenticated as a restricted-role (sales) user who owns nothing."""
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = lambda: sales_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+
+
+# ── Service: parse_serial_paste ────────────────────────────────────────────────
+
+
+class TestParseSerialPasteService:
+    async def test_maps_and_sanitizes_rows(self):
+        from app.services.qp_serial_paste_service import parse_serial_paste
+
+        ai_result = {
+            "rows": [
+                {  # padded values get stripped; unknown keys dropped
+                    "purchase_order": "  PO-1001 ",
+                    "part_number": "ST4000NM000A",
+                    "serial_number": " ZC11AAAA ",
+                    "seagate_sn": "",
+                    "tso": None,
+                    "customer_po": "CPO-5",
+                    "bogus_key": "ignored",
+                },
+                {"serial_number": "X" * 300},  # over-length truncated to 255
+                {"purchase_order": "", "part_number": " ", "serial_number": None},  # all-empty dropped
+            ]
+        }
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai_result):
+            rows = await parse_serial_paste("PO-1001 ST4000NM000A ZC11AAAA ...")
+
+        assert rows == [
+            {
+                "purchase_order": "PO-1001",
+                "part_number": "ST4000NM000A",
+                "serial_number": "ZC11AAAA",
+                "seagate_sn": None,
+                "tso": None,
+                "customer_po": "CPO-5",
+            },
+            {
+                "purchase_order": None,
+                "part_number": None,
+                "serial_number": "X" * 255,
+                "seagate_sn": None,
+                "tso": None,
+                "customer_po": None,
+            },
+        ]
+
+    async def test_empty_text_returns_empty_without_ai_call(self):
+        from app.services.qp_serial_paste_service import parse_serial_paste
+
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock) as mock:
+            assert await parse_serial_paste("   \n  ") == []
+        mock.assert_not_called()
+
+    async def test_ai_failure_returns_none(self):
+        from app.services.qp_serial_paste_service import parse_serial_paste
+
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=None):
+            assert await parse_serial_paste("some packing list") is None
+
+
+# ── Route: POST /v2/qp/{id}/serial/parse ───────────────────────────────────────
+
+
+class TestSerialParseRoute:
+    def test_parse_renders_preview_with_confirm_form(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        with patch("app.routers.quality_plans.parse_serial_paste", new_callable=AsyncMock, return_value=_THREE_ROWS):
+            resp = client.post(f"/v2/qp/{qp.id}/serial/parse", data={"pasted_text": "raw packing list"}, headers=_HX)
+        assert resp.status_code == 200
+        body = resp.text
+        # All three rows previewed with per-row checked checkboxes.
+        assert "ZC11AAAA" in body and "ZC11BBBB" in body and "ZC22CCCC" in body
+        assert body.count('name="include"') == 3
+        assert body.count("checked") >= 3
+        # Confirm form carries the rows and posts to the bulk endpoint; nothing written yet.
+        assert f"/v2/qp/{qp.id}/serial/bulk" in body
+        assert 'name="rows_json"' in body
+        assert _serial_rows(db_session, qp.id) == []
+
+    def test_parse_ai_failure_shows_error_not_confirm(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        with patch("app.routers.quality_plans.parse_serial_paste", new_callable=AsyncMock, return_value=None):
+            resp = client.post(f"/v2/qp/{qp.id}/serial/parse", data={"pasted_text": "raw"}, headers=_HX)
+        assert resp.status_code == 200
+        assert "could not parse" in resp.text.lower()
+        assert "serial/bulk" not in resp.text
+
+    def test_parse_empty_paste_shows_message_without_ai(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        with patch("app.routers.quality_plans.parse_serial_paste", new_callable=AsyncMock, return_value=[]) as mock:
+            resp = client.post(f"/v2/qp/{qp.id}/serial/parse", data={"pasted_text": ""}, headers=_HX)
+        assert resp.status_code == 200
+        assert "nothing to parse" in resp.text.lower()
+        mock.assert_not_called()
+
+    def test_parse_unauthenticated_401(self, unauthenticated_client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = unauthenticated_client.post(f"/v2/qp/{qp.id}/serial/parse", data={"pasted_text": "x"}, headers=_HX)
+        assert resp.status_code == 401
+
+
+# ── Route: POST /v2/qp/{id}/serial/bulk ────────────────────────────────────────
+
+
+class TestSerialBulkRoute:
+    def test_bulk_inserts_only_checked_rows(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = client.post(
+            f"/v2/qp/{qp.id}/serial/bulk",
+            data={"rows_json": json.dumps(_THREE_ROWS), "include": ["0", "2"]},
+            headers=_HX,
+        )
+        assert resp.status_code == 200
+        rows = _serial_rows(db_session, qp.id)
+        assert [r.serial_number for r in rows] == ["ZC11AAAA", "ZC22CCCC"]
+        first = rows[0]
+        assert first.purchase_order == "PO-1001"
+        assert first.part_number == "ST4000NM000A"
+        assert first.seagate_sn == "SG-1"
+        assert first.tso == "TSO-77"
+        assert first.customer_po == "CPO-5"
+        assert first.submitted_by_id == test_user.id
+        # Response is the refreshed section partial showing the new rows.
+        assert "ZC11AAAA" in resp.text and "ZC22CCCC" in resp.text
+        assert 'id="qp-section-serial"' in resp.text
+
+    def test_bulk_ignores_out_of_range_and_junk_indices(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        # "²" is isdigit()-true but int()-invalid; "9"*5000 trips int()'s max_str_digits —
+        # both must be silently skipped like any other junk index, never a 500.
+        resp = client.post(
+            f"/v2/qp/{qp.id}/serial/bulk",
+            data={"rows_json": json.dumps(_THREE_ROWS), "include": ["1", "99", "-1", "abc", "²", "9" * 5000]},
+            headers=_HX,
+        )
+        assert resp.status_code == 200
+        rows = _serial_rows(db_session, qp.id)
+        assert [r.serial_number for r in rows] == ["ZC11BBBB"]
+
+    def test_bulk_deeply_nested_rows_json_400(self, client, db_session, test_user, test_customer_site):
+        """A recursion-bomb payload gets the intended 400, not an unhandled 500."""
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = client.post(
+            f"/v2/qp/{qp.id}/serial/bulk",
+            data={"rows_json": "[" * 20000 + "]" * 20000, "include": ["0"]},
+            headers=_HX,
+        )
+        assert resp.status_code == 400
+        assert _serial_rows(db_session, qp.id) == []
+
+    def test_bulk_nothing_checked_inserts_nothing(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = client.post(f"/v2/qp/{qp.id}/serial/bulk", data={"rows_json": json.dumps(_THREE_ROWS)}, headers=_HX)
+        assert resp.status_code == 200
+        assert _serial_rows(db_session, qp.id) == []
+
+    def test_bulk_malformed_json_400(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = client.post(
+            f"/v2/qp/{qp.id}/serial/bulk", data={"rows_json": "{not json", "include": ["0"]}, headers=_HX
+        )
+        assert resp.status_code == 400
+        assert _serial_rows(db_session, qp.id) == []
+
+    def test_bulk_oversized_payload_400(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        big = [{"serial_number": f"SN-{i}"} for i in range(301)]
+        resp = client.post(
+            f"/v2/qp/{qp.id}/serial/bulk", data={"rows_json": json.dumps(big), "include": ["0"]}, headers=_HX
+        )
+        assert resp.status_code == 400
+        assert _serial_rows(db_session, qp.id) == []
+
+    def test_bulk_restricted_non_owner_404(self, restricted_client, db_session, test_user, test_customer_site):
+        """The new write path enforces the same ownership rule as every QP mutation."""
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = restricted_client.post(
+            f"/v2/qp/{qp.id}/serial/bulk",
+            data={"rows_json": json.dumps(_THREE_ROWS), "include": ["0"]},
+            headers=_HX,
+        )
+        assert resp.status_code == 404
+        assert _serial_rows(db_session, qp.id) == []
+
+
+# ── Template: paste affordance in the Serial section ───────────────────────────
+
+
+def test_serial_section_renders_paste_affordance(client, db_session, test_user, test_customer_site):
+    qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+    resp = client.get(f"/v2/qp/{qp.id}", headers=_HX)
+    assert resp.status_code == 200
+    body = resp.text
+    assert f"/v2/qp/{qp.id}/serial/parse" in body
+    assert 'name="pasted_text"' in body
+
+
+def test_row_actions_target_entries_div_so_preview_survives(client, db_session, test_user, test_customer_site):
+    """Row Delete and the single-add form swap only #qp-serial-entries (via hx-select),
+    so an open paste panel / unconfirmed preview outside that div is not destroyed."""
+    qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+    client.post(f"/v2/qp/{qp.id}/serial", data={"serial_number": "ZKEEP1"}, headers=_HX)
+    resp = client.get(f"/v2/qp/{qp.id}", headers=_HX)
+    body = resp.text
+    assert 'id="qp-serial-entries"' in body
+    # The delete button and add form both narrow their swap to the entries div.
+    assert body.count('hx-target="#qp-serial-entries"') == 2
+    assert body.count('hx-select="#qp-serial-entries"') == 2
+    # The paste preview mount lives OUTSIDE the entries div (after it in the section).
+    assert body.index('id="qp-serial-entries"') < body.index('id="qp-serial-paste-preview"')
+
+
+class TestSerialChipOob:
+    def test_bulk_response_carries_oob_chip_with_new_count(self, client, db_session, test_user, test_customer_site):
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = client.post(
+            f"/v2/qp/{qp.id}/serial/bulk",
+            data={"rows_json": json.dumps(_THREE_ROWS), "include": ["0", "2"]},
+            headers=_HX,
+        )
+        assert resp.status_code == 200
+        assert 'id="qp-serial-chip"' in resp.text
+        assert 'hx-swap-oob="true"' in resp.text
+        assert "2 entries" in resp.text
+
+    def test_detail_render_has_single_chip_and_no_oob_twin(self, client, db_session, test_user, test_customer_site):
+        """The full QP detail (which {% include %}s the section) must not render a
+        duplicate OOB chip span — the guard keeps it to the refresh responses."""
+        qp = _seed_qp(db_session, test_user.id, test_customer_site.id)
+        resp = client.get(f"/v2/qp/{qp.id}", headers=_HX)
+        assert resp.text.count('id="qp-serial-chip"') == 1
+        # (the page's <title> legitimately uses hx-swap-oob — only the chip twin is guarded)
+        assert 'id="qp-serial-chip" hx-swap-oob' not in resp.text


### PR DESCRIPTION
First build from the AI opportunity survey (specs/ai-opportunity-survey-2026-08-21.md, idea #2 — the highest-pain S-effort win).

## What
The QP Serial section gains a collapsed **Paste packing list…** panel:
- `POST /v2/qp/{id}/serial/parse` → `qp_serial_paste_service.parse_serial_paste`: one `claude_structured` fast-tier call (verbatim-only prompt, interactive `max_attempts=1`, rows sanitized to the six `String(255)` fields, capped at 300) → preview partial with per-row checked checkboxes + hidden `rows_json`. **No DB write.**
- `POST /v2/qp/{id}/serial/bulk` → re-validates `rows_json` (400 on malformed / nested-bomb / oversized; junk `include` indices silently skipped), inserts only the checked rows via the same `_coerce` as the single add (`submitted_by` = acting user), re-renders `#qp-section-serial`.
- Row Delete + single-add now swap only `#qp-serial-entries` (hx-select) so an open unconfirmed preview survives them; every serial refresh carries an `hx-swap-oob` twin of the header "N entries" chip so it can't go stale after a bulk import.
- AI failure → inline error state, no confirm form; empty paste never calls the AI.

## Review
Adversarial 8-agent find/refute pass on the diff: 5 confirmed findings (all low), **all fixed** — include-index 500s (`"²"`, 5000-digit strings), `RecursionError` escaping the `JSONDecodeError` guard, preview destroyed by sibling section actions, stale header chip. 0 findings refuted-but-shipped.

## Tests
18 new tests in `tests/test_qp_serial_paste.py` (service sanitization, parse/bulk routes incl. authz + tamper cases, template wiring, OOB chip). Full suite: **24260 passed, 35 skipped, 0 failed** (6m01s, run inside the worktree). pre-commit 10/10 hooks pass. APP_MAP_INTERACTIONS updated. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skqbrbYAUTMGwxc3AwNN3