### PR TITLE
Resell reply → offer prefill: AI drafts bid lines from the buyer's reply

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -48,6 +48,7 @@ from ..dependencies import require_access, require_fresh_token
 from ..file_utils import ParseError, parse_tabular_file
 from ..models import Company, User, VendorCard, VendorResponse
 from ..models.excess import CustomerBid, ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine, ExcessOutreach
+from ..rate_limit import check_rate_limit
 from ..services import (
     bid_back_service,
     buyer_affinity_service,
@@ -56,6 +57,7 @@ from ..services import (
     resell_outreach_service,
     task_service,
 )
+from ..services.resell_reply_parse_service import parse_buyer_reply
 from ..template_env import template_response
 from ..utils.csv_export import stream_csv
 from ..utils.normalization import normalize_mpn_key
@@ -2584,6 +2586,49 @@ async def resell_outreach_reply(
             "replies": replies,
         },
     )
+
+
+@router.post("/v2/partials/resell/{list_id}/outreach/{outreach_id}/parse-reply", response_class=HTMLResponse)
+async def resell_outreach_parse_reply(
+    request: Request,
+    list_id: int,
+    outreach_id: int,
+    user: User = Depends(require_access(AccessKey.RESELL)),
+    db: Session = Depends(get_db),
+):
+    """AI-draft offer lines from the buyer's captured reply → the SAME viewer with
+    tappable draft rows pre-filling the convert form. No DB write — the trader reviews
+    and submits each line through the existing quick-add, and the mining pipeline's
+    auto-create path stays untouched (manual by recorded decision).
+
+    Ownership gates BEFORE the paid AI call; per-user throttle 10/min.
+    """
+    el, outreach = _load_outreach_for_owner(db, list_id, outreach_id, user)
+    replies = _conversation_replies(db, outreach.graph_conversation_id)
+
+    def _viewer(**extra):
+        return template_response(
+            "htmx/partials/resell/_reply_viewer.html",
+            {"request": request, "user": user, "list": el, "outreach": outreach, "replies": replies, **extra},
+        )
+
+    if not replies:
+        return _viewer(ai_note="No captured reply text to parse — record the bid manually below.")
+    if not check_rate_limit(user.id, "resell_reply_parse", limit=10, window_seconds=60):
+        return _viewer(ai_note="Too many parse attempts — wait a minute and try again.")
+
+    line_mpns = [
+        pn for (pn,) in db.query(ExcessLineItem.part_number).filter(ExcessLineItem.excess_list_id == el.id).all() if pn
+    ]
+    reply_text = "\n\n".join((vr.body or "") for vr in replies)
+    drafted = await parse_buyer_reply(reply_text, line_mpns=line_mpns)
+    if drafted is None:
+        return _viewer(ai_note="AI could not parse that reply — record the bid manually below.")
+    if not drafted["lines"] and not drafted["take_all"]:
+        # A designed, common outcome (buyer passed / asked a question) — say so
+        # instead of re-rendering a byte-identical viewer with no feedback.
+        return _viewer(ai_note="The AI found no concrete bid in this reply — record it manually below.")
+    return _viewer(ai_lines=drafted["lines"], ai_take_all=drafted["take_all"])
 
 
 @router.post("/api/resell/{list_id}/outreach/{outreach_id}/offer", response_class=HTMLResponse)

--- a/app/services/resell_reply_parse_service.py
+++ b/app/services/resell_reply_parse_service.py
@@ -1,0 +1,131 @@
+"""resell_reply_parse_service.py — AI draft of offer lines from a buyer's resell reply.
+
+Purpose:
+  The on-demand "Draft offer from reply" button on the resell reply viewer. The
+  buyer's inbound bid email (already matched to the outreach by the inbox poll's
+  Tier 2.5 pass, which DELIBERATELY leaves it unparsed) goes through one
+  claude_structured call scoped to the list's line MPNs. The result renders as
+  tappable draft rows that pre-fill the existing convert-to-offer form — the
+  trader reviews and submits each line themselves. This module never writes to
+  the database, and the inbox-mining >=0.8 auto-create path stays untouched:
+  manual extraction there is a recorded design decision.
+
+Called by: routers/resell.py (POST /v2/partials/resell/{list}/outreach/{o}/parse-reply)
+Depends on: utils/claude_client, utils/claude_errors, utils/normalization
+"""
+
+import re
+
+from loguru import logger
+
+from app.utils import claude_client
+from app.utils.claude_errors import ClaudeError
+from app.utils.normalization import normalize_mpn_key
+
+_MAX_TEXT_CHARS = 20_000
+_MAX_LINES = 100
+
+REPLY_PARSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "take_all": {
+            "type": ["boolean", "null"],
+            "description": "True only if the buyer clearly bids on the WHOLE list, not specific lines",
+        },
+        "lines": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "mpn": {"type": ["string", "null"], "description": "Part number the bid line refers to, verbatim"},
+                    "quantity": {"type": ["integer", "null"]},
+                    "unit_price": {"type": ["number", "null"]},
+                    "lead_time_days": {"type": ["integer", "null"]},
+                    "terms": {"type": ["string", "null"], "description": "Payment/packaging/date-code terms stated"},
+                    "notes": {"type": ["string", "null"], "description": "Other context from the reply for this line"},
+                },
+            },
+        },
+    },
+    "required": ["lines"],
+}
+
+REPLY_PARSE_SYSTEM = """You extract a buyer's bid from their reply to an excess-inventory offer list.
+
+Context: We offered a list of excess parts; the buyer replied with a bid — often terse, phone-typed, one or two lines.
+The user message starts with the list's part numbers, then the reply text.
+
+Rules:
+- One line per part the buyer bids on. mpn verbatim as the buyer wrote it (match to the list's part numbers when clearly intended).
+- quantity / unit_price / lead_time_days: only when stated. NEVER invent or infer a price.
+- take_all: true ONLY when the buyer clearly wants the entire list ("take them all", "whole lot").
+- terms: payment/packaging/date-code conditions stated. notes: any other per-line context.
+- Empty lines array when the reply contains no actual bid."""
+
+
+def _clean_str(value: object, max_len: int = 255) -> str | None:
+    if value is None:
+        return None
+    return str(value).strip()[:max_len] or None
+
+
+def _pos_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+async def parse_buyer_reply(reply_text: str, *, line_mpns: list[str]) -> dict | None:
+    """Parse a buyer's reply into sanitized draft offer lines scoped to the list.
+
+    Returns None when the AI call fails, else {"take_all": bool, "lines": [...]}
+    where each line carries on_list (normalized-key membership in *line_mpns*) so
+    the UI can flag bids that don't match any posted line. Never writes.
+    """
+    # Strip only tag-SHAPED spans (start with a letter or /letter, or a comment) so
+    # plain-text angle-bracket content a buyer typed — "<$2.00 each>", "qty <500>" —
+    # survives to the model. Pre-slice at 10× the cap bounds the regex scan on a
+    # flooded thread; the real char budget is applied to the stripped text.
+    text = re.sub(r"</?[A-Za-z][^>]*>|<!--.*?-->", " ", (reply_text or "")[: _MAX_TEXT_CHARS * 10])
+    text = text.strip()[:_MAX_TEXT_CHARS]
+    if not text:
+        return None
+
+    prompt = "List part numbers: " + ", ".join(line_mpns[:200]) + "\n\nBuyer reply:\n" + text
+    try:
+        # Interactive HTMX caller: single attempt, tightened timeout (P2.8 pattern).
+        ai = await claude_client.claude_structured(
+            prompt,
+            REPLY_PARSE_SCHEMA,
+            system=REPLY_PARSE_SYSTEM,
+            model_tier="fast",
+            max_tokens=4096,
+            timeout=45,
+            max_attempts=1,
+            cost_bucket="resell_reply_parse",
+        )
+    except ClaudeError as e:
+        logger.warning("resell reply parse failed: {}", e)
+        return None
+    if ai is None:
+        return None
+
+    list_keys = {normalize_mpn_key(m) for m in line_mpns if m}
+    lines: list[dict] = []
+    for raw in (ai.get("lines") or [])[:_MAX_LINES]:
+        if not isinstance(raw, dict):
+            continue
+        mpn = _clean_str(raw.get("mpn"))
+        if not mpn:
+            continue
+        price = raw.get("unit_price")
+        lines.append(
+            {
+                "mpn": mpn,
+                "quantity": _pos_int(raw.get("quantity")),
+                "unit_price": float(price) if isinstance(price, (int, float)) and price >= 0 else None,
+                "lead_time_days": _pos_int(raw.get("lead_time_days")),
+                "terms": _clean_str(raw.get("terms")),
+                "notes": _clean_str(raw.get("notes"), 1000),
+                "on_list": normalize_mpn_key(mpn) in list_keys,
+            }
+        )
+    return {"take_all": bool(ai.get("take_all")), "lines": lines}

--- a/app/templates/htmx/partials/resell/_reply_viewer.html
+++ b/app/templates/htmx/partials/resell/_reply_viewer.html
@@ -17,7 +17,9 @@
    points the convert form at the right POST route (email-convert vs manual log-bid). #}
 {% set manual = manual|default(false) %}
 {% set convert_url = convert_url|default('/api/resell/' ~ el.id ~ '/outreach/' ~ outreach.id ~ '/offer') %}
-<div class="p-5" x-data="{ showConvert: {{ 'false' if outreach.status == 'bid' else 'true' }} }">
+<div class="p-5" id="resell-reply-viewer"
+     x-data="{ showConvert: {{ 'true' if outreach.status != 'bid' else 'false' }} }"
+     @open-convert="showConvert = true">
 
   {# ── Header ─────────────────────────────────────────────────────── #}
   <div class="flex items-start justify-between gap-3 mb-4">
@@ -71,6 +73,73 @@
   </div>
   {% endif %}
 
+  {# ── AI draft from reply (survey idea #3): parse the captured reply into
+       tappable draft rows — the convert form below stays the ONLY write path.
+       This whole block is its own swap target so a parse never re-renders (and
+       wipes) the convert form the trader may be typing in. The AI JSON rides a
+       SINGLE-quoted data-* carrier (tojson escapes < > & ') read via JSON.parse —
+       never inlined into a double-quoted x-data attribute (XSS + attr-truncation).
+       fill(i) opens the form by dispatching open-convert to the viewer root. ── #}
+  {% if not manual %}
+  <div id="ai-draft-results" class="mt-4"
+       data-ai-lines='{{ (ai_lines or []) | tojson }}'
+       x-data="{ parsing: false,
+                 aiLines: JSON.parse($el.dataset.aiLines || '[]'),
+                 fill(i) {
+                   const l = this.aiLines[i];
+                   const f = document.getElementById('convert-offer-form');
+                   if (!f) return;
+                   f.mpn_raw.value = l.mpn || '';
+                   f.quantity.value = l.quantity ?? '';
+                   f.unit_price.value = l.unit_price ?? '';
+                   f.lead_time_days.value = l.lead_time_days ?? '';
+                   f.terms_text.value = l.terms || '';
+                   f.notes.value = l.notes || '';
+                   this.$dispatch('open-convert');
+                 } }">
+    {% if replies %}
+    <button type="button"
+            hx-post="/v2/partials/resell/{{ el.id }}/outreach/{{ outreach.id }}/parse-reply"
+            hx-target="#ai-draft-results" hx-select="#ai-draft-results" hx-swap="outerHTML"
+            @htmx:before-request="parsing = true"
+            @htmx:after-request="parsing = false"
+            data-loading-disable :disabled="parsing"
+            class="btn btn-secondary btn-sm">
+      <span x-text="parsing ? 'Drafting…' : 'Draft offer from reply (AI)'">Draft offer from reply (AI)</span>
+    </button>
+    {% endif %}
+    {% if ai_note %}
+    <p class="mt-2 text-xs text-rose-600">{{ ai_note }}</p>
+    {% endif %}
+    {% if ai_take_all %}
+    <div class="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+      The buyer appears to bid on the <span class="font-semibold">whole list</span> (take-all). This form records
+      <span class="font-semibold">individual per-line offers only</span> — enter each quoted line below and capture
+      the take-all intent in Notes (a take-all scope is not recorded here).
+    </div>
+    {% endif %}
+    {% if ai_lines %}
+    <div class="mt-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5 space-y-1.5">
+      <div class="text-xs font-semibold text-amber-800">AI-drafted from the reply — tap Use, verify every field, then save.</div>
+      {% for l in ai_lines %}
+      <div class="flex flex-wrap items-center gap-2 rounded border border-amber-300 bg-white px-2 py-1 text-xs">
+        <span class="font-mono">{{ l.mpn }}</span>
+        <span class="text-gray-600">qty {{ l.quantity if l.quantity is not none else '—' }}</span>
+        <span class="text-gray-600">${{ l.unit_price if l.unit_price is not none else '—' }}</span>
+        {% if l.lead_time_days is not none %}<span class="text-gray-600">{{ l.lead_time_days }}d lead</span>{% endif %}
+        {% if l.terms %}<span class="text-gray-500">{{ l.terms }}</span>{% endif %}
+        {% if not l.on_list %}
+        <span class="rounded bg-rose-50 px-1 py-0.5 text-[11px] text-rose-600 border border-rose-200">not on this list</span>
+        {% endif %}
+        <button type="button" @click="fill({{ loop.index0 }})"
+                class="ml-auto text-accent-600 hover:text-accent-700 font-medium">Use</button>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+  {% endif %}
+
   {# ── Convert to offer ───────────────────────────────────────────── #}
   <div class="mt-5 pt-4 border-t border-gray-100">
     <div class="flex items-center justify-between">
@@ -83,7 +152,7 @@
     </div>
     <p class="text-secondary mt-0.5">Record the buyer's price and quantity as a tracked offer.</p>
 
-    <form x-show="showConvert" x-cloak
+    <form x-show="showConvert" x-cloak id="convert-offer-form"
           hx-post="{{ convert_url }}"
           hx-target="#tab-outreach-{{ el.id }}"
           hx-swap="innerHTML"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1536,6 +1536,18 @@ email_service.poll_inbox()
     |             per-line campaign sharing one conversation logs the reply once and
     |             never collides with the requisition-side log_email_activity row).
     |             A PURELY-resell reply (no Contact) skips AI parsing (never billed).
+    |             ON-DEMAND prefill (idea #3): the reply viewer's "Draft offer from
+    |             reply (AI)" button POSTs /v2/partials/resell/{list}/outreach/{o}/
+    |             parse-reply (owner-gated + 10/min throttle BEFORE the AI call).
+    |             resell_reply_parse_service.parse_buyer_reply strips HTML, one fast
+    |             claude_structured call scoped to the list's line MPNs → sanitized
+    |             draft rows {mpn,qty,unit_price,lead_time_days,terms,notes,on_list}
+    |             + take_all flag. Rows render in #ai-draft-results (its own swap
+    |             target so a parse never wipes the convert form); "Use" fills the
+    |             existing convert-to-offer form via a single-quoted data-ai-lines
+    |             carrier + JSON.parse (never inlined into double-quoted x-data — XSS
+    |             + attr-truncation). NO db write on parse; convert stays the sole
+    |             write path; the >=0.8 mining auto-create path is untouched.
     |
     v
 ai_email_parser.py

--- a/tests/test_resell_reply_prefill.py
+++ b/tests/test_resell_reply_prefill.py
@@ -1,0 +1,410 @@
+"""test_resell_reply_prefill.py — TDD tests for resell reply → offer prefill (survey
+idea #3, the seam email_service.py's Tier 2.5 comment reserved).
+
+Covers:
+  - parse_buyer_reply service: extraction scoped to the list's line MPNs (on_list
+    cross-check via normalized keys), sanitized fields, take-all flag, HTML tags
+    stripped before the model, None on AI failure.
+  - POST /v2/partials/resell/{list}/outreach/{o}/parse-reply: owner-gated BEFORE
+    the AI call, per-user throttled, re-renders the reply viewer with tappable
+    AI-drafted line rows — NO ExcessOffer is written (the existing convert-to-offer
+    quick-add stays the single write path; the >=0.8 mining auto-create path is
+    deliberately untouched).
+  - The reply viewer renders the "Draft offer from reply" button when replies exist.
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_resell_reply_prefill.py -v)
+Depends on: app.services.resell_reply_parse_service, app.routers.resell, conftest
+            (client/db_session/test_user), seeds mirrored from test_resell_reply_routes.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import Company, ExcessList, ExcessOutreach, User, VendorCard, VendorResponse
+from app.models.excess import ExcessLineItem, ExcessOffer
+
+_HX = {"HX-Request": "true"}
+
+# ── Seeds (mirroring test_resell_reply_routes.py) ──────────────────────────────
+
+
+@pytest.fixture()
+def buyer_card(db_session: Session) -> VendorCard:
+    vc = VendorCard(normalized_name="buyer two", display_name="Buyer Two", emails=["sales@buyertwo.com"])
+    db_session.add(vc)
+    db_session.commit()
+    return vc
+
+
+def _seed_list(db: Session, owner: User) -> ExcessList:
+    co = Company(name="Prefill Seller")
+    db.add(co)
+    db.flush()
+    el = ExcessList(company_id=co.id, owner_id=owner.id, title="Prefill Excess", status="open")
+    db.add(el)
+    db.flush()
+    for pn, norm in (("XCVU9P-2FLGA2104I", "xcvu9p2flga2104i"), ("LM317T", "lm317t")):
+        db.add(ExcessLineItem(excess_list_id=el.id, part_number=pn, normalized_part_number=norm, quantity=100))
+    db.commit()
+    return el
+
+
+def _seed_outreach(db: Session, el: ExcessList, card: VendorCard, owner: User, *, conv="conv-p") -> ExcessOutreach:
+    row = ExcessOutreach(
+        excess_list_id=el.id,
+        target_vendor_card_id=card.id,
+        submitted_by=owner.id,
+        channel="email",
+        status="responded",
+        graph_conversation_id=conv,
+        graph_message_id="msg-p",
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+def _seed_reply(db: Session, conv: str, body: str) -> VendorResponse:
+    vr = VendorResponse(
+        vendor_name="Buyer Two",
+        vendor_email="sales@buyertwo.com",
+        subject="RE: excess",
+        body=body,
+        graph_conversation_id=conv,
+        received_at=datetime.now(UTC),
+        status="matched",
+    )
+    db.add(vr)
+    db.commit()
+    return vr
+
+
+_AI_RESULT = {
+    "take_all": False,
+    "lines": [
+        {
+            "mpn": "XCVU9P-2FLGA2104I",
+            "quantity": 40,
+            "unit_price": 1150.0,
+            "lead_time_days": 5,
+            "terms": "net 30",
+            "notes": "prefers full reels",
+        },
+        {
+            "mpn": "NOT-ON-LIST-1",
+            "quantity": 10,
+            "unit_price": 2.0,
+            "lead_time_days": None,
+            "terms": None,
+            "notes": None,
+        },
+    ],
+}
+
+
+# ── Service ────────────────────────────────────────────────────────────────────
+
+
+class TestParseBuyerReply:
+    async def test_scoped_parse_flags_off_list_lines(self):
+        from app.services.resell_reply_parse_service import parse_buyer_reply
+
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_AI_RESULT):
+            result = await parse_buyer_reply(
+                "<p>We will take 40 of the XCVU9P at $1150</p>",
+                line_mpns=["XCVU9P-2FLGA2104I", "LM317T"],
+            )
+        assert result is not None
+        assert result["take_all"] is False
+        by_mpn = {ln["mpn"]: ln for ln in result["lines"]}
+        assert by_mpn["XCVU9P-2FLGA2104I"]["on_list"] is True
+        assert by_mpn["XCVU9P-2FLGA2104I"]["quantity"] == 40
+        assert by_mpn["NOT-ON-LIST-1"]["on_list"] is False
+
+    async def test_html_stripped_before_model(self):
+        from app.services.resell_reply_parse_service import parse_buyer_reply
+
+        with patch(
+            "app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_AI_RESULT
+        ) as mock:
+            await parse_buyer_reply("<div><b>take</b> 40</div>", line_mpns=["LM317T"])
+        prompt = mock.call_args.args[0]
+        assert "<div>" not in prompt and "<b>" not in prompt
+        assert "take" in prompt and "40" in prompt
+
+    async def test_sanitizes_and_drops_mpnless_lines(self):
+        from app.services.resell_reply_parse_service import parse_buyer_reply
+
+        ai = {
+            "take_all": None,
+            "lines": [
+                {
+                    "mpn": "  LM317T ",
+                    "quantity": -5,
+                    "unit_price": -1,
+                    "lead_time_days": "soon",
+                    "terms": "x" * 400,
+                    "notes": None,
+                },
+                {"mpn": None, "quantity": 5, "unit_price": 1.0, "lead_time_days": 1, "terms": None, "notes": None},
+            ],
+        }
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=ai):
+            result = await parse_buyer_reply("text", line_mpns=["LM317T"])
+        assert result is not None
+        assert len(result["lines"]) == 1
+        line = result["lines"][0]
+        assert line["mpn"] == "LM317T"
+        assert line["quantity"] is None  # negative dropped
+        assert line["unit_price"] is None  # negative dropped
+        assert line["lead_time_days"] is None  # non-int dropped
+        assert len(line["terms"]) <= 255
+        assert result["take_all"] is False  # null coerced to False
+
+    async def test_ai_failure_returns_none(self):
+        from app.services.resell_reply_parse_service import parse_buyer_reply
+
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=None):
+            assert await parse_buyer_reply("text", line_mpns=["LM317T"]) is None
+
+
+# ── Route ──────────────────────────────────────────────────────────────────────
+
+
+class TestParseReplyRoute:
+    def _url(self, el, o):
+        return f"/v2/partials/resell/{el.id}/outreach/{o.id}/parse-reply"
+
+    def test_parse_renders_draft_rows_without_writing(self, client, db_session, test_user, buyer_card):
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "We'll take 40 XCVU9P at $1150, net 30")
+        drafted = {
+            "take_all": False,
+            "lines": [
+                {
+                    "mpn": "XCVU9P-2FLGA2104I",
+                    "quantity": 40,
+                    "unit_price": 1150.0,
+                    "lead_time_days": 5,
+                    "terms": "net 30",
+                    "notes": None,
+                    "on_list": True,
+                },
+                {
+                    "mpn": "NOT-ON-LIST-1",
+                    "quantity": 10,
+                    "unit_price": 2.0,
+                    "lead_time_days": None,
+                    "terms": None,
+                    "notes": None,
+                    "on_list": False,
+                },
+            ],
+        }
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock, return_value=drafted):
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert resp.status_code == 200
+        body = resp.text
+        assert "XCVU9P-2FLGA2104I" in body
+        assert "1150" in body
+        assert "Use" in body  # tappable fill affordance per drafted line
+        assert "not on this list" in body.lower()  # off-list cross-check flag
+        assert "Save offer" in body  # the convert form (single write path) is intact
+        assert db_session.query(ExcessOffer).count() == 0  # parse never writes
+
+    def test_parse_take_all_note(self, client, db_session, test_user, buyer_card):
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "We'll take the whole lot")
+        drafted = {"take_all": True, "lines": []}
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock, return_value=drafted):
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert "whole list" in resp.text.lower() or "take-all" in resp.text.lower()
+
+    def test_parse_no_replies_notes_without_ai(self, client, db_session, test_user, buyer_card):
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user, conv="conv-empty")
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock) as mock:
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert resp.status_code == 200
+        assert "no captured reply" in resp.text.lower()
+        mock.assert_not_called()
+
+    def test_parse_non_owner_gated_before_ai(self, client, db_session, test_user, buyer_card):
+        other = User(email="prefill-other@trioscs.com", name="Other", role="trader", azure_id="prefill-other")
+        db_session.add(other)
+        db_session.commit()
+        el = _seed_list(db_session, other)
+        o = _seed_outreach(db_session, el, buyer_card, other)
+        _seed_reply(db_session, "conv-p", "bid text")
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock) as mock:
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert resp.status_code in (403, 404)
+        mock.assert_not_called()
+
+    def test_parse_rate_limited_notes_without_ai(self, client, db_session, test_user, buyer_card):
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "bid text")
+        with (
+            patch("app.routers.resell.check_rate_limit", return_value=False),
+            patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock) as mock,
+        ):
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert resp.status_code == 200
+        assert "too many" in resp.text.lower()
+        mock.assert_not_called()
+
+    def test_parse_ai_failure_notes_and_keeps_form(self, client, db_session, test_user, buyer_card):
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "bid text")
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock, return_value=None):
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert resp.status_code == 200
+        assert "could not parse" in resp.text.lower()
+        assert "Save offer" in resp.text
+
+
+# ── Viewer affordance ──────────────────────────────────────────────────────────
+
+
+def test_reply_viewer_renders_draft_button(client, db_session, test_user, buyer_card):
+    el = _seed_list(db_session, test_user)
+    o = _seed_outreach(db_session, el, buyer_card, test_user)
+    _seed_reply(db_session, "conv-p", "We'll take them")
+    resp = client.get(f"/v2/partials/resell/{el.id}/outreach/{o.id}/reply", headers=_HX)
+    assert resp.status_code == 200
+    assert f"/v2/partials/resell/{el.id}/outreach/{o.id}/parse-reply" in resp.text
+    assert "Draft offer from reply" in resp.text
+
+
+# ── Adversarial-review fixes (9 confirmed findings) ────────────────────────────
+
+
+class TestReviewFixes:
+    _PAYLOAD = 'x" onmouseover="alert(1)" data-z="'
+
+    def _url(self, el, o):
+        return f"/v2/partials/resell/{el.id}/outreach/{o.id}/parse-reply"
+
+    def test_xss_payload_cannot_break_xdata_attribute(self, client, db_session, test_user, buyer_card):
+        """A malicious mpn must NOT break out of the x-data/data attribute — the AI JSON
+        rides in a single-quoted data-* carrier (tojson escapes < > & ')."""
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "bid")
+        drafted = {
+            "take_all": False,
+            "lines": [
+                {
+                    "mpn": self._PAYLOAD,
+                    "quantity": 1,
+                    "unit_price": None,
+                    "lead_time_days": None,
+                    "terms": None,
+                    "notes": None,
+                    "on_list": False,
+                }
+            ],
+        }
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock, return_value=drafted):
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert resp.status_code == 200
+        # The raw attribute-injection substring must never appear unescaped.
+        assert 'onmouseover="alert(1)"' not in resp.text
+
+    def test_xdata_json_carrier_is_parseable(self, client, db_session, test_user, buyer_card):
+        """The aiLines JSON must survive intact (double quotes not truncated) — the
+        component-break bug.
+
+        The single-quoted data attribute holds valid JSON.
+        """
+        import html as _html
+        import re as _re
+
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "bid")
+        drafted = {
+            "take_all": False,
+            "lines": [
+                {
+                    "mpn": "LM317T",
+                    "quantity": 40,
+                    "unit_price": 1150.0,
+                    "lead_time_days": 5,
+                    "terms": "net 30",
+                    "notes": None,
+                    "on_list": True,
+                }
+            ],
+        }
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock, return_value=drafted):
+            resp = client.post(self._url(el, o), headers=_HX)
+        m = _re.search(r"data-ai-lines='([^']*)'", resp.text)
+        assert m, "single-quoted data-ai-lines carrier not found"
+        parsed = json.loads(_html.unescape(m.group(1)))
+        assert parsed[0]["mpn"] == "LM317T"
+        assert parsed[0]["quantity"] == 40
+
+    def test_draft_button_swaps_only_ai_section(self, client, db_session, test_user, buyer_card):
+        """The Draft button targets #ai-draft-results (hx-select), never the whole
+        viewer — so a part-typed convert form survives a parse."""
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "bid")
+        resp = client.get(f"/v2/partials/resell/{el.id}/outreach/{o.id}/reply", headers=_HX)
+        body = resp.text
+        assert 'id="ai-draft-results"' in body
+        assert 'hx-target="#ai-draft-results"' in body
+        assert 'hx-select="#ai-draft-results"' in body
+
+    def test_empty_bid_result_shows_note(self, client, db_session, test_user, buyer_card):
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "thanks, we'll pass")
+        drafted = {"take_all": False, "lines": []}
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock, return_value=drafted):
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert "found no" in resp.text.lower() and "bid" in resp.text.lower()
+
+    async def test_plain_text_angle_bracket_price_survives_strip(self):
+        """A plain-text reply's '<$2.00 each>' must reach the model — only real tag-
+        shaped spans are stripped."""
+        from app.services.resell_reply_parse_service import parse_buyer_reply
+
+        with patch(
+            "app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_AI_RESULT
+        ) as mock:
+            await parse_buyer_reply("we can do <$2.00 each> on qty <500>", line_mpns=["LM317T"])
+        prompt = mock.call_args.args[0]
+        assert "$2.00 each" in prompt
+        assert "500" in prompt
+
+    async def test_real_html_tags_still_stripped(self):
+        from app.services.resell_reply_parse_service import parse_buyer_reply
+
+        with patch(
+            "app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_AI_RESULT
+        ) as mock:
+            await parse_buyer_reply("<div><b>take 40</b></div><!-- hi -->", line_mpns=["LM317T"])
+        prompt = mock.call_args.args[0]
+        assert "<div>" not in prompt and "<b>" not in prompt and "<!--" not in prompt
+        assert "take 40" in prompt
+
+    def test_take_all_banner_is_honest_about_per_line(self, client, db_session, test_user, buyer_card):
+        el = _seed_list(db_session, test_user)
+        o = _seed_outreach(db_session, el, buyer_card, test_user)
+        _seed_reply(db_session, "conv-p", "we'll take the whole lot")
+        drafted = {"take_all": True, "lines": []}
+        with patch("app.routers.resell.parse_buyer_reply", new_callable=AsyncMock, return_value=drafted):
+            resp = client.post(self._url(el, o), headers=_HX)
+        assert "per-line" in resp.text.lower() or "individual" in resp.text.lower()


### PR DESCRIPTION
Fourth build from the AI opportunity survey (specs/ai-opportunity-survey-2026-08-21.md, idea #3 — the seam email_service.py's Tier 2.5 comment literally reserved).

## What
The resell reply viewer gains **"Draft offer from reply (AI)"**. It parses the buyer's captured bid email into tappable draft rows — the owner stops hand-compiling multi-bidder sheets and typing each line.

- `POST /v2/partials/resell/{list}/outreach/{o}/parse-reply` → `resell_reply_parse_service.parse_buyer_reply`: HTML stripped, one fast `claude_structured` call **scoped to the list's line MPNs**, sanitized rows `{mpn, quantity, unit_price, lead_time_days, terms, notes, on_list}` + a `take_all` flag
- Rows render in their own `#ai-draft-results` swap target; **"Use"** fills the existing convert-to-offer form (the single write path — parse never writes)
- Gates BEFORE the AI call: owner-only (`_load_outreach_for_owner`), replies-exist, 10/min per-user throttle. The `>=0.8` mining auto-create path is deliberately untouched. Customer identity stays hidden — the parse sees only reply text + line MPNs.

## Review
12-agent adversarial find/refute: **9 confirmed findings, all fixed with regression tests.** The critical one: AI-derived line values inlined into a **double-quoted** `x-data` via `tojson` — Jinja's `tojson` doesn't escape `"`, so a malicious "part number" broke out into a live `onmouseover` handler AND truncated the attribute (dead component on every parse). Now carried in a **single-quoted `data-ai-lines`** attribute + `JSON.parse`. Also fixed: form-wipe on re-render (own swap target), silent empty-bid result, plain-text `<$2.00>` eaten by a naive tag-strip, dishonest take-all banner.

## Verification
- 18 new tests in `tests/test_resell_reply_prefill.py` (incl. an XSS-payload attribute-integrity test + a JSON-carrier parse test); neighbors green (112 resell tests)
- **Browser dry run** vs throwaway-Postgres rig, real Claude call, real modal UI: **8/8** — drafted 2 lines, "Use" filled the form, explicit XSS guard (no injected handler fired), Alpine component alive
- Full suite **24327 passed / 0 failed**; hooks + assertion-theater lint clean; APP_MAP updated. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skqbrbYAUTMGwxc3AwNN3