### PR TITLE
PO-confirm paste-prefill: AI fills the confirm form from pasted ERP text

### DIFF
--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -24,7 +24,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, joinedload
@@ -43,12 +43,14 @@ from ...database import get_db
 from ...dependencies import can_verify_po_line, require_access, require_user
 from ...models import BuyPlan, BuyPlanLine, User
 from ...models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
+from ...rate_limit import check_rate_limit
 from ...services.approvals.po_queue import build_po_queue_view
 from ...services.approvals.queue import (
     buy_plan_tracking_rows,
     pending_rows_for_gate,
     resolved_rows_for_gate,
 )
+from ...services.po_confirm_paste_service import parse_po_confirmation
 from ...template_env import template_response
 from ...utils.csv_export import stream_csv
 from ._shared import _base_ctx
@@ -654,7 +656,14 @@ async def approvals_plan_header(
 # ── Purchase-order line detail pane ─────────────────────────────────────
 
 
-def render_po_pane(request: Request, user: User, db: Session, line_id: int) -> HTMLResponse:
+def render_po_pane(
+    request: Request,
+    user: User,
+    db: Session,
+    line_id: int,
+    *,
+    po_prefill: dict | None = None,
+) -> HTMLResponse:
     """Build + render the PO-line detail pane (shared by the pane GET route and the
     confirm-po / verify-po / resource handlers' origin=approvals_workspace branches).
 
@@ -761,6 +770,11 @@ def render_po_pane(request: Request, user: User, db: Session, line_id: int) -> H
             ),
             # Notes + attachments (2.4): the line's own thread.
             **_notes_ctx(db, user, plan_id=plan.id, line_id=line.id),
+            # PO-confirm paste-prefill (survey idea #6): AI-drafted confirm-form
+            # values + advisory cross-check warnings; the buyer reviews and still
+            # clicks Confirm PO. Empty/failed-parse notes go through the small
+            # #po-paste-result fragment instead (never a pane re-render).
+            "po_prefill": po_prefill,
         }
     )
     return template_response("htmx/partials/approvals/_pane_po_line.html", ctx)
@@ -775,6 +789,60 @@ async def approvals_po_pane(
 ):
     """The Purchase Orders right-hand detail pane for one buy-plan line."""
     return render_po_pane(request, user, db, line_id)
+
+
+@router.post("/v2/partials/approvals/po/{line_id:int}/parse-confirmation", response_class=HTMLResponse)
+async def approvals_po_parse_confirmation(
+    request: Request,
+    line_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+    pasted_text: str = Form(""),
+) -> HTMLResponse:
+    """AI-parse pasted PO-confirmation text → the SAME pane with the confirm form pre-
+    filled (advisory mismatch warnings included).
+
+    No DB write — the buyer reviews every field and still submits Confirm PO themselves.
+    Ownership, line-status, and a per-user throttle all gate BEFORE the paid AI call.
+    Failure paths return a small #po-paste-result fragment (the pasted text and any
+    typed values stay untouched); success retargets the full #aw-pane.
+    """
+    from ...dependencies import get_buyplan_for_user
+
+    line = db.get(BuyPlanLine, line_id, options=[joinedload(BuyPlanLine.offer), joinedload(BuyPlanLine.requirement)])
+    if line is None:
+        raise HTTPException(404, "PO line not found")
+    # Ownership BEFORE any AI work (mirrors approvals_po_sent_check): a restricted
+    # non-owner 404s here, never burning a Claude call on a line they can't view.
+    get_buyplan_for_user(db, user, line.buy_plan_id)
+    if line.status != BuyPlanLineStatus.AWAITING_PO.value:
+        # The line moved on (e.g. confirmed in another tab) — the pane's current
+        # state IS the feedback; no AI call for a form that no longer renders.
+        return render_po_pane(request, user, db, line_id)
+    text = (pasted_text or "").strip()
+    if not text:
+        return _po_paste_note_fragment(request, "Nothing to parse — paste the text first.")
+    if not check_rate_limit(user.id, "po_confirm_paste", limit=10, window_seconds=60):
+        return _po_paste_note_fragment(request, "Too many parse attempts — wait a minute and try again.")
+    prefill = await parse_po_confirmation(
+        text,
+        line_mpn=(line.requirement.primary_mpn if line.requirement else None)
+        or (line.offer.mpn if line.offer else None),
+        vendor_name=line.offer.vendor_name if line.offer else None,
+        quantity=line.quantity,
+        unit_cost=float(line.unit_cost) if line.unit_cost is not None else None,
+    )
+    if prefill is None:
+        return _po_paste_note_fragment(request, "AI could not parse that text — try trimming it and re-parsing.")
+    response = render_po_pane(request, user, db, line_id, po_prefill=prefill)
+    response.headers["HX-Retarget"] = "#aw-pane"
+    return response
+
+
+def _po_paste_note_fragment(request: Request, note: str) -> HTMLResponse:
+    """A tiny note into #po-paste-result — deliberately NOT a pane re-render, so the
+    pasted text, the open fold, and any typed-but-unsubmitted values stay intact."""
+    return template_response("htmx/partials/approvals/_po_paste_note.html", {"request": request, "note": note})
 
 
 @router.get("/v2/partials/approvals/po/{line_id:int}/sent-check", response_class=HTMLResponse)

--- a/app/services/po_confirm_paste_service.py
+++ b/app/services/po_confirm_paste_service.py
@@ -1,0 +1,184 @@
+"""po_confirm_paste_service.py — AI parse of a pasted PO confirmation into form prefill.
+
+Purpose:
+  The inbound twin of the Copy-for-ERP chip. A buyer pastes the PO confirmation
+  text they copied out of the ERP screen (or an emailed confirmation) into the
+  Approvals PO pane; this extracts po_number / est. ship date / payment method /
+  serial numbers for the confirm-PO form and cross-checks vendor, part number,
+  quantity, and unit cost against the plan line, returning ADVISORY warnings.
+  The human transports the text and reviews every field — nothing here reads,
+  writes, or syncs the ERP, and this module never writes to the database.
+
+Called by: routers/htmx/approvals_hub.py (POST /v2/partials/approvals/po/{id}/parse-confirmation)
+Depends on: utils/claude_client, utils/claude_errors, constants (PO_LINE_PAYMENT_METHODS)
+"""
+
+import re
+from datetime import date
+
+from loguru import logger
+
+from app.constants import PO_LINE_PAYMENT_METHODS
+from app.utils import claude_client
+from app.utils.claude_errors import ClaudeError
+
+_MAX_TEXT_CHARS = 20_000
+_MAX_SERIALS = 500
+
+# Regex-first PO number: a labeled token ("PO 77812", "PO Number: 77812", "P.O.# ABC-123").
+# Deliberately ERP-neutral — a labeled token, not any screen layout. The token must
+# contain a digit (so "po box"/"po token" never misfire) and must not be a bare
+# YYYY-MM-DD date (so "PO: 2026-09-04" falls through to the AI).
+_PO_LABEL_RE = re.compile(
+    r"\bP\.?\s?O\.?\s*(?:number|no\.?)?\s*[#:\-]{0,2}\s*"
+    r"(?!\d{4}-\d{2}-\d{2}\b)(?=[A-Za-z-]*\d)([A-Za-z0-9][A-Za-z0-9-]{2,30})\b",
+    re.IGNORECASE,
+)
+
+_ALLOWED_PAYMENT_METHODS = {m.value for m in PO_LINE_PAYMENT_METHODS}
+
+PO_CONFIRM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "po_number": {"type": ["string", "null"], "description": "Purchase order number, verbatim"},
+        "estimated_ship_date": {"type": ["string", "null"], "description": "Estimated ship date, YYYY-MM-DD"},
+        "payment_method": {
+            "type": ["string", "null"],
+            "enum": ["cc", "paypal", "wire", "ach", "cod", None],
+            "description": "Payment terms mapped to one of: cc, paypal, wire, ach, cod",
+        },
+        "serial_numbers": {"type": "array", "items": {"type": ["string", "null"]}},
+        "vendor_name": {"type": ["string", "null"], "description": "Vendor/supplier the PO was cut to"},
+        "mpn": {"type": ["string", "null"], "description": "Part number on the PO"},
+        "quantity": {"type": ["integer", "null"]},
+        "unit_cost": {"type": ["number", "null"]},
+    },
+    "required": ["po_number"],
+}
+
+PO_CONFIRM_SYSTEM = """You extract structured fields from purchase-order confirmation text a buyer pasted from their ERP screen or a confirmation email.
+
+Rules:
+- Copy values VERBATIM — never invent, complete, or reformat identifiers.
+- po_number: the purchase order number. estimated_ship_date: YYYY-MM-DD only (null if no full date).
+- payment_method: map stated terms to exactly one of cc, paypal, wire, ach, cod (e.g. "credit card"→cc, "wire transfer"→wire, "collect on delivery"→cod). Null if not stated.
+- serial_numbers: every unit serial number listed, verbatim, in order.
+- vendor_name / mpn / quantity / unit_cost: as stated on the confirmation — used only to cross-check against the plan line.
+- Use null for anything the text does not state."""
+
+
+def _clean(value: object) -> str | None:
+    """Strip/truncate a scalar to a form-safe string, None when empty/absent."""
+    if value is None:
+        return None
+    return str(value).strip()[:255] or None
+
+
+def _norm_mpn(value: str) -> str:
+    return re.sub(r"[^A-Z0-9]", "", value.upper())
+
+
+def _cross_check(ai: dict, *, line_mpn, vendor_name, quantity, unit_cost) -> list[str]:
+    """Advisory mismatch warnings — only when BOTH sides have a value.
+
+    Never blocks.
+    """
+    warnings: list[str] = []
+    ai_vendor = _clean(ai.get("vendor_name"))
+    if ai_vendor and vendor_name:
+        a, b = ai_vendor.casefold(), str(vendor_name).casefold()
+        if a not in b and b not in a:
+            warnings.append(
+                f"Vendor on the confirmation ('{ai_vendor}') does not match this line's vendor ('{vendor_name}')."
+            )
+    ai_mpn = _clean(ai.get("mpn"))
+    if ai_mpn and line_mpn and _norm_mpn(ai_mpn) != _norm_mpn(str(line_mpn)):
+        warnings.append(f"Part number on the confirmation ('{ai_mpn}') does not match this line ('{line_mpn}').")
+    ai_qty = ai.get("quantity")
+    if isinstance(ai_qty, int) and quantity and ai_qty != quantity:
+        warnings.append(f"Quantity on the confirmation ({ai_qty}) does not match this line ({quantity}).")
+    ai_cost = ai.get("unit_cost")
+    if isinstance(ai_cost, (int, float)) and unit_cost:
+        try:
+            if abs(float(ai_cost) - float(unit_cost)) > 0.005 * float(unit_cost):
+                warnings.append(f"Unit cost on the confirmation ({ai_cost}) does not match this line ({unit_cost}).")
+        except (TypeError, ValueError):
+            pass
+    return warnings
+
+
+async def parse_po_confirmation(
+    raw_text: str,
+    *,
+    line_mpn: str | None,
+    vendor_name: str | None,
+    quantity: int | None,
+    unit_cost: float | None,
+) -> dict | None:
+    """Parse pasted PO-confirmation text into confirm-form prefill + advisory warnings.
+
+    Returns None when the AI call fails, else a dict with po_number /
+    estimated_ship_date / payment_method / serial_numbers (comma-joined str) / warnings.
+    A labeled PO-number token found by regex WINS over the AI's value (the highest-
+    stakes field stays deterministic whenever the text labels it).
+    """
+    text = (raw_text or "").strip()[:_MAX_TEXT_CHARS]
+    if not text:
+        return None
+
+    try:
+        # Interactive HTMX caller: single attempt, tightened timeout (P2.8 pattern).
+        ai = await claude_client.claude_structured(
+            text,
+            PO_CONFIRM_SCHEMA,
+            system=PO_CONFIRM_SYSTEM,
+            model_tier="fast",
+            max_tokens=4096,
+            timeout=45,
+            max_attempts=1,
+            cost_bucket="po_confirm_paste",
+        )
+    except ClaudeError as e:
+        logger.warning("PO confirmation paste parse failed: {}", e)
+        return None
+    if ai is None:
+        return None
+
+    # A UNIQUE labeled token is deterministic and wins over the AI. With several
+    # labeled tokens (a customer-PO reference beside the real PO is common), only
+    # the one the AI agrees with wins — never a blind first-match.
+    tokens = list(dict.fromkeys(m.group(1) for m in _PO_LABEL_RE.finditer(text)))
+    ai_po = _clean(ai.get("po_number"))
+    if len(tokens) == 1:
+        po_number = tokens[0]
+    elif tokens:
+        po_number = next((t for t in tokens if ai_po and t.casefold() in ai_po.casefold()), ai_po or tokens[0])
+    else:
+        po_number = ai_po
+
+    ship_date = _clean(ai.get("estimated_ship_date"))
+    if ship_date:
+        try:
+            # Normalize: Py3.12 fromisoformat also accepts "20260904"/"2026-W36-4",
+            # which an <input type=date> would silently drop.
+            ship_date = date.fromisoformat(ship_date).isoformat()
+        except ValueError:
+            ship_date = None
+
+    payment_method = _clean(ai.get("payment_method"))
+    if payment_method:
+        payment_method = payment_method.lower()
+        if payment_method not in _ALLOWED_PAYMENT_METHODS:
+            payment_method = None
+
+    serials = [s for s in (_clean(v) for v in (ai.get("serial_numbers") or [])[:_MAX_SERIALS]) if s]
+
+    return {
+        "po_number": po_number,
+        "estimated_ship_date": ship_date,
+        "payment_method": payment_method,
+        "serial_numbers": ", ".join(serials) if serials else None,
+        "warnings": _cross_check(
+            ai, line_mpn=line_mpn, vendor_name=vendor_name, quantity=quantity, unit_cost=unit_cost
+        ),
+    }

--- a/app/templates/htmx/partials/approvals/_pane_po_line.html
+++ b/app/templates/htmx/partials/approvals/_pane_po_line.html
@@ -16,7 +16,7 @@
   Depends on: HTMX, Alpine.js, Tailwind; shared copy_chip + age_chip macros;
               buy_plans/_macros.html resource_form.
 #}
-{% from "htmx/partials/shared/_macros.html" import copy_chip, age_chip, lazy_body %}
+{% from "htmx/partials/shared/_macros.html" import copy_chip, age_chip, lazy_body, spinner %}
 {% from "htmx/partials/buy_plans/_macros.html" import prepay_state_badge, request_prepayment_button, resource_form %}
 
 {% macro qp_text_input(name, label, value) %}
@@ -123,6 +123,45 @@
   {% endmacro %}
 
   {% if line.status == 'awaiting_po' %}
+  {# ── Paste PO confirmation (inbound twin of Copy-for-ERP): AI pre-fills the
+       confirm form below for REVIEW — its own form (forms can't nest), no DB write,
+       the buyer still submits Confirm PO. ── #}
+  <div x-data="{ poPasteOpen: false, parsing: false }">
+    <button type="button" @click="poPasteOpen = !poPasteOpen"
+            class="text-xs font-medium text-gray-500 hover:text-gray-700"
+            x-text="poPasteOpen ? 'Hide paste import' : 'Paste PO confirmation…'">Paste PO confirmation…</button>
+    {# Failure notes swap into #po-paste-result only — the pasted text, this open
+       fold, and typed-but-unsubmitted confirm values survive a failed parse.
+       Success retargets the whole #aw-pane server-side (HX-Retarget). #}
+    <form x-show="poPasteOpen" x-cloak x-collapse
+          hx-post="/v2/partials/approvals/po/{{ line.id }}/parse-confirmation"
+          hx-target="#po-paste-result" hx-swap="innerHTML"
+          @htmx:before-request="parsing = true"
+          @htmx:after-request="parsing = false"
+          class="mt-1.5 space-y-1.5">
+      <textarea name="pasted_text" rows="5" required
+                placeholder="Paste the PO confirmation text copied from the ERP screen or email — PO #, ship date, terms, serials"
+                class="input input-sm w-full font-mono"></textarea>
+      <button type="submit" data-loading-disable :disabled="parsing" class="btn-secondary btn-sm">
+        {{ spinner('h-4 w-4 animate-spin', attrs='x-show="parsing" x-cloak') }}
+        <span x-text="parsing ? 'Parsing…' : 'Parse with AI'">Parse with AI</span>
+      </button>
+      <div id="po-paste-result"></div>
+    </form>
+  </div>
+  {% if po_prefill %}
+  <div class="rounded-lg border border-amber-200 bg-amber-50 p-2.5 space-y-1">
+    <div class="text-xs font-semibold text-amber-800">AI-filled from your paste — verify every field before confirming.</div>
+    {% for w in po_prefill.warnings %}
+    <div class="text-xs text-amber-800">⚠ {{ w }}</div>
+    {% endfor %}
+    {% if po_prefill.serial_numbers and qp and qp.purchasing_serial_numbers %}
+    <div class="text-xs text-amber-800">⚠ Serials parsed from the paste were not applied — this vendor's QP already
+      records serial numbers. Reconcile manually: {{ po_prefill.serial_numbers }}</div>
+    {% endif %}
+  </div>
+  {% endif %}
+
   {# ── Buyer view: confirm-PO form + QP-purchasing ─────────────────── #}
   <form hx-post="/v2/partials/buy-plans/{{ plan.id }}/lines/{{ line.id }}/confirm-po"
         hx-target="#aw-pane" hx-swap="innerHTML" class="space-y-3">
@@ -138,18 +177,23 @@
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-2">
         <label class="block">
           <span class="text-[11px] uppercase tracking-wide text-gray-500">PO number</span>
-          <input type="text" name="po_number" required placeholder="PO-…" class="input input-sm w-full font-mono">
+          <input type="text" name="po_number" required placeholder="PO-…"
+                 value="{{ po_prefill.po_number or '' if po_prefill else '' }}"
+                 class="input input-sm w-full font-mono">
         </label>
         <label class="block">
           <span class="text-[11px] uppercase tracking-wide text-gray-500">Est. ship date</span>
-          <input type="date" name="estimated_ship_date" class="input input-sm w-full">
+          <input type="date" name="estimated_ship_date"
+                 value="{{ po_prefill.estimated_ship_date or '' if po_prefill else '' }}"
+                 class="input input-sm w-full">
         </label>
         <label class="block">
           <span class="text-[11px] uppercase tracking-wide text-gray-500">Payment method</span>
+          {% set pm_selected = (po_prefill.payment_method if po_prefill and po_prefill.payment_method else line.payment_method) %}
           <select name="payment_method" required class="input input-sm w-full">
             <option value="">Select…</option>
             {% for val, label in payment_methods %}
-            <option value="{{ val }}" {% if line.payment_method == val %}selected{% endif %}>{{ label }}</option>
+            <option value="{{ val }}" {% if pm_selected == val %}selected{% endif %}>{{ label }}</option>
             {% endfor %}
           </select>
         </label>
@@ -161,6 +205,11 @@
       <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
         {% for name, kind, label, _summary_label in qp_purchasing_fields %}
         {% if kind == 'yn' %}{{ qp_yn_select(name, label, qp|attr(name) if qp else none) }}
+        {% elif name == 'purchasing_serial_numbers' and po_prefill and po_prefill.serial_numbers
+              and not (qp and qp.purchasing_serial_numbers) %}
+        {# Serials parsed off the pasted confirmation FILL-EMPTY-ONLY: a saved QP
+           value always wins (the banner carries the not-applied advisory). #}
+        {{ qp_text_input(name, label, po_prefill.serial_numbers) }}
         {% else %}{{ qp_text_input(name, label, qp|attr(name) if qp else none) }}{% endif %}
         {% endfor %}
       </div>

--- a/app/templates/htmx/partials/approvals/_po_paste_note.html
+++ b/app/templates/htmx/partials/approvals/_po_paste_note.html
@@ -1,0 +1,9 @@
+{#
+  approvals/_po_paste_note.html — tiny note swapped into #po-paste-result on the
+  PO pane's paste fold (empty paste / AI failure / throttle). Deliberately NOT a
+  pane re-render: the pasted text, the open fold, and any typed-but-unsubmitted
+  confirm-form values stay untouched.
+  Receives: note (str).
+  Called by: routers/htmx/approvals_hub.py (_po_paste_note_fragment).
+#}
+<p class="text-xs text-rose-600">{{ note }}</p>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2138,6 +2138,19 @@ to the token's buyer). Cut-PO task rows (`source_ref buyline:{id}`) deep-link th
 same PO-tab URL. Flag-issue/resolve-issue live inline on the PO pane (buyer
 disclosure + supervisor resolve), as do the prepayment request/state and the
 late-fall-down re-source on the verified branch, and Copy-for-ERP as a `copy_chip`.
+Copy-for-ERP's inbound twin (AI paste-prefill): the awaiting_po pane carries a
+collapsed "Paste PO confirmation…" form (its own `<form>` — never nested in the
+confirm form) POSTing `/v2/partials/approvals/po/{line_id}/parse-confirmation`.
+`po_confirm_paste_service.parse_po_confirmation` finds the PO number regex-first
+(labeled token containing a digit — deterministic wins over the AI), one
+`claude_structured` fast call (interactive `max_attempts=1`) fills est-ship-date
+(ISO-validated), payment_method (whitelisted against PO_LINE_PAYMENT_METHODS),
+and serials (comma-joined into the `purchasing_serial_numbers` field), and
+cross-checks vendor/MPN/qty/unit-cost against the plan line into ADVISORY
+warnings. The route re-renders the SAME pane via `render_po_pane(po_prefill=…)`
+— amber "AI-filled — verify" banner + warnings above the form, NO db write; the
+buyer reviews and still clicks Confirm PO. Empty paste / AI failure render
+`po_paste_note` instead. ERP stays untouched: the human transports the text.
 
 
 **Resell workspace — resell/excess split-panel (Chunk F, ADDITIVE).** `/v2/resell` is

--- a/tests/test_po_confirm_paste.py
+++ b/tests/test_po_confirm_paste.py
@@ -1,0 +1,493 @@
+"""test_po_confirm_paste.py — TDD tests for PO-confirm paste-prefill (survey idea #6).
+
+Covers the inbound twin of the Copy-for-ERP chip on the Approvals PO pane:
+  - parse_po_confirmation service: regex-first PO number (wins over the AI's),
+    sanitized fields (date validated, payment method whitelisted, serials joined),
+    advisory cross-check warnings vs the plan line (vendor/MPN/qty — only when both
+    sides are present), None on AI failure.
+  - POST /v2/partials/approvals/po/{line_id}/parse-confirmation: re-renders the PO
+    pane with the confirm form pre-filled + warning banner; empty paste and AI
+    failure render friendly notes; NEVER writes the line (po_number stays None,
+    status stays awaiting_po — the buyer still clicks Confirm PO).
+  - The awaiting_po pane renders the paste affordance; other statuses do not.
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_po_confirm_paste.py -v)
+Depends on: app.services.po_confirm_paste_service, app.routers.htmx.approvals_hub,
+            conftest (client/db_session/test_user), seed helpers mirrored from
+            tests/test_approvals_hub_tabs.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.constants import BuyPlanLineStatus, OfferStatus, SOVerificationStatus
+from app.models import Offer, Requirement, User
+from app.models.buy_plan import BuyPlan, BuyPlanLine
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+from app.models.vendors import VendorCard
+
+_HX = {"HX-Request": "true"}
+
+# ── Seed helpers (mirroring test_approvals_hub_tabs.py) ────────────────────────
+
+
+def _seed_awaiting_po_line(db: Session, user: User) -> BuyPlanLine:
+    req = Requisition(
+        name=f"REQ-{uuid.uuid4().hex[:6]}",
+        customer_name="AcmeCo",
+        status="open",
+        created_by=user.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(req)
+    db.flush()
+    rq = Requirement(requisition_id=req.id, primary_mpn="LM317", created_at=datetime.now(UTC))
+    db.add(rq)
+    db.flush()
+    q = Quote(
+        requisition_id=req.id,
+        quote_number=f"Q-{uuid.uuid4().hex[:8]}",
+        line_items=[],
+        status="sent",
+        created_by_id=user.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.flush()
+    bp = BuyPlan(
+        requisition_id=req.id,
+        quote_id=q.id,
+        status="active",
+        so_status=SOVerificationStatus.APPROVED.value,
+        submitted_by_id=user.id,
+        total_cost=1000.0,
+        total_revenue=2000.0,
+        total_margin_pct=50.0,
+        created_at=datetime.now(UTC),
+    )
+    db.add(bp)
+    db.flush()
+    vc = VendorCard(normalized_name=f"vc-{uuid.uuid4().hex[:8]}", display_name="Acme Dist")
+    db.add(vc)
+    db.flush()
+    off = Offer(
+        requirement_id=rq.id,
+        vendor_card_id=vc.id,
+        vendor_name="Acme Dist",
+        vendor_name_normalized="acme dist",
+        mpn="LM317",
+        normalized_mpn="LM317",
+        unit_price=1.0,
+        status=OfferStatus.ACTIVE.value,
+    )
+    db.add(off)
+    db.flush()
+    line = BuyPlanLine(
+        buy_plan_id=bp.id,
+        requirement_id=rq.id,
+        offer_id=off.id,
+        quantity=100,
+        unit_cost=1.0,
+        unit_sell=2.0,
+        buyer_id=user.id,
+        status=BuyPlanLineStatus.AWAITING_PO.value,
+    )
+    db.add(line)
+    db.commit()
+    return line
+
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def restricted_client(db_session: Session, sales_user: User):
+    """TestClient authenticated as a restricted-role (sales) user who owns nothing."""
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = lambda: sales_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+
+
+_AI_RESULT = {
+    "po_number": "PO-77812",
+    "estimated_ship_date": "2026-09-04",
+    "payment_method": "wire",
+    "serial_numbers": ["ZC11AAAA", "ZC11BBBB"],
+    "vendor_name": "Acme Dist",
+    "mpn": "LM317",
+    "quantity": 100,
+    "unit_cost": 1.0,
+}
+
+
+# ── Service: parse_po_confirmation ─────────────────────────────────────────────
+
+
+class TestParsePoConfirmationService:
+    async def test_regex_po_number_wins_over_ai(self):
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        ai = dict(_AI_RESULT, po_number="PO-WRONG")
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+            result = await parse_po_confirmation(
+                "Purchase Order PO# 77812 for Acme Dist ...",
+                line_mpn="LM317",
+                vendor_name="Acme Dist",
+                quantity=100,
+                unit_cost=1.0,
+            )
+        assert result is not None
+        assert result["po_number"] == "77812"
+
+    async def test_fields_sanitized_and_serials_joined(self):
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        ai = dict(
+            _AI_RESULT,
+            po_number="  PO-9001  ",
+            estimated_ship_date="not-a-date",
+            payment_method="bitcoin",
+            serial_numbers=["  S1 ", "", None, "S2"],
+        )
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+            result = await parse_po_confirmation(
+                "confirmation text without a labeled po token",
+                line_mpn="LM317",
+                vendor_name="Acme Dist",
+                quantity=100,
+                unit_cost=1.0,
+            )
+        assert result is not None
+        assert result["po_number"] == "PO-9001"  # AI value used when regex finds nothing
+        assert result["estimated_ship_date"] is None  # invalid date dropped
+        assert result["payment_method"] is None  # not a PO_LINE_PAYMENT_METHODS value
+        assert result["serial_numbers"] == "S1, S2"
+
+    async def test_warnings_on_vendor_mpn_qty_mismatch(self):
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        ai = dict(_AI_RESULT, vendor_name="Other Corp", mpn="LM318", quantity=50)
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+            result = await parse_po_confirmation(
+                "text", line_mpn="LM317", vendor_name="Acme Dist", quantity=100, unit_cost=1.0
+            )
+        assert result is not None
+        joined = " ".join(result["warnings"]).lower()
+        assert "vendor" in joined
+        assert "part" in joined or "mpn" in joined
+        assert "quantity" in joined
+
+    async def test_no_warnings_when_fields_match_or_absent(self):
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        ai = dict(_AI_RESULT, vendor_name=None, mpn="lm317", quantity=None, unit_cost=None)
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+            result = await parse_po_confirmation(
+                "text", line_mpn="LM317", vendor_name="Acme Dist", quantity=100, unit_cost=1.0
+            )
+        assert result is not None
+        assert result["warnings"] == []
+
+    async def test_ai_failure_returns_none(self):
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=None):
+            assert (
+                await parse_po_confirmation("text", line_mpn="LM317", vendor_name="V", quantity=1, unit_cost=1.0)
+            ) is None
+
+    async def test_multiple_labeled_tokens_prefer_the_ai_agreeing_one(self):
+        """A customer-PO reference next to the real PO must not hijack the field:
+        with several labeled tokens, the one the AI agrees with wins."""
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        text = "Customer PO: ACME-889   Ship to: Fremont\nOur PO# 77812 acknowledged."
+        ai = dict(_AI_RESULT, po_number="PO-77812")
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+            result = await parse_po_confirmation(
+                text, line_mpn="LM317", vendor_name="Acme Dist", quantity=100, unit_cost=1.0
+            )
+        assert result is not None
+        assert result["po_number"] == "77812"
+
+    async def test_label_grammar_common_shapes_match(self):
+        """'PO Number: X' / 'PO No: X' are the dominant label styles and must stay
+        deterministic; a bare 'PO:' followed by a date must NOT capture the date."""
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        ai = dict(_AI_RESULT, po_number="PO-WRONG")
+        cases = {
+            "PO Number: 77812 confirmed": "77812",
+            "PO No: 4512 thanks": "4512",
+        }
+        for text, expected in cases.items():
+            with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+                result = await parse_po_confirmation(
+                    text, line_mpn="LM317", vendor_name="Acme Dist", quantity=100, unit_cost=1.0
+                )
+            assert result is not None and result["po_number"] == expected, text
+
+        ai_date = dict(_AI_RESULT, po_number="PO-9001")
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai_date):
+            result = await parse_po_confirmation(
+                "PO: 2026-09-04 is the ship date",
+                line_mpn="LM317",
+                vendor_name="Acme Dist",
+                quantity=100,
+                unit_cost=1.0,
+            )
+        assert result is not None
+        assert result["po_number"] == "PO-9001"  # date-shaped token rejected → AI value
+
+    async def test_ship_date_normalized_to_iso(self):
+        """Python 3.12 fromisoformat accepts '20260904' — normalize so the <input
+        type=date> doesn't silently drop the value."""
+        from app.services.po_confirm_paste_service import parse_po_confirmation
+
+        ai = dict(_AI_RESULT, estimated_ship_date="20260904")
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+            result = await parse_po_confirmation(
+                "text", line_mpn="LM317", vendor_name="Acme Dist", quantity=100, unit_cost=1.0
+            )
+        assert result is not None
+        assert result["estimated_ship_date"] == "2026-09-04"
+
+
+# ── Route: POST /v2/partials/approvals/po/{line_id}/parse-confirmation ─────────
+
+
+class TestParseConfirmationRoute:
+    def test_parse_prefills_confirm_form_with_warning_banner(self, client, db_session, test_user):
+        line = _seed_awaiting_po_line(db_session, test_user)
+        prefill = {
+            "po_number": "PO-77812",
+            "estimated_ship_date": "2026-09-04",
+            "payment_method": "wire",
+            "serial_numbers": "ZC11AAAA, ZC11BBBB",
+            "warnings": ["Vendor on the confirmation ('Other Corp') does not match this line ('Acme Dist')."],
+        }
+        with patch(
+            "app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock, return_value=prefill
+        ):
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation",
+                data={"pasted_text": "PO confirmation text"},
+                headers=_HX,
+            )
+        assert resp.status_code == 200
+        body = resp.text
+        assert 'value="PO-77812"' in body
+        assert 'value="2026-09-04"' in body
+        assert "ZC11AAAA, ZC11BBBB" in body
+        assert "Other Corp" in body  # warning banner rendered
+        # The confirm form is still there for the human to review + submit.
+        assert "Confirm PO" in body
+        # Nothing was written.
+        db_session.refresh(line)
+        assert line.po_number is None
+        assert line.status == BuyPlanLineStatus.AWAITING_PO.value
+
+    def test_parse_prefill_selects_payment_method(self, client, db_session, test_user):
+        line = _seed_awaiting_po_line(db_session, test_user)
+        prefill = {
+            "po_number": "PO-1",
+            "estimated_ship_date": None,
+            "payment_method": "ach",
+            "serial_numbers": None,
+            "warnings": [],
+        }
+        with patch(
+            "app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock, return_value=prefill
+        ):
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation",
+                data={"pasted_text": "x"},
+                headers=_HX,
+            )
+        assert resp.status_code == 200
+        assert '<option value="ach" selected' in resp.text
+
+    def test_parse_success_retargets_full_pane(self, client, db_session, test_user):
+        """Success swaps the whole pane (HX-Retarget) so the prefilled form renders; the
+        paste form itself targets only the small #po-paste-result note div."""
+        line = _seed_awaiting_po_line(db_session, test_user)
+        prefill = {
+            "po_number": "PO-1",
+            "estimated_ship_date": None,
+            "payment_method": None,
+            "serial_numbers": None,
+            "warnings": [],
+        }
+        with patch(
+            "app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock, return_value=prefill
+        ):
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+            )
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Retarget") == "#aw-pane"
+
+    def test_parse_empty_paste_returns_note_fragment_without_ai(self, client, db_session, test_user):
+        """Empty paste → a tiny note into #po-paste-result — NOT a pane re-render, so
+        the buyer's typed-but-unsubmitted values and the open fold stay untouched."""
+        line = _seed_awaiting_po_line(db_session, test_user)
+        with patch("app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock) as mock_parse:
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "  "}, headers=_HX
+            )
+        assert resp.status_code == 200
+        assert "nothing to parse" in resp.text.lower()
+        assert "Confirm PO" not in resp.text  # fragment, not the pane
+        assert resp.headers.get("HX-Retarget") is None
+        mock_parse.assert_not_called()
+
+    def test_parse_ai_failure_returns_note_fragment(self, client, db_session, test_user):
+        """AI failure → note fragment only; the pasted text stays in the textarea
+        because nothing re-renders (the 'try trimming' advice stays honest)."""
+        line = _seed_awaiting_po_line(db_session, test_user)
+        with patch("app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock, return_value=None):
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+            )
+        assert resp.status_code == 200
+        assert "could not parse" in resp.text.lower()
+        assert "Confirm PO" not in resp.text
+        assert resp.headers.get("HX-Retarget") is None
+
+    def test_parse_restricted_non_owner_404_without_ai_call(self, restricted_client, db_session, test_user):
+        """The ownership gate runs BEFORE the paid AI call (review finding)."""
+        line = _seed_awaiting_po_line(db_session, test_user)
+        with patch("app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock) as mock_parse:
+            resp = restricted_client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+            )
+        assert resp.status_code == 404
+        mock_parse.assert_not_called()
+
+    def test_parse_non_awaiting_po_line_short_circuits_without_ai(self, client, db_session, test_user):
+        """A line that moved on (confirmed elsewhere) renders its current pane state
+        without burning an AI call whose output nothing would display."""
+        line = _seed_awaiting_po_line(db_session, test_user)
+        line.status = BuyPlanLineStatus.PENDING_VERIFY.value
+        line.po_number = "PO-9"
+        line.po_confirmed_at = datetime.now(UTC)
+        db_session.commit()
+        with patch("app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock) as mock_parse:
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+            )
+        assert resp.status_code == 200
+        mock_parse.assert_not_called()
+
+    def test_parse_rate_limited_returns_note_without_ai(self, client, db_session, test_user):
+        line = _seed_awaiting_po_line(db_session, test_user)
+        with (
+            patch("app.routers.htmx.approvals_hub.check_rate_limit", return_value=False),
+            patch("app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock) as mock_parse,
+        ):
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+            )
+        assert resp.status_code == 200
+        assert "too many parse attempts" in resp.text.lower()
+        mock_parse.assert_not_called()
+
+    def test_parse_unknown_line_404(self, client):
+        resp = client.post(
+            "/v2/partials/approvals/po/999999/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+        )
+        assert resp.status_code == 404
+
+    def test_parse_unauthenticated_401(self, unauthenticated_client, db_session, test_user):
+        line = _seed_awaiting_po_line(db_session, test_user)
+        resp = unauthenticated_client.post(
+            f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+        )
+        assert resp.status_code == 401
+
+
+# ── Template: paste affordance on the awaiting_po pane ─────────────────────────
+
+
+def test_awaiting_po_pane_renders_paste_affordance(client, db_session, test_user):
+    line = _seed_awaiting_po_line(db_session, test_user)
+    resp = client.get(f"/v2/partials/approvals/po/{line.id}/pane", headers=_HX)
+    assert resp.status_code == 200
+    body = resp.text
+    assert f"/v2/partials/approvals/po/{line.id}/parse-confirmation" in body
+    assert 'name="pasted_text"' in body
+
+
+def test_awaiting_po_pane_parse_button_has_inflight_state(client, db_session, test_user):
+    """The Parse button disables + relabels during the 45s AI call (loading-states on
+    the BUTTON, not the form, plus the Alpine 'parsing' flag — the codebase's
+    paste_offer_form idiom)."""
+    line = _seed_awaiting_po_line(db_session, test_user)
+    resp = client.get(f"/v2/partials/approvals/po/{line.id}/pane", headers=_HX)
+    body = resp.text
+    assert "parsing:" in body or "parsing =" in body  # Alpine flag in x-data
+    assert ':disabled="parsing"' in body
+    assert 'id="po-paste-result"' in body  # failure-note target inside the fold
+
+
+def test_serials_prefill_never_overwrites_saved_qp_serials(client, db_session, test_user):
+    """A QP that already records serial numbers keeps them — the parsed serials are
+    suppressed with an advisory line instead of silently replacing a saved value."""
+    from app.models.quality_plan import QualityPlan
+
+    line = _seed_awaiting_po_line(db_session, test_user)
+    qp = QualityPlan(
+        buy_plan_id=line.buy_plan_id,
+        vendor_card_id=line.offer.vendor_card_id,  # qp_for_line matches per-vendor
+        created_by_id=test_user.id,
+        status="draft",
+        order_type="new",
+        purchasing_serial_numbers="SAVED-001",
+    )
+    db_session.add(qp)
+    db_session.commit()
+    prefill = {
+        "po_number": "PO-1",
+        "estimated_ship_date": None,
+        "payment_method": None,
+        "serial_numbers": "NEW-111, NEW-222",
+        "warnings": [],
+    }
+    with patch("app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock, return_value=prefill):
+        resp = client.post(
+            f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
+        )
+    body = resp.text
+    assert 'value="SAVED-001"' in body  # saved QP value wins in the input
+    assert 'value="NEW-111, NEW-222"' not in body
+    assert "not applied" in body  # advisory tells the buyer to reconcile
+
+
+def test_pending_verify_pane_has_no_paste_affordance(client, db_session, test_user):
+    line = _seed_awaiting_po_line(db_session, test_user)
+    line.status = BuyPlanLineStatus.PENDING_VERIFY.value
+    line.po_number = "PO-9"
+    line.po_confirmed_at = datetime.now(UTC)
+    db_session.commit()
+    resp = client.get(f"/v2/partials/approvals/po/{line.id}/pane", headers=_HX)
+    assert resp.status_code == 200
+    assert "parse-confirmation" not in resp.text

--- a/tests/test_po_confirm_paste.py
+++ b/tests/test_po_confirm_paste.py
@@ -396,6 +396,11 @@ class TestParseConfirmationRoute:
                 f"/v2/partials/approvals/po/{line.id}/parse-confirmation", data={"pasted_text": "x"}, headers=_HX
             )
         assert resp.status_code == 200
+        # The re-rendered pane shows the line's CURRENT state — the manager/pending
+        # branch, not the buyer confirm form or the paste affordance.
+        assert "parse-confirmation" not in resp.text
+        assert "Confirm the PO you cut" not in resp.text
+        assert 'value="PO-9"' in resp.text or "PO-9" in resp.text  # the confirmed PO renders
         mock_parse.assert_not_called()
 
     def test_parse_rate_limited_returns_note_without_ai(self, client, db_session, test_user):


### PR DESCRIPTION
Second build from the AI opportunity survey (specs/ai-opportunity-survey-2026-08-21.md, idea #6 — highest-stakes double-entry).

## What
The Approvals PO pane (awaiting_po) gets the **inbound twin of the Copy-for-ERP chip**: paste the PO confirmation text copied from the ERP screen or email, and AI pre-fills the confirm form **for review** — the buyer still clicks Confirm PO, nothing writes on parse, and the ERP stays manual by design (the human transports the text both ways).

- `POST /v2/partials/approvals/po/{line_id}/parse-confirmation` → `po_confirm_paste_service.parse_po_confirmation`: PO number by **labeled-token regex first** (unique token = deterministic; several tokens = the one the AI agrees with, so a customer-PO reference can't hijack the field), est. ship date ISO-normalized, payment method whitelisted vs `PO_LINE_PAYMENT_METHODS`, serials comma-joined **fill-empty-only** (a saved QP value always wins, with an advisory).
- Advisory cross-checks vs the plan line: vendor / MPN / qty / unit-cost mismatches render as amber warnings — never blocking.
- **Gates before the paid AI call**: ownership (`get_buyplan_for_user`), line-status (a line that moved on re-renders its current state, no AI call), and a 10/min per-user throttle.
- Failure paths return a tiny `#po-paste-result` fragment — the pasted text, open fold, and any typed values survive; success retargets the full pane via `HX-Retarget`. Parse button disables with an in-flight spinner.

## Review
15-agent adversarial find/refute pass: **11 confirmed findings, all fixed with regression tests** (authz-before-AI ×2, per-user throttle, multi-token PO regex, label grammar incl. `PO: <date>` rejection, Py3.12 date normalization, loading state, fragment-not-wipe failure paths, honest failure copy, saved-serials protection, status gate). 1 finding refuted.

## Verification
- 22 new tests in `tests/test_po_confirm_paste.py`; neighbors green (approvals hub tabs, buy-plan IDOR authz, QP paste suite): 114 passed.
- Full suite **24285 passed, 34 skipped, 0 failed** (5m23s, inside the worktree).
- Browser dry run vs a throwaway-Postgres rig, real Claude call, driving the real workspace UI: **11/11** — regex PO `20771`, "Wire transfer in advance"→`wire`, serials landed, zero false warnings, zero JS errors.
- pre-commit hooks all pass. APP_MAP_INTERACTIONS updated. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skqbrbYAUTMGwxc3AwNN3