### PR TITLE
Equivalence-aware recall in global search and the part dossier

### DIFF
--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -945,6 +945,14 @@ async def proactive_equivalence_verdict(
         raise HTTPException(400, str(e)) from e
     db.commit()
     word = "confirmed the same part" if verdict == "same" else "marked as different parts"
+    # origin=search (idea #21): the demote came from the search banner / dossier
+    # chip — swap just that chip with a tiny confirmation instead of teleporting
+    # the user into the Proactive Matches tab.
+    if str(form.get("origin") or "").strip() == "search":
+        return HTMLResponse(
+            '<span class="inline-flex items-center rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 '
+            'text-[11px] text-gray-400">removed — won&#39;t pool again</span>'
+        )
     return _render_matches_tab(request, user, db, success_msg=f"{part_a} / {part_b} {word}.")
 
 

--- a/app/routers/htmx/search_views.py
+++ b/app/routers/htmx/search_views.py
@@ -13,6 +13,7 @@ Depends on: app.search_service, app.services.global_search_service,
     app.services.sse_broker, app.scoring, app.vendor_utils
 """
 
+import asyncio
 import html as html_mod
 import json
 
@@ -23,13 +24,14 @@ from sqlalchemy.orm import Session
 
 from ...constants import AccessKey, ApiSourceStatus, SourcingStatus
 from ...database import get_db
-from ...dependencies import require_access, require_requisition_access, require_user
+from ...dependencies import require_access, require_requisition_access, require_user, user_has_access
 from ...models import ApiSource, Requirement, Requisition, Sighting, SourcingLead, User
-from ...rate_limit import limiter
+from ...rate_limit import check_rate_limit, limiter
 from ...scoring import classify_lead, explain_lead, score_unified
 from ...services.sighting_ingest import sighting_from_row
 from ...services.vendor_unavailability import apply_to_fresh_sightings
 from ...template_env import template_response, templates
+from ...utils.async_helpers import safe_background_task
 from ...utils.sql_helpers import escape_like
 from ._shared import _base_ctx, set_canonical_url
 
@@ -73,6 +75,43 @@ async def ai_search_endpoint(
     )
 
 
+# One sweep at a time per process: the windowed scan + O(n²) pair-finding is real
+# CPU, and concurrent sweeps would race to classify the same pairs (paying Claude
+# for duplicates the unique index then discards). A later zero-hit search simply
+# re-triggers once the running sweep finishes.
+_sweep_lock = asyncio.Lock()
+
+
+async def _zero_hit_equivalence_sweep(query: str) -> None:
+    """Background classify pass seeded by a zero-hit MPN search (survey idea #21).
+
+    Runs OUTSIDE the request (via safe_background_task, own session) so no LLM
+    ever sits in the search path: the windowed candidate population plus the
+    missed query key go through classify_new_pairs with involving=<missed key> —
+    the budget is spent ONLY on pairs touching the part the user searched (which
+    also caps what rotating junk queries can mint). Best-effort — any failure
+    just means no new verdicts this time.
+    """
+    from ...database import SessionLocal
+    from ...services.part_equivalence import classify_new_pairs, norm_key, windowed_spellings_by_key
+
+    if _sweep_lock.locked():
+        return
+    async with _sweep_lock:
+        db = SessionLocal()
+        try:
+            spellings = await asyncio.to_thread(windowed_spellings_by_key, db)
+            key = norm_key(query)
+            if not key:
+                return
+            spellings.setdefault(key, query.strip().upper())
+            await classify_new_pairs(db, spellings, limit=5, involving=key)
+        except Exception as e:
+            logger.warning("zero-hit equivalence sweep failed for {!r}: {}", query, e)
+        finally:
+            db.close()
+
+
 @router.get("/v2/partials/search/results", response_class=HTMLResponse)
 async def search_results_page(
     request: Request,
@@ -82,11 +121,33 @@ async def search_results_page(
 ):
     """Full search results page."""
     from ...services.global_search_service import fast_search
+    from ...utils.normalization import normalize_mpn_key
 
     results = fast_search(q, db, user) if q else {"best_match": None, "groups": {}, "total_count": 0}
+    # Zero-hit MPN on the DELIBERATE results page (never the per-keystroke
+    # type-ahead) seeds a background equivalence sweep, throttled per user. The
+    # digit requirement keeps vendor/contact words ("arrow", "smith") from ever
+    # burning AI budget — real MPNs virtually always carry a digit.
+    mpn_key = normalize_mpn_key(q) if q else ""
+    if (
+        q
+        and results["total_count"] == 0
+        and mpn_key
+        and len(mpn_key) >= 4
+        and any(ch.isdigit() for ch in mpn_key)
+        and check_rate_limit(user.id, "eq_zero_hit", limit=5, window_seconds=60)
+    ):
+        await safe_background_task(_zero_hit_equivalence_sweep(q), task_name="zero_hit_equivalence_sweep")
     resp = template_response(
         "htmx/partials/search/full_results.html",
-        {**_base_ctx(request, user), "results": results, "query": q},
+        {
+            **_base_ctx(request, user),
+            "results": results,
+            "query": q,
+            # Gates the equivalence banner's demote button — the verdict endpoint
+            # requires PROACTIVE access, so never render an affordance that 403s.
+            "can_verdict": user_has_access(user, AccessKey.PROACTIVE, db),
+        },
     )
     # Nav audit #10: the refine box used to push /v2/search/results with no ?q, so a
     # reload came back empty. The canonical stamp carries the live query instead.

--- a/app/routers/part_dossier.py
+++ b/app/routers/part_dossier.py
@@ -34,8 +34,9 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from ..constants import AccessKey
 from ..database import get_db
-from ..dependencies import require_user
+from ..dependencies import require_user, user_has_access
 from ..models import User
 from ..models.intelligence import MaterialCard, MaterialCardDatasheet
 from ..models.sourcing import Requisition
@@ -126,9 +127,29 @@ async def dossier_hero(
 
         price_series = price_series_for_card(db, card.id)
 
+    # Equivalence class (idea #21): "Also known as" chips — stored verdicts only,
+    # never an LLM in the render path; failures just hide the chips.
+    equivalence = None
+    try:
+        from ..services.global_search_service import _equivalence_expansion
+
+        _eq_keys, equivalence = _equivalence_expansion(db, mpn)
+    except Exception:
+        logger.exception("dossier_hero equivalence expansion failed mpn={} key={}", mpn, key)
+
     ctx = _ctx(request, user)
     ctx.update(
-        {"mpn": display_mpn, "card": card, "history": history, "fru_view": fru_view, "price_series": price_series}
+        {
+            "mpn": display_mpn,
+            "card": card,
+            "history": history,
+            "fru_view": fru_view,
+            "price_series": price_series,
+            "equivalence": equivalence,
+            # Same gate as the search banner: the demote button only renders for
+            # users the PROACTIVE-gated verdict endpoint will actually accept.
+            "can_verdict": user_has_access(user, AccessKey.PROACTIVE, db),
+        }
     )
 
     # Auto-datasheet capture (background, never blocks the dossier render).

--- a/app/services/global_search_service.py
+++ b/app/services/global_search_service.py
@@ -19,7 +19,7 @@ import hashlib
 from collections.abc import Callable
 
 from loguru import logger
-from sqlalchemy import String, cast, func, or_
+from sqlalchemy import String, cast, func, or_, select
 from sqlalchemy.orm import Query, Session
 
 from app.constants import RESTRICTED_ROLES
@@ -97,19 +97,74 @@ def _scope_owned_reqs(q: Query, user: User | None, *, req_id_col) -> Query:
     return q.filter(req_id_col.in_(owned))
 
 
-def _add_mpn_match(sb: SearchBuilder, query: str, *ilike_cols, normalized_col):
+def _add_mpn_match(sb: SearchBuilder, query: str, *ilike_cols, normalized_col, eq_keys: set[str] | None = None):
     """OR an exact normalized-MPN match onto the ILIKE filter across *ilike_cols*.
 
     Typing "lm-2596s-5.0" canonicalizes to the same key the normalized_mpn columns
     store, so a part number reliably hits its requirement/offer/card/sighting via the
     index even when separators differ. Falls back to plain ILIKE when the query has no
     usable MPN key (e.g. a vendor name).
+
+    ``eq_keys`` (survey idea #21): the query's stored equivalence class — its own key
+    plus verdict='same' variants — so a search under one ordering-suffix spelling
+    recalls rows stored under another. A stored-table join only; never an LLM.
     """
     clause = sb.ilike_filter(*ilike_cols)
     mpn_key = normalize_mpn_key(query)
-    if mpn_key and len(mpn_key) >= 3:
+    if eq_keys and len(eq_keys) > 1:
+        clause = or_(clause, normalized_col.in_(sorted(eq_keys)))
+    elif mpn_key and len(mpn_key) >= 3:
         clause = or_(clause, normalized_col == mpn_key)
     return clause
+
+
+def _equivalence_expansion(db: Session, query: str, user: User | None = None) -> tuple[set[str] | None, dict | None]:
+    """(pooled keys, template-facing variants block) for an MPN query.
+
+    Reads the stored part_equivalences verdicts (human 'different' kill-switch included,
+    via expand_part) — no LLM in the query path. Returns (None, None) when the query has
+    no usable MPN key or the class has no variants. Each variant's kind comes from the
+    EDGE that pooled it (expand_parts' pool_source) so an AI-pooled key always renders
+    the amber verify chip, even when an unrelated human edge touches the same key.
+
+    RESTRICTED_ROLES never see foreign offers'/requirements' raw spellings — their
+    variant spellings come from the verdict rows' own examples instead.
+    """
+    from ..models.intelligence import PartEquivalence
+    from .part_equivalence import expand_part, observed_spellings
+
+    mpn_key = normalize_mpn_key(query)
+    if not mpn_key or len(mpn_key) < 3:
+        return None, None
+    eq = expand_part(db, query)
+    keys = set(eq["keys"])
+    variant_keys = keys - {mpn_key}
+    if not variant_keys:
+        return None, None
+    pool_source = eq.get("pool_source", {})
+    if _is_restricted(user):
+        spellings: dict[str, set[str]] = {}
+        for r in db.scalars(
+            select(PartEquivalence).where(
+                PartEquivalence.verdict == "same",
+                or_(PartEquivalence.key_a.in_(variant_keys), PartEquivalence.key_b.in_(variant_keys)),
+            )
+        ):
+            for k, example in ((r.key_a, r.example_a), (r.key_b, r.example_b)):
+                if k in variant_keys and example:
+                    spellings.setdefault(k, set()).add(example)
+    else:
+        spellings = observed_spellings(db, variant_keys)
+    variants = [
+        {
+            "key": k,
+            "spelling": sorted(spellings.get(k) or {k})[0],
+            "kind": pool_source.get(k, "ai"),
+            "reason": eq["ai_variants"].get(k, ""),
+        }
+        for k in sorted(variant_keys)
+    ]
+    return keys, {"variants": variants}
 
 
 def _to_dict(obj, fields: list[str], entity_type: str) -> dict:
@@ -226,6 +281,11 @@ def fast_search(query: str, db: Session, user: User | None = None) -> dict:
     sb = SearchBuilder(query.strip())
     use_pg = _is_postgres(db)
 
+    # Equivalence-aware recall (survey idea #21): pool the query's stored
+    # verdict='same' class into every MPN-keyed match below. Stored-table join
+    # only — no LLM at query time.
+    eq_keys, equivalence = _equivalence_expansion(db, query, user)
+
     groups = {}
     all_results = []
 
@@ -326,6 +386,7 @@ def fast_search(query: str, db: Session, user: User | None = None) -> dict:
                 Requirement.brand,
                 Requirement.substitutes_text,
                 normalized_col=Requirement.normalized_mpn,
+                eq_keys=eq_keys,
             )
         ),
         user,
@@ -342,7 +403,9 @@ def fast_search(query: str, db: Session, user: User | None = None) -> dict:
     # --- Offers — dedup by (mpn, vendor_name) so same offer combo shows once ---
     q = _scope_owned_reqs(
         db.query(Offer).filter(
-            _add_mpn_match(sb, query, Offer.vendor_name, Offer.mpn, normalized_col=Offer.normalized_mpn)
+            _add_mpn_match(
+                sb, query, Offer.vendor_name, Offer.mpn, normalized_col=Offer.normalized_mpn, eq_keys=eq_keys
+            )
         ),
         user,
         req_id_col=Offer.requisition_id,
@@ -367,6 +430,7 @@ def fast_search(query: str, db: Session, user: User | None = None) -> dict:
             MaterialCard.brand,
             MaterialCard.description,
             normalized_col=MaterialCard.normalized_mpn,
+            eq_keys=eq_keys,
         ),
     )
     if use_pg:
@@ -389,6 +453,7 @@ def fast_search(query: str, db: Session, user: User | None = None) -> dict:
                 Sighting.vendor_name,
                 Sighting.manufacturer,
                 normalized_col=Sighting.normalized_mpn,
+                eq_keys=eq_keys,
             )
         )
         # Exclude the resell mirror's synthetic rows — supply advertising on a hidden
@@ -409,6 +474,9 @@ def fast_search(query: str, db: Session, user: User | None = None) -> dict:
         "best_match": best,
         "groups": groups,
         "total_count": len(all_results),
+        # Present only when the query's equivalence class pooled variant keys —
+        # the results templates render these as the "also matching" banner.
+        "equivalence": equivalence,
     }
 
 

--- a/app/services/part_equivalence.py
+++ b/app/services/part_equivalence.py
@@ -123,7 +123,7 @@ def expand_parts(db: Session, parts: set[str]) -> dict[str, dict]:
     for p in parts:
         base = norm_key(p)
         if not base:
-            out[p] = {"keys": [], "ai_variants": {}}
+            out[p] = {"keys": [], "ai_variants": {}, "pool_source": {}}
             continue
         state[p] = {"keys": {base}, "ai_variants": {}}
         frontier.add(base)
@@ -166,12 +166,20 @@ def expand_parts(db: Session, parts: set[str]) -> dict[str, dict]:
                     continue
                 keys.add(other)
                 info["ai_variants"][other] = r.reason or "AI: same part, ordering-code variant"
+                # Source of the edge that ACTUALLY pooled this key into the class —
+                # surfaces render the amber verify chip iff this is 'ai', regardless
+                # of unrelated human edges elsewhere touching the same key.
+                info.setdefault("pool_source", {})[other] = r.source
                 frontier.add(other)
         if not frontier:
             break
 
     for p, info in state.items():
-        out[p] = {"keys": sorted(info["keys"]), "ai_variants": info["ai_variants"]}
+        out[p] = {
+            "keys": sorted(info["keys"]),
+            "ai_variants": info["ai_variants"],
+            "pool_source": info.get("pool_source", {}),
+        }
     return out
 
 
@@ -218,11 +226,22 @@ def windowed_spellings_by_key(db: Session) -> dict[str, str]:
     return out
 
 
-async def classify_new_pairs(db: Session, spellings_by_key: dict[str, str], *, limit: int = MAX_PAIRS_PER_PASS) -> int:
+async def classify_new_pairs(
+    db: Session,
+    spellings_by_key: dict[str, str],
+    *,
+    limit: int = MAX_PAIRS_PER_PASS,
+    involving: str | None = None,
+) -> int:
     """Ask Claude about not-yet-classified candidate pairs; store verdicts.
 
     One call per pair, Haiku tier, verdict cached forever (a human can flip it).
     Failures skip the pair — it retries on a later pass. Commits.
+
+    ``involving`` restricts classification to pairs touching that normalized key —
+    the zero-hit search sweep uses it so its budget is spent on the part the user
+    actually searched (and so rotating junk queries can only mint verdicts about
+    their own key, never the whole window's backlog).
     """
     from ..utils.claude_client import claude_json
 
@@ -230,6 +249,8 @@ async def classify_new_pairs(db: Session, spellings_by_key: dict[str, str], *, l
     # inline would block the event loop when the window is large. Offload it to a
     # worker thread so the loop stays responsive — same pairs, same verdicts.
     pairs = await asyncio.get_running_loop().run_in_executor(None, find_candidate_pairs, spellings_by_key)
+    if involving:
+        pairs = [p for p in pairs if involving in p]
     if not pairs:
         return 0
     existing = {

--- a/app/templates/htmx/partials/search/dossier_hero.html
+++ b/app/templates/htmx/partials/search/dossier_hero.html
@@ -32,6 +32,31 @@
           <span x-show="copied" x-cloak class="text-[11px] text-emerald-600 font-medium">copied</span>
         </div>
 
+        {% if equivalence %}
+        {# Also-known-as chips (idea #21): stored equivalence verdicts; AI-pooled
+           rows carry the amber verify chip + one-tap permanent demote (conformant
+           hx-post button; origin=search swaps just this chip on success). #}
+        <div class="mt-1.5 flex flex-wrap items-center gap-1.5 text-xs text-amber-800">
+          <span class="font-medium">Also known as:</span>
+          {% for v in equivalence.variants %}
+          <span class="inline-flex items-center gap-1 rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 font-mono">
+            {{ v.spelling }}
+            {% if v.kind == 'ai' %}
+            <span class="text-[11px] uppercase tracking-wide text-amber-600" title="{{ v.reason }}">AI — verify</span>
+            {% if can_verdict %}
+            <button type="button"
+                    hx-post="/v2/partials/proactive/equivalence/verdict"
+                    hx-vals='{{ {"part_a": mpn, "part_b": v.spelling, "verdict": "different", "origin": "search"}|tojson }}'
+                    hx-target="closest span" hx-swap="outerHTML"
+                    hx-confirm="Mark {{ v.spelling }} as NOT the same part as {{ mpn }}? This removes it from pooled results permanently."
+                    class="text-amber-500 hover:text-rose-600" title="Not the same part">&#10005;</button>
+            {% endif %}
+            {% endif %}
+          </span>
+          {% endfor %}
+        </div>
+        {% endif %}
+
         <div class="mt-2 flex flex-wrap items-center gap-1.5">
           {% if known %}
           {% if card.manufacturer %}<span class="text-sm font-medium text-gray-700">{{ card.manufacturer }}</span>{% endif %}

--- a/app/templates/htmx/partials/search/full_results.html
+++ b/app/templates/htmx/partials/search/full_results.html
@@ -131,6 +131,33 @@
     </p>
   </div>
 
+  {% if results.equivalence and results.total_count > 0 %}
+  {# ── Equivalence-aware recall (idea #21): the query's stored verdict='same'
+       class also matched — every AI-pooled variant is visibly amber with the
+       one-tap "not the same part" demote (human verdict outranks AI, permanently).
+       The demote is a conformant hx-post BUTTON (no form nested in the span); on
+       success the endpoint's origin=search branch swaps just this chip. ── #}
+  <div class="mb-4 flex flex-wrap items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+    <span class="font-semibold">Also matching known variants:</span>
+    {% for v in results.equivalence.variants %}
+    <span class="inline-flex items-center gap-1.5 rounded border border-amber-300 bg-white px-1.5 py-0.5 font-mono">
+      {{ v.spelling }}
+      {% if v.kind == 'ai' %}
+      <span class="text-[11px] uppercase tracking-wide text-amber-600" title="{{ v.reason }}">AI — verify</span>
+      {% if can_verdict %}
+      <button type="button"
+              hx-post="/v2/partials/proactive/equivalence/verdict"
+              hx-vals='{{ {"part_a": query, "part_b": v.spelling, "verdict": "different", "origin": "search"}|tojson }}'
+              hx-target="closest span" hx-swap="outerHTML"
+              hx-confirm="Mark {{ v.spelling }} as NOT the same part as {{ query }}? This removes it from pooled results permanently."
+              class="text-amber-500 hover:text-rose-600" title="Not the same part">&#10005;</button>
+      {% endif %}
+      {% endif %}
+    </span>
+    {% endfor %}
+  </div>
+  {% endif %}
+
   {# ── Search input (pre-filled) ── #}
   <div class="relative mb-6 max-w-xl">
     <svg xmlns="http://www.w3.org/2000/svg" class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-brand-400"

--- a/app/templates/htmx/partials/shared/search_results.html
+++ b/app/templates/htmx/partials/shared/search_results.html
@@ -23,6 +23,15 @@
     </div>
     {% endif %}
 
+    {# ── Equivalence note (idea #21): variant-key rows are pooled in — label them
+         so a result titled with a different suffix never reads as wrong. #}
+    {% if results.equivalence %}
+    <div class="px-3 py-1.5 text-xs text-amber-700 bg-amber-50">
+      Includes known variants:
+      {% for v in results.equivalence.variants %}<span class="font-mono">{{ v.spelling }}</span>{% if not loop.last %}, {% endif %}{% endfor %}
+    </div>
+    {% endif %}
+
     {# ── Best match card ── #}
     {% if results.best_match %}
     {% set bm = results.best_match %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -5967,6 +5967,18 @@ fast_search(query, db, user)  — one universal entity search, grouped results:
     +---> Part number: matches Requirement / Offer / MaterialCard / Sighting by ILIKE
     |     AND by exact normalized_mpn == normalize_mpn_key(query) (separator-insensitive,
     |     index-backed), so a PN returns every req/offer/card/sighting it appears on.
+    +---> Equivalence-aware recall (idea #21): _equivalence_expansion pools the query's
+    |     stored part_equivalences verdict='same' class (human 'different' kill-switch
+    |     respected via expand_part; NO LLM at query time) into every normalized_mpn
+    |     match (`IN (class keys)`), and the result dict carries `equivalence.variants`
+    |     [{spelling, kind: ai|human, reason}]. full_results.html renders these as the
+    |     amber "Also matching known variants" banner — AI variants get the verify chip
+    |     + one-tap verdict=different POST to the existing proactive endpoint; the part
+    |     dossier hero shows the same as "Also known as" chips. A ZERO-hit MPN on the
+    |     deliberate results page (never the type-ahead) fires a background
+    |     _zero_hit_equivalence_sweep (own session, windowed spellings + the missed key
+    |     through classify_new_pairs limit=5, per-user throttle 5/min) so the next
+    |     search can pool variants.
     +---> Vendor: VendorCard surfaced by its own name/email/phone OR via a matching
     |     VendorContact (vendor_card_id subquery) OR a matching Offer.vendor_name — so a
     |     contact name / stocked MPN leads back to the card. Its contacts, offers, and

--- a/tests/test_equivalence_search_recall.py
+++ b/tests/test_equivalence_search_recall.py
@@ -1,0 +1,316 @@
+"""test_equivalence_search_recall.py — TDD tests for equivalence-aware search recall
+(survey idea #21).
+
+Covers:
+  - fast_search pools stored part_equivalences 'same' verdicts into the MPN match
+    (an offer stored under a variant key surfaces when the query's class includes
+    it) and returns an `equivalence` block naming the variants; a human
+    'different' verdict keeps the variant OUT; no verdicts → unchanged shape.
+  - The full search-results page renders the variants banner with the amber chip
+    + the existing one-tap 'not the same part' verdict form (AI variants only).
+  - Zero-hit full-page search enqueues a background classify sweep (throttled per
+    user); the type-ahead endpoint NEVER enqueues.
+  - The part-dossier hero shows the 'Also known as' variants.
+
+No LLM runs at query time — expansion is a stored-table join (the sanctioned
+part-number-only pooling table).
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_equivalence_search_recall.py -v)
+Depends on: app.services.global_search_service, app.services.part_equivalence,
+            app.routers.htmx.search_views, app.routers.part_dossier, conftest.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.constants import OfferStatus
+from app.models import Offer, Requirement, User
+from app.models.intelligence import PartEquivalence
+from app.models.sourcing import Requisition
+from app.services.global_search_service import fast_search
+
+_HX = {"HX-Request": "true"}
+
+
+def _seed_offer(db: Session, user: User, mpn: str, norm: str) -> Offer:
+    req = Requisition(
+        name=f"REQ-EQ-{norm[:8]}",
+        status="open",
+        customer_name="AcmeCo",
+        created_by=user.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(req)
+    db.flush()
+    rq = Requirement(requisition_id=req.id, primary_mpn=mpn, normalized_mpn=norm, created_at=datetime.now(UTC))
+    db.add(rq)
+    db.flush()
+    off = Offer(
+        requirement_id=rq.id,
+        vendor_name="Var Vendor",
+        vendor_name_normalized="var vendor",
+        mpn=mpn,
+        normalized_mpn=norm,
+        unit_price=2.0,
+        status=OfferStatus.ACTIVE.value,
+    )
+    db.add(off)
+    db.commit()
+    return off
+
+
+def _verdict(db: Session, a: str, b: str, verdict: str, source: str = "ai") -> None:
+    key_a, key_b = sorted((a, b))
+    db.add(
+        PartEquivalence(
+            key_a=key_a,
+            key_b=key_b,
+            example_a=key_a,
+            example_b=key_b,
+            verdict=verdict,
+            source=source,
+            reason="suffix variant" if verdict == "same" else "different family",
+        )
+    )
+    db.commit()
+
+
+# ── Service: fast_search pooling ───────────────────────────────────────────────
+
+
+class TestFastSearchEquivalence:
+    def test_ai_same_verdict_pools_variant_offer(self, db_session, test_user):
+        """Searching LTSR15NP surfaces the offer stored under LTSR15NPR."""
+        _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="ai")
+
+        results = fast_search("LTSR15-NPR", db_session, test_user)
+        offers = results["groups"].get("offers", [])
+        assert any(o.get("mpn") == "LTSR15-NP" for o in offers)
+        eq = results.get("equivalence")
+        assert eq is not None
+        variants = {v["spelling"]: v for v in eq["variants"]}
+        assert "LTSR15-NP" in variants  # the observed raw spelling for the variant key
+        assert all(v["kind"] == "ai" for v in variants.values())
+
+    def test_human_different_verdict_never_pools(self, db_session, test_user):
+        _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "different", source="human")
+
+        results = fast_search("LTSR15-NPR", db_session, test_user)
+        offers = results["groups"].get("offers", [])
+        assert not any(o.get("mpn") == "LTSR15-NP" for o in offers)
+        assert not results.get("equivalence")
+
+    def test_no_verdicts_leaves_shape_unchanged(self, db_session, test_user):
+        _seed_offer(db_session, test_user, "LM317T", "lm317t")
+        results = fast_search("LM317T", db_session, test_user)
+        assert any(o.get("mpn") == "LM317T" for o in results["groups"].get("offers", []))
+        assert results.get("equivalence") is None
+
+    def test_human_same_verdict_variant_kind_is_human(self, db_session, test_user):
+        _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="human")
+        results = fast_search("LTSR15-NPR", db_session, test_user)
+        eq = results.get("equivalence")
+        assert eq is not None
+        assert all(v["kind"] == "human" for v in eq["variants"])
+
+
+# ── Full results page: banner + verdict chip ───────────────────────────────────
+
+
+class TestResultsPageBanner:
+    def test_variants_banner_with_verdict_form(self, client, db_session, test_user):
+        _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="ai")
+
+        resp = client.get("/v2/partials/search/results?q=LTSR15-NPR", headers=_HX)
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Also matching" in body or "also known as" in body.lower()
+        assert "LTSR15-NP" in body
+        # AI variants carry the one-tap 'not the same part' demote button
+        # (conformant hx-post button with hx-vals — no form nested in the chip span).
+        assert "/v2/partials/proactive/equivalence/verdict" in body
+        assert "hx-vals" in body
+        assert "part_b" in body
+
+    def test_human_variant_has_no_verdict_form(self, client, db_session, test_user):
+        _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="human")
+        resp = client.get("/v2/partials/search/results?q=LTSR15-NPR", headers=_HX)
+        body = resp.text
+        assert "LTSR15-NP" in body
+        assert "/v2/partials/proactive/equivalence/verdict" not in body
+
+
+# ── Zero-hit enqueue ───────────────────────────────────────────────────────────
+
+
+class TestZeroHitEnqueue:
+    def test_results_page_zero_hit_enqueues_sweep(self, client, db_session, test_user):
+        with patch("app.routers.htmx.search_views._zero_hit_equivalence_sweep", new_callable=AsyncMock) as sweep:
+            resp = client.get("/v2/partials/search/results?q=ZZ99XX77", headers=_HX)
+        assert resp.status_code == 200
+        sweep.assert_called_once()
+        assert sweep.call_args.args[0] == "ZZ99XX77"
+
+    def test_results_page_hit_does_not_enqueue(self, client, db_session, test_user):
+        _seed_offer(db_session, test_user, "LM317T", "lm317t")
+        with patch("app.routers.htmx.search_views._zero_hit_equivalence_sweep", new_callable=AsyncMock) as sweep:
+            client.get("/v2/partials/search/results?q=LM317T", headers=_HX)
+        sweep.assert_not_called()
+
+    def test_typeahead_zero_hit_never_enqueues(self, client, db_session, test_user):
+        with patch("app.routers.htmx.search_views._zero_hit_equivalence_sweep", new_callable=AsyncMock) as sweep:
+            client.get("/v2/partials/search/global?q=ZZ99XX77", headers=_HX)
+        sweep.assert_not_called()
+
+    def test_zero_hit_enqueue_rate_limited(self, client, db_session, test_user):
+        with (
+            patch("app.routers.htmx.search_views.check_rate_limit", return_value=False),
+            patch("app.routers.htmx.search_views._zero_hit_equivalence_sweep", new_callable=AsyncMock) as sweep,
+        ):
+            client.get("/v2/partials/search/results?q=ZZ99XX77", headers=_HX)
+        sweep.assert_not_called()
+
+    def test_non_mpn_query_does_not_enqueue(self, client, db_session, test_user):
+        """A vendor-name-ish query with no usable MPN key must not burn AI calls."""
+        with patch("app.routers.htmx.search_views._zero_hit_equivalence_sweep", new_callable=AsyncMock) as sweep:
+            client.get("/v2/partials/search/results?q=ac", headers=_HX)
+        sweep.assert_not_called()
+
+
+# ── Part dossier hero ──────────────────────────────────────────────────────────
+
+
+def test_dossier_hero_shows_also_known_as(client, db_session, test_user):
+    _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+    _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="ai")
+    resp = client.get("/v2/partials/search/dossier/hero?mpn=LTSR15-NPR", headers=_HX)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "known as" in body.lower()
+    assert "LTSR15-NP" in body
+    assert "/v2/partials/proactive/equivalence/verdict" in body
+
+
+# ── Adversarial-review fixes (13 confirmed findings) ───────────────────────────
+
+
+class TestReviewFixes:
+    def test_word_query_zero_hit_does_not_enqueue(self, client, db_session, test_user):
+        """'arrow' has >=4 chars but no digit — vendor/contact words never burn AI."""
+        with patch("app.routers.htmx.search_views._zero_hit_equivalence_sweep", new_callable=AsyncMock) as sweep:
+            client.get("/v2/partials/search/results?q=arrow", headers=_HX)
+        sweep.assert_not_called()
+
+    def test_sweep_uses_safe_background_task(self, client, db_session, test_user):
+        """The sweep goes through the canonical strong-ref/error-isolated holder (P0.4
+        pattern) — never a bare asyncio.create_task."""
+        with (
+            patch("app.routers.htmx.search_views.safe_background_task", new_callable=AsyncMock) as sbt,
+            patch("app.routers.htmx.search_views._zero_hit_equivalence_sweep", new_callable=AsyncMock),
+        ):
+            client.get("/v2/partials/search/results?q=ZZ99XX77", headers=_HX)
+        sbt.assert_called_once()
+
+    async def test_classify_involving_filters_pairs(self, db_session):
+        """Involving= caps the sweep to pairs touching the missed key — both the spend
+        bound and the aim-at-the-searched-part fix."""
+        from app.services.part_equivalence import classify_new_pairs
+
+        spellings = {"lm317": "LM317", "lm317t": "LM317T", "zz991": "ZZ991", "zz991x": "ZZ991X"}
+        with patch(
+            "app.utils.claude_client.claude_json",
+            new_callable=AsyncMock,
+            return_value={"verdict": "same", "confidence": 0.9, "reason": "suffix"},
+        ) as cj:
+            stored = await classify_new_pairs(db_session, spellings, limit=5, involving="lm317")
+        assert stored == 1
+        assert cj.call_count == 1
+        rows = db_session.query(PartEquivalence).all()
+        assert {(r.key_a, r.key_b) for r in rows} == {("lm317", "lm317t")}
+
+    def test_ai_pooled_variant_stays_amber_despite_adjacent_human_edge(self, db_session, test_user):
+        """Review repro: aaa111x pooled ONLY via an AI edge must render kind='ai'
+        (verify chip shown) even though a human 'same' edge touches it elsewhere."""
+        _seed_offer(db_session, test_user, "AAA-111X", "aaa111x")
+        _verdict(db_session, "aaa111", "aaa111x", "same", source="ai")
+        _verdict(db_session, "aaa111x", "aaa111xz", "same", source="human")
+
+        results = fast_search("AAA-111", db_session, test_user)
+        eq = results.get("equivalence")
+        assert eq is not None
+        kind_by_key = {v["key"]: v["kind"] for v in eq["variants"]}
+        assert kind_by_key["aaa111x"] == "ai"
+        assert kind_by_key["aaa111xz"] == "human"
+
+    def test_restricted_user_variant_spelling_not_from_foreign_offer(self, db_session, test_user, sales_user):
+        """RESTRICTED_ROLES never see foreign offers' raw spellings in the banner — the
+        spelling falls back to the verdict row's own example."""
+        _seed_offer(db_session, test_user, "SECRET-15X-RAW", "secret15x")
+        key_a, key_b = sorted(("secret15", "secret15x"))
+        db_session.add(
+            PartEquivalence(
+                key_a=key_a,
+                key_b=key_b,
+                example_a="SECRET-15",
+                example_b="SECRET-15X",
+                verdict="same",
+                source="ai",
+                reason="suffix",
+            )
+        )
+        db_session.commit()
+
+        results = fast_search("SECRET-15", db_session, sales_user)
+        assert not results["groups"].get("offers")  # scope-gated as before
+        eq = results.get("equivalence")
+        assert eq is not None
+        spellings = [v["spelling"] for v in eq["variants"]]
+        assert "SECRET-15X-RAW" not in spellings
+        assert "SECRET-15X" in spellings
+
+    def test_banner_hidden_on_zero_result_page(self, client, db_session, test_user):
+        """A verdict with no matching rows must not claim 'Also matching…' on an empty
+        results page."""
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="ai")
+        resp = client.get("/v2/partials/search/results?q=LTSR15-NPR", headers=_HX)
+        assert resp.status_code == 200
+        assert "Also matching" not in resp.text
+
+    def test_typeahead_dropdown_labels_variants(self, client, db_session, test_user):
+        _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="ai")
+        resp = client.get("/v2/partials/search/global?q=LTSR15-NPR", headers=_HX)
+        assert resp.status_code == 200
+        assert "Includes known variants" in resp.text
+
+    def test_verdict_button_hidden_without_proactive_access(self, client, db_session, test_user):
+        _seed_offer(db_session, test_user, "LTSR15-NP", "ltsr15np")
+        _verdict(db_session, "ltsr15np", "ltsr15npr", "same", source="ai")
+        with patch("app.routers.htmx.search_views.user_has_access", return_value=False):
+            resp = client.get("/v2/partials/search/results?q=LTSR15-NPR", headers=_HX)
+        assert "LTSR15-NP" in resp.text  # banner still informs
+        assert "/v2/partials/proactive/equivalence/verdict" not in resp.text
+
+    def test_verdict_origin_search_returns_inline_snippet(self, client, db_session, test_user):
+        """Demoting from Search must NOT teleport into the Proactive Matches tab —
+        origin=search gets a tiny inline replacement for the chip."""
+        resp = client.post(
+            "/v2/partials/proactive/equivalence/verdict",
+            data={"part_a": "LTSR15-NPR", "part_b": "LTSR15-NP", "verdict": "different", "origin": "search"},
+            headers=_HX,
+        )
+        assert resp.status_code == 200
+        assert "removed" in resp.text.lower()
+        assert len(resp.text) < 600  # a chip-sized snippet, not the Matches tab
+        row = db_session.query(PartEquivalence).one()
+        assert row.verdict == "different"
+        assert row.source == "human"


### PR DESCRIPTION
Third build from the AI opportunity survey (specs/ai-opportunity-survey-2026-08-21.md, idea #21 — the verifiers' "would build first, highest value per line of code").

## What
Searching any spelling of a part now recalls rows stored under its **verified equivalents** — the stored `part_equivalences` class (human verdicts + AI 'same' verdicts, human-'different' kill-switch respected). **No LLM in the query path** — a stored-table join into the existing normalized-MPN match.

- Full results page: amber **"Also matching known variants"** banner; AI-pooled variants carry the verify chip + one-tap permanent demote (swaps just the chip — no Proactive-tab teleport; hidden for users without PROACTIVE access)
- Type-ahead dropdown: one-line "Includes known variants" label so a variant-titled row never reads as wrong
- Part dossier hero: "Also known as" chips, same demote
- Zero-hit MPN search (digit-bearing key, results page only, 5/min/user) seeds a **background** classify sweep via `safe_background_task`, scoped by the new `classify_new_pairs(involving=…)` filter to the searched part's pairs only
- `expand_parts` now returns `pool_source` so surfaces label variants by the edge that actually pooled them; RESTRICTED_ROLES get spellings from verdict examples, never foreign offers

## Review
17-agent adversarial find/refute: **13 confirmed findings, all fixed with regression tests** — bare `create_task` → canonical holder (P0.4 class), kind-misattribution (verified repro), demote teleport + invalid nested-form HTML, restricted-user spelling leak, sweep economics (involving-filter + digit gate + in-process latch), zero-result banner contradiction, access-gated affordance. 1 refuted.

## Verification
- 21 new tests in `tests/test_equivalence_search_recall.py`; neighbors green (search/proactive/part-equivalence suites, 597 tests)
- Full suite: **24307 passed / 0 real failures** (one text-size ratchet tripped and fixed: chip labels 10px→11px)
- pre-commit hooks pass; assertion-theater lint clean; APP_MAP updated. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skqbrbYAUTMGwxc3AwNN3