### PR TITLE
Ask AVAIL: natural-language questions → whitelisted report templates + CSV

### DIFF
--- a/app/routers/htmx/search_views.py
+++ b/app/routers/htmx/search_views.py
@@ -17,7 +17,7 @@ import asyncio
 import html as html_mod
 import json
 
-from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -65,13 +65,64 @@ async def ai_search_endpoint(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """AI-powered search — triggered by Enter key."""
+    """AI-powered search — triggered by Enter key.
+
+    Ask AVAIL first: a question that maps to a whitelisted report template renders
+    the result table (idea #18). Anything else falls through to entity search.
+    """
+    from ...services.ask_avail_service import answer_question
     from ...services.global_search_service import ai_search
+
+    # Only dispatch the report classifier for question-shaped input (>=3 words or a
+    # trailing '?'), so a bare MPN/vendor lookup never pays a second Claude call on
+    # top of ai_search's own. Throttled per user; on refusal skip to entity search.
+    qs = q.strip()
+    looks_like_question = qs.endswith("?") or len(qs.split()) >= 3
+    if qs and looks_like_question and check_rate_limit(user.id, "ask_avail", limit=20, window_seconds=60):
+        ask = await answer_question(db, user, q)
+        if ask["matched"]:
+            return template_response(
+                "htmx/partials/search/ask_result.html",
+                {**_base_ctx(request, user), "ask": ask, "query": q},
+            )
 
     results = await ai_search(q, db, user)
     return template_response(
         "htmx/partials/shared/search_results.html",
         {**_base_ctx(request, user), "results": results, "query": q, "ai_search": True},
+    )
+
+
+@router.get("/v2/partials/search/ask.csv")
+async def ask_avail_csv(
+    template: str = "",
+    params: str = "",
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Stream the exact Ask AVAIL template result as CSV (deterministic re-run).
+
+    Params arrive as a JSON string echoed from the rendered result; an unknown template
+    404s (never free SQL — the name is validated against the registry).
+    """
+    import json as _json
+
+    from ...services.ask_avail_service import TEMPLATES, run_template
+    from ...utils.csv_export import stream_csv
+
+    if template not in TEMPLATES:
+        raise HTTPException(404, "Unknown report template")
+    try:
+        parsed = _json.loads(params) if params else {}
+    except _json.JSONDecodeError:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    cols, rows, _effective = run_template(db, user, template, parsed)
+    return stream_csv(
+        filename=f"{template}.csv",
+        header=cols,
+        rows=([row.get(c) for c in cols] for row in rows),
     )
 
 

--- a/app/services/ask_avail_service.py
+++ b/app/services/ask_avail_service.py
@@ -1,0 +1,573 @@
+"""ask_avail_service.py — Ask AVAIL: NL questions → whitelisted query templates.
+
+Purpose (survey idea #18):
+  A typed question is mapped by Claude to ONE named, parameterized query template
+  and its parameters — NEVER free SQL. Each template is a hand-written ORM query
+  returning a uniform (columns, rows) table the caller renders with a one-tap CSV.
+  This fills the reporting-page gap without a BI page. When no template matches,
+  the caller falls through to the existing entity search.
+
+Security:
+  - Claude only chooses a template NAME (validated against the registry) and fills
+    a params dict; parameters are coerced per template (ints bounded, dates ISO,
+    strings capped) and only ever bound through the ORM — never string-interpolated.
+  - Requisition-scoped templates apply the same ownership read-gating as
+    global search for RESTRICTED_ROLES (sales/trader see only requisitions they own).
+
+Called by: routers/htmx/search_views.py (Enter-key ai_search path + ask.csv export)
+Depends on: utils/claude_client, utils/claude_errors, the ORM models, constants.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.constants import (
+    RESTRICTED_ROLES,
+    ActivityType,
+    BuyPlanLineStatus,
+    OfferStatus,
+    PrepaymentStatus,
+    QuoteStatus,
+    RequisitionStatus,
+)
+from app.models.auth import User
+from app.models.buy_plan import BuyPlan, BuyPlanLine
+from app.models.intelligence import ActivityLog, MaterialCard
+from app.models.offers import Offer
+from app.models.quality_plan import Prepayment
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+from app.utils.claude_client import claude_structured
+from app.utils.claude_errors import ClaudeError, ClaudeUnavailableError
+from app.utils.sql_helpers import escape_like
+from app.vendor_utils import normalize_vendor_name
+
+_MAX_ROWS = 100
+
+
+def _contains(col, value: str):
+    """A wildcard-safe case-insensitive substring filter (escapes %/_ so an AI/client-
+    supplied value can't act as a LIKE metacharacter)."""
+    return col.ilike(f"%{escape_like(value)}%", escape="\\")
+
+
+# ── Param coercion (all AI-supplied params pass through these) ──────────────────
+
+
+def _p_int(params: dict, key: str, default: int | None, *, lo: int = 0, hi: int = _MAX_ROWS) -> int | None:
+    raw = params.get(key)
+    if raw is None or isinstance(raw, bool):
+        return default
+    try:
+        return max(lo, min(hi, int(raw)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _p_str(params: dict, key: str, *, max_len: int = 120) -> str | None:
+    raw = params.get(key)
+    if raw is None:
+        return None
+    text = str(raw).strip()[:max_len]
+    return text or None
+
+
+def _p_bool(params: dict, key: str) -> bool:
+    return bool(params.get(key)) and str(params.get(key)).lower() not in ("false", "0", "no", "")
+
+
+def _since(params: dict, key: str, default_days: int | None) -> datetime | None:
+    """A cutoff datetime from an ISO date param or a default N-days-ago."""
+    raw = _p_str(params, key, max_len=32)
+    if raw:
+        try:
+            return datetime.combine(date.fromisoformat(raw), datetime.min.time(), tzinfo=UTC)
+        except ValueError:
+            pass
+    if default_days is not None:
+        return datetime.now(UTC) - timedelta(days=default_days)
+    return None
+
+
+def _owned_req_ids(db: Session, user: User | None):
+    """For a RESTRICTED_ROLE user, a scalar-subquery of requisition ids they own; None
+    for an unrestricted user (or legacy no-user caller) — no filtering."""
+    if user is None or getattr(user, "role", None) not in RESTRICTED_ROLES:
+        return None
+    return select(Requisition.id).where(Requisition.created_by == user.id).scalar_subquery()
+
+
+def _fmt(value: Any) -> Any:
+    """Table-cell normalization: dates → ISO, everything else passthrough."""
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).strftime("%Y-%m-%d %H:%M")
+    if isinstance(value, date):
+        return value.isoformat()
+    return value
+
+
+# ── Templates ──────────────────────────────────────────────────────────────────
+# Each run(db, user, params) -> (columns, rows). Requisition-scoped ones apply
+# _owned_req_ids gating. All limited to _MAX_ROWS.
+
+
+def _t_open_requisitions(db, user, params):
+    q = db.query(Requisition).filter(
+        Requisition.is_scratch.is_(False), Requisition.status == RequisitionStatus.OPEN.value
+    )
+    cust = _p_str(params, "customer")
+    if cust:
+        q = q.filter(_contains(Requisition.customer_name, cust))
+    if _p_bool(params, "past_deadline"):
+        q = q.filter(Requisition.deadline.isnot(None), Requisition.deadline < date.today().isoformat())
+    older = _p_int(params, "older_than_days", None, hi=3650)
+    if older:
+        q = q.filter(Requisition.created_at < datetime.now(UTC) - timedelta(days=older))
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.filter(Requisition.id.in_(owned))
+    rows = q.order_by(Requisition.created_at.desc()).limit(_MAX_ROWS).all()
+    cols = ["id", "name", "customer", "deadline", "created"]
+    return cols, [
+        {
+            "id": r.id,
+            "name": r.name,
+            "customer": r.customer_name,
+            "deadline": _fmt(r.deadline),
+            "created": _fmt(r.created_at),
+        }
+        for r in rows
+    ]
+
+
+def _t_requisitions_by_customer(db, user, params):
+    q = db.query(Requisition).filter(Requisition.is_scratch.is_(False))
+    cust = _p_str(params, "customer")
+    if cust:
+        q = q.filter(_contains(Requisition.customer_name, cust))
+    since = _since(params, "since", None)
+    if since:
+        q = q.filter(Requisition.created_at >= since)
+    until = _since(params, "until", None)
+    if until:
+        q = q.filter(Requisition.created_at < until + timedelta(days=1))
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.filter(Requisition.id.in_(owned))
+    rows = q.order_by(Requisition.created_at.desc()).limit(_MAX_ROWS).all()
+    cols = ["id", "name", "customer", "status", "created"]
+    return cols, [
+        {"id": r.id, "name": r.name, "customer": r.customer_name, "status": r.status, "created": _fmt(r.created_at)}
+        for r in rows
+    ]
+
+
+def _t_reqs_without_quotes(db, user, params):
+    older = _p_int(params, "older_than_days", 5, hi=3650)
+    has_quote = select(Quote.requisition_id).where(Quote.requisition_id == Requisition.id).exists()
+    q = db.query(Requisition).filter(
+        Requisition.is_scratch.is_(False),
+        Requisition.status == RequisitionStatus.OPEN.value,
+        Requisition.created_at < datetime.now(UTC) - timedelta(days=older or 0),
+        ~has_quote,
+    )
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.filter(Requisition.id.in_(owned))
+    rows = q.order_by(Requisition.created_at.asc()).limit(_MAX_ROWS).all()
+    cols = ["id", "name", "customer", "created"]
+    return cols, [
+        {"id": r.id, "name": r.name, "customer": r.customer_name, "created": _fmt(r.created_at)} for r in rows
+    ]
+
+
+def _t_unanswered_quotes(db, user, params):
+    older = _p_int(params, "older_than_days", 7, hi=3650)
+    q = db.query(Quote).filter(
+        Quote.status == QuoteStatus.SENT.value,
+        Quote.sent_at.isnot(None),
+        Quote.sent_at < datetime.now(UTC) - timedelta(days=older or 0),
+    )
+    cust = _p_str(params, "customer")
+    if cust:
+        q = q.join(Requisition, Quote.requisition_id == Requisition.id).filter(
+            _contains(Requisition.customer_name, cust)
+        )
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.filter(Quote.requisition_id.in_(owned))
+    rows = q.order_by(Quote.sent_at.asc()).limit(_MAX_ROWS).all()
+    cols = ["quote", "requisition_id", "status", "sent"]
+    eff = {"older_than_days": older, **({"customer": cust} if cust else {})}
+    return (
+        cols,
+        [
+            {"quote": r.quote_number, "requisition_id": r.requisition_id, "status": r.status, "sent": _fmt(r.sent_at)}
+            for r in rows
+        ],
+        eff,
+    )
+
+
+def _t_quotes_by_customer(db, user, params):
+    q = db.query(Quote).join(Requisition, Quote.requisition_id == Requisition.id)
+    cust = _p_str(params, "customer")
+    if cust:
+        q = q.filter(_contains(Requisition.customer_name, cust))
+    since = _since(params, "since", None)
+    if since:
+        q = q.filter(Quote.created_at >= since)
+    until = _since(params, "until", None)
+    if until:
+        q = q.filter(Quote.created_at < until + timedelta(days=1))
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.filter(Quote.requisition_id.in_(owned))
+    rows = q.order_by(Quote.created_at.desc()).limit(_MAX_ROWS).all()
+    cols = ["quote", "customer", "status", "created"]
+    return cols, [
+        {
+            "quote": r.quote_number,
+            "customer": r.requisition.customer_name if r.requisition else None,
+            "status": r.status,
+            "created": _fmt(r.created_at),
+        }
+        for r in rows
+    ]
+
+
+def _t_stale_pending_offers(db, user, params):
+    older = _p_int(params, "older_than_days", 3, hi=3650)
+    q = db.query(Offer).filter(
+        Offer.status == OfferStatus.PENDING_REVIEW.value,
+        Offer.created_at < datetime.now(UTC) - timedelta(days=older or 0),
+    )
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.filter(Offer.requisition_id.in_(owned))
+    rows = q.order_by(Offer.created_at.asc()).limit(_MAX_ROWS).all()
+    cols = ["id", "mpn", "vendor", "requisition_id", "created"]
+    return cols, [
+        {
+            "id": r.id,
+            "mpn": r.mpn,
+            "vendor": r.vendor_name,
+            "requisition_id": r.requisition_id,
+            "created": _fmt(r.created_at),
+        }
+        for r in rows
+    ]
+
+
+def _t_vendor_offer_history(db, user, params):
+    q = db.query(Offer)
+    vendor = _p_str(params, "vendor")
+    if vendor:
+        q = q.filter(Offer.vendor_name_normalized == normalize_vendor_name(vendor))
+    since = _since(params, "since", None)
+    if since:
+        q = q.filter(Offer.created_at >= since)
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.filter(Offer.requisition_id.in_(owned))
+    rows = q.order_by(Offer.created_at.desc()).limit(_MAX_ROWS).all()
+    cols = ["id", "vendor", "mpn", "unit_price", "status", "created"]
+    return cols, [
+        {
+            "id": r.id,
+            "vendor": r.vendor_name,
+            "mpn": r.mpn,
+            "unit_price": _fmt(r.unit_price),
+            "status": r.status,
+            "created": _fmt(r.created_at),
+        }
+        for r in rows
+    ]
+
+
+def _lines_by_status(db, user, params, status):
+    q = db.query(BuyPlanLine).filter(BuyPlanLine.status == status)
+    buyer = _p_str(params, "buyer")
+    if buyer:
+        q = q.join(User, BuyPlanLine.buyer_id == User.id).filter(_contains(User.name, buyer))
+    older = _p_int(params, "older_than_days", None, hi=3650)
+    if older:
+        q = q.filter(BuyPlanLine.created_at < datetime.now(UTC) - timedelta(days=older))
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.join(BuyPlan, BuyPlanLine.buy_plan_id == BuyPlan.id).filter(BuyPlan.requisition_id.in_(owned))
+    rows = q.order_by(BuyPlanLine.created_at.asc()).limit(_MAX_ROWS).all()
+    cols = ["line_id", "buy_plan_id", "po_number", "status", "created"]
+    return cols, [
+        {
+            "line_id": r.id,
+            "buy_plan_id": r.buy_plan_id,
+            "po_number": r.po_number,
+            "status": r.status,
+            "created": _fmt(r.created_at),
+        }
+        for r in rows
+    ]
+
+
+def _t_lines_awaiting_po(db, user, params):
+    return _lines_by_status(db, user, params, BuyPlanLineStatus.AWAITING_PO.value)
+
+
+def _t_lines_pending_verify(db, user, params):
+    return _lines_by_status(db, user, params, BuyPlanLineStatus.PENDING_VERIFY.value)
+
+
+def _t_prepayments_outstanding(db, user, params):
+    q = db.query(Prepayment).filter(
+        Prepayment.status.in_([PrepaymentStatus.REQUESTED.value, PrepaymentStatus.APPROVED.value]),
+        Prepayment.paid_at.is_(None),
+        Prepayment.voided_at.is_(None),
+    )
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        q = q.join(BuyPlan, Prepayment.buy_plan_id == BuyPlan.id).filter(BuyPlan.requisition_id.in_(owned))
+    rows = q.order_by(Prepayment.created_at.asc()).limit(_MAX_ROWS).all()
+    cols = ["id", "vendor", "amount", "status", "created"]
+    return cols, [
+        {
+            "id": r.id,
+            "vendor": r.vendor_name,
+            "amount": _fmt(r.total_incl_fees),
+            "status": r.status,
+            "created": _fmt(r.created_at),
+        }
+        for r in rows
+    ]
+
+
+def _t_top_searched_parts(db, user, params):
+    limit = _p_int(params, "limit", 20) or 20
+    rows = (
+        db.query(MaterialCard)
+        .filter(MaterialCard.deleted_at.is_(None), MaterialCard.search_count > 0)
+        .order_by(MaterialCard.search_count.desc())
+        .limit(limit)
+        .all()
+    )
+    cols = ["mpn", "manufacturer", "search_count", "last_searched"]
+    return cols, [
+        {
+            "mpn": r.display_mpn,
+            "manufacturer": r.manufacturer,
+            "search_count": r.search_count,
+            "last_searched": _fmt(r.last_searched_at),
+        }
+        for r in rows
+    ]
+
+
+def _t_user_edits(db, user, params):
+    q = db.query(ActivityLog).filter(ActivityLog.activity_type == ActivityType.FIELD_EDIT.value)
+    # A restricted user may only inspect their OWN edit history; a manager/admin can
+    # name any user (matched on User.name).
+    if user is not None and getattr(user, "role", None) in RESTRICTED_ROLES:
+        q = q.filter(ActivityLog.user_id == user.id)
+    else:
+        name = _p_str(params, "user_name")
+        if name:
+            q = q.join(User, ActivityLog.user_id == User.id).filter(_contains(User.name, name))
+    since = _since(params, "since", 7)
+    if since:
+        q = q.filter(ActivityLog.created_at >= since)
+    rows = q.order_by(ActivityLog.created_at.desc()).limit(_MAX_ROWS).all()
+    cols = ["at", "user_id", "buy_plan_id", "edits"]
+    return cols, [
+        {
+            "at": _fmt(r.created_at),
+            "user_id": r.user_id,
+            "buy_plan_id": r.buy_plan_id,
+            "edits": len((r.details or {}).get("edits", [])),
+        }
+        for r in rows
+    ]
+
+
+def _t_approval_cycle_time(db, user, params):
+    """Per-request submit→first-decision hours for buy-plan approvals."""
+    from app.constants import ApprovalGateType, ApprovalSubjectType
+    from app.models.approvals import ApprovalEvent, ApprovalRequest
+
+    since = _since(params, "since", None)
+    q = db.query(ApprovalRequest).filter(ApprovalRequest.gate_type == ApprovalGateType.BUY_PLAN.value)
+    if since:
+        q = q.filter(ApprovalRequest.created_at >= since)
+    # Read-gate for restricted roles through subject→buy plan→requisition ownership
+    # (owner_id alone is wrong — a manager may submit on behalf of the req creator).
+    owned = _owned_req_ids(db, user)
+    if owned is not None:
+        owned_bp = select(BuyPlan.id).where(BuyPlan.requisition_id.in_(owned)).scalar_subquery()
+        q = q.filter(
+            ApprovalRequest.subject_type == ApprovalSubjectType.BUY_PLAN.value,
+            ApprovalRequest.subject_id.in_(owned_bp),
+        )
+    reqs = q.order_by(ApprovalRequest.created_at.desc()).limit(_MAX_ROWS).all()
+    cols = ["request_id", "status", "submitted", "cycle_hours"]
+    out = []
+    for r in reqs:
+        decided = (
+            db.query(ApprovalEvent.created_at)
+            .filter(ApprovalEvent.request_id == r.id, ApprovalEvent.event_type.in_(["approved", "rejected"]))
+            .order_by(ApprovalEvent.created_at.asc())
+            .first()
+        )
+        hours = None
+        if decided and r.created_at:
+            hours = round((decided[0] - r.created_at).total_seconds() / 3600, 1)
+        out.append({"request_id": r.id, "status": r.status, "submitted": _fmt(r.created_at), "cycle_hours": hours})
+    return cols, out
+
+
+# name → {label (human), fn}. The label doubles as the Claude enum description.
+TEMPLATES: dict[str, dict[str, Any]] = {
+    "open_requisitions": {
+        "label": "Open requisitions",
+        "fn": _t_open_requisitions,
+        "params": "customer?, past_deadline?, older_than_days?",
+    },
+    "requisitions_by_customer": {
+        "label": "Requisitions for a customer",
+        "fn": _t_requisitions_by_customer,
+        "params": "customer, since?, until?",
+    },
+    "reqs_without_quotes": {
+        "label": "Open requisitions with no quote",
+        "fn": _t_reqs_without_quotes,
+        "params": "older_than_days?",
+    },
+    "unanswered_quotes": {
+        "label": "Quotes sent but unanswered",
+        "fn": _t_unanswered_quotes,
+        "params": "older_than_days?, customer?",
+    },
+    "quotes_by_customer": {
+        "label": "Quotes for a customer",
+        "fn": _t_quotes_by_customer,
+        "params": "customer, since?, until?",
+    },
+    "stale_pending_offers": {
+        "label": "Offers stuck in pending review",
+        "fn": _t_stale_pending_offers,
+        "params": "older_than_days?",
+    },
+    "vendor_offer_history": {
+        "label": "Offer history for a vendor",
+        "fn": _t_vendor_offer_history,
+        "params": "vendor, since?",
+    },
+    "lines_awaiting_po": {
+        "label": "Buy-plan lines awaiting PO",
+        "fn": _t_lines_awaiting_po,
+        "params": "buyer?, older_than_days?",
+    },
+    "lines_pending_verify": {
+        "label": "Buy-plan lines pending approval",
+        "fn": _t_lines_pending_verify,
+        "params": "older_than_days?",
+    },
+    "prepayments_outstanding": {
+        "label": "Prepayments not yet paid",
+        "fn": _t_prepayments_outstanding,
+        "params": "(none)",
+    },
+    "top_searched_parts": {"label": "Most-searched parts", "fn": _t_top_searched_parts, "params": "limit?"},
+    "user_edits": {"label": "Recent field edits by a user", "fn": _t_user_edits, "params": "user_name, since?"},
+    "approval_cycle_time": {"label": "Buy-plan approval cycle time", "fn": _t_approval_cycle_time, "params": "since?"},
+}
+
+ASK_INTENT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "template": {
+            "type": "string",
+            "enum": [*TEMPLATES.keys(), "none"],
+            "description": "The report template that answers the question, or 'none' if none fits.",
+        },
+        "params": {"type": "object", "description": "Parameter values for the chosen template (may be empty)."},
+    },
+    "required": ["template"],
+}
+
+
+def _intent_system() -> str:
+    lines = "\n".join(f"- {name}: {t['label']} (params: {t['params']})" for name, t in TEMPLATES.items())
+    return (
+        "You route a user's question to ONE reporting template, or 'none' if no template fits.\n"
+        "Return the template name and a params object. Only use parameters the template lists.\n"
+        "Dates are ISO YYYY-MM-DD. Never guess a template just to answer — 'none' is correct when nothing fits.\n\n"
+        f"Templates:\n{lines}"
+    )
+
+
+def run_template(db: Session, user: User | None, template: str, params: dict) -> tuple[list[str], list[dict], dict]:
+    """Run a named template with coerced params → (columns, rows, effective_params).
+
+    A template fn may return (cols, rows) or (cols, rows, effective) — the third element
+    is the params it ACTUALLY applied (defaults filled in) so the UI can be honest about
+    e.g. a silent 7-day window. Raises KeyError for an unknown name (callers validate
+    against TEMPLATES first).
+    """
+    entry = TEMPLATES[template]
+    result = entry["fn"](db, user, params or {})
+    if len(result) == 3:
+        cols, rows, effective = result
+    else:
+        cols, rows = result
+        effective = dict(params or {})
+    return cols, rows, effective
+
+
+async def answer_question(db: Session, user: User | None, question: str) -> dict:
+    """Map *question* to a template and run it.
+
+    Returns {"matched": True, "template", "label", "params", "columns", "rows"} on a
+    hit, else {"matched": False}. Never raises for a bad AI response — an unknown
+    template name or a failed call falls through to matched=False so the caller can
+    render the ordinary entity search.
+    """
+    q = (question or "").strip()
+    if not q:
+        return {"matched": False}
+    try:
+        intent = await claude_structured(
+            q,
+            ASK_INTENT_SCHEMA,
+            system=_intent_system(),
+            model_tier="fast",
+            timeout=15,
+            max_attempts=1,
+            cost_bucket="ask_avail",
+        )
+    except (ClaudeUnavailableError, ClaudeError) as e:
+        logger.info("Ask AVAIL intent parse unavailable/failed: {}", e)
+        return {"matched": False}
+    if not intent:
+        return {"matched": False}
+    template = str(intent.get("template") or "").strip()
+    if template not in TEMPLATES:
+        return {"matched": False}
+    params = intent.get("params") if isinstance(intent.get("params"), dict) else {}
+    try:
+        cols, rows, effective = run_template(db, user, template, params)
+    except Exception:  # noqa: BLE001 — a template failure must fall through to entity search, never 500 the search box
+        logger.exception("Ask AVAIL template {} failed", template)
+        return {"matched": False}
+    return {
+        "matched": True,
+        "template": template,
+        "label": TEMPLATES[template]["label"],
+        "params": effective,  # what actually ran (defaults filled in), not the raw AI dict
+        "columns": cols,
+        "rows": rows,
+    }

--- a/app/templates/htmx/partials/search/ask_result.html
+++ b/app/templates/htmx/partials/search/ask_result.html
@@ -1,0 +1,53 @@
+{#
+  search/ask_result.html — Ask AVAIL result table (survey idea #18).
+  Renders one whitelisted report template's (columns, rows) plus a transparency
+  line naming EXACTLY which template + params ran, and a one-tap CSV export that
+  re-runs the same template deterministically. Autoescaped throughout; the CSV
+  route re-validates the template name against the registry.
+  Receives: ask ({template, label, params, columns, rows}), query (str).
+  Called by: routers/htmx/search_views.py (ai_search_endpoint on a template match).
+#}
+<div class="page-fluid px-4 py-6">
+  <div class="mb-4">
+    <h1 class="text-lg font-semibold text-gray-900">{{ ask.label }}</h1>
+    <p class="mt-1 text-xs text-gray-500">
+      Answering “<span class="text-gray-700">{{ query }}</span>” via report
+      <span class="font-mono text-gray-700">{{ ask.template }}</span>{% if ask.params %}
+      with <span class="font-mono text-gray-700">{{ ask.params | tojson }}</span>{% endif %}.
+      <span class="text-gray-400">Runs a fixed query — never free-form SQL.</span>
+    </p>
+  </div>
+
+  <div class="mb-3 flex items-center gap-3">
+    <span class="text-sm text-gray-600">{{ ask.rows | length }} row{{ "s" if ask.rows | length != 1 }}</span>
+    {% if ask.rows %}
+    <a class="btn btn-secondary btn-sm"
+       href="/v2/partials/search/ask.csv?template={{ ask.template | urlencode }}&params={{ ask.params | tojson | urlencode }}">
+      Export CSV
+    </a>
+    {% endif %}
+  </div>
+
+  {% if ask.rows %}
+  <div class="overflow-x-auto rounded-lg border border-gray-200">
+    <table class="compact-table min-w-full">
+      <thead>
+        <tr>
+          {% for col in ask.columns %}<th class="text-left">{{ col.replace('_', ' ') }}</th>{% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in ask.rows %}
+        <tr>
+          {% for col in ask.columns %}<td class="text-xs">{{ row.get(col) if row.get(col) is not none else '—' }}</td>{% endfor %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <div class="rounded-lg border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+    No rows matched this report.
+  </div>
+  {% endif %}
+</div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -5969,7 +5969,19 @@ The header search input (templates/htmx/partials/shared/topbar.html, name="q") d
 into `GET /v2/partials/search/global` → `htmx.search_views.global_search` →
 `global_search_service.fast_search(q, db, user)` → renders the grouped dropdown
 `partials/shared/search_results.html`. Pressing Enter posts `/v2/partials/search/ai` →
-`ai_search(q, db, user)` (Claude Haiku intent parse, falls back to fast_search). "View all"
+Ask AVAIL FIRST (idea #18): `ask_avail_service.answer_question` maps the question to ONE
+whitelisted report template (Claude picks a template NAME from a fixed enum + a params
+dict — NEVER free SQL) and runs the hand-written ORM query; a match renders
+`partials/search/ask_result.html` (uniform table + a transparency line naming the exact
+template+params + a one-tap CSV via `GET /v2/partials/search/ask.csv`, which re-validates
+the template name and streams `stream_csv`). Params are coerced per template (ints bounded
+≤100 rows, dates ISO, strings capped); requisition-scoped templates apply the same
+`_owned_req_ids` RESTRICTED_ROLES gating as search; the dispatch is throttled 20/min/user.
+No match (or throttle) → falls through to `ai_search(q, db, user)` (Claude Haiku intent
+parse, falls back to fast_search). Registry: 13 templates in `ask_avail_service.TEMPLATES`
+(open/by-customer/no-quote requisitions, unanswered/by-customer quotes, stale pending
+offers, vendor offer history, lines awaiting-PO / pending-verify, outstanding prepayments,
+top-searched parts, user field-edits, buy-plan approval cycle time). "View all"
 renders the full page `partials/search/full_results.html` via `/v2/partials/search/results`.
 
 ```

--- a/tests/test_ask_avail.py
+++ b/tests/test_ask_avail.py
@@ -1,0 +1,334 @@
+"""test_ask_avail.py — TDD tests for Ask AVAIL (survey idea #18).
+
+Natural-language questions dispatched to named, parameterized query templates
+(NEVER free SQL): Claude maps the question to one template name + params, the
+service coerces params and runs the hand-written ORM query, and the Enter-key
+search path renders a uniform result table + one-tap CSV. Falls through to the
+existing entity search when no template matches.
+
+Covers: the dispatch (intent→template, param coercion, no-match/failure →
+matched False), restricted-role read-gating on req-scoped templates, a
+smoke-run of EVERY registered template (catches field typos), and the route
+(renders the ask table on a match, falls through otherwise, throttled; the CSV
+endpoint streams the same template deterministically).
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_ask_avail.py -v)
+Depends on: app.services.ask_avail_service, app.routers.htmx.search_views, conftest.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from app.models.intelligence import MaterialCard
+from app.models.sourcing import Requisition
+
+_HX = {"HX-Request": "true"}
+
+
+def _req(db, user, *, name, customer="AcmeCo", status="open", deadline=None, created=None):
+    r = Requisition(
+        name=name,
+        customer_name=customer,
+        status=status,
+        created_by=user.id,
+        deadline=deadline,
+        created_at=created or datetime.now(UTC),
+    )
+    db.add(r)
+    db.flush()
+    return r
+
+
+# ── Service dispatch ───────────────────────────────────────────────────────────
+
+
+class TestDispatch:
+    async def test_matched_template_runs_and_returns_table(self, db_session, test_user):
+        from app.services.ask_avail_service import answer_question
+
+        _req(db_session, test_user, name="OPEN-1", customer="AcmeCo")
+        db_session.commit()
+        intent = {"template": "open_requisitions", "params": {"customer": "Acme"}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "open reqs for Acme")
+        assert out["matched"] is True
+        assert out["template"] == "open_requisitions"
+        assert out["params"] == {"customer": "Acme"}
+        assert isinstance(out["columns"], list) and out["columns"]
+        assert any("OPEN-1" in str(v) for row in out["rows"] for v in row.values())
+
+    async def test_unknown_template_returns_not_matched(self, db_session, test_user):
+        from app.services.ask_avail_service import answer_question
+
+        intent = {"template": "none", "params": {}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "what's the weather")
+        assert out["matched"] is False
+
+    async def test_ai_failure_returns_not_matched(self, db_session, test_user):
+        from app.services.ask_avail_service import answer_question
+
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=None):
+            out = await answer_question(db_session, test_user, "anything")
+        assert out["matched"] is False
+
+    async def test_bad_template_name_from_ai_returns_not_matched(self, db_session, test_user):
+        from app.services.ask_avail_service import answer_question
+
+        intent = {"template": "'; DROP TABLE requisitions; --", "params": {}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "evil")
+        assert out["matched"] is False
+
+    async def test_param_coercion_bounds_limit(self, db_session, test_user):
+        from app.services.ask_avail_service import answer_question
+
+        for i in range(3):
+            db_session.add(MaterialCard(normalized_mpn=f"p{i}", display_mpn=f"P{i}", search_count=10 - i))
+        db_session.commit()
+        intent = {"template": "top_searched_parts", "params": {"limit": 999999}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "most searched parts")
+        assert out["matched"] is True
+        assert len(out["rows"]) <= 100  # hard cap, not 999999
+
+
+class TestReadGating:
+    async def test_restricted_role_sees_only_owned_reqs(self, db_session, test_user, sales_user):
+        from app.services.ask_avail_service import answer_question
+
+        _req(db_session, test_user, name="OWNER-REQ", customer="Acme")  # owned by test_user
+        r2 = Requisition(
+            name="SALES-REQ",
+            customer_name="Acme",
+            status="open",
+            created_by=sales_user.id,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(r2)
+        db_session.commit()
+        intent = {"template": "open_requisitions", "params": {}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, sales_user, "open reqs")
+        blob = str(out["rows"])
+        assert "SALES-REQ" in blob
+        assert "OWNER-REQ" not in blob  # restricted role never sees another user's req
+
+
+class TestEveryTemplateSmokeRuns:
+    async def test_all_registered_templates_execute(self, db_session, test_user):
+        """Every registered template runs without error on an empty-ish DB and returns
+        (columns, rows) — catches field/enum typos across all 13."""
+        from app.services.ask_avail_service import TEMPLATES, answer_question
+
+        assert len(TEMPLATES) >= 13
+        for name in TEMPLATES:
+            intent = {"template": name, "params": {}}
+            with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+                out = await answer_question(db_session, test_user, f"run {name}")
+            assert out["matched"] is True, name
+            assert isinstance(out["columns"], list) and out["columns"], name
+            assert isinstance(out["rows"], list), name
+
+
+# ── Route ──────────────────────────────────────────────────────────────────────
+
+
+class TestRoute:
+    def test_enter_key_renders_ask_table_on_match(self, client, db_session, test_user):
+        _req(db_session, test_user, name="ROUTE-OPEN-1")
+        db_session.commit()
+        intent = {"template": "open_requisitions", "params": {}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            resp = client.post("/v2/partials/search/ai", data={"q": "list open requisitions"}, headers=_HX)
+        assert resp.status_code == 200
+        body = resp.text
+        assert "ROUTE-OPEN-1" in body
+        assert "open_requisitions" in body  # transparency: which template ran is shown
+        assert "ask.csv" in body  # one-tap CSV affordance
+
+    def test_no_match_falls_through_to_entity_search(self, client, db_session, test_user):
+        intent = {"template": "none", "params": {}}
+        entity = {"best_match": None, "groups": {}, "total_count": 0}
+        with (
+            patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent),
+            patch("app.services.global_search_service.ai_search", new_callable=AsyncMock, return_value=entity),
+        ):
+            resp = client.post("/v2/partials/search/ai", data={"q": "arrow electronics"}, headers=_HX)
+        assert resp.status_code == 200
+        # Entity-search render, not the ask table.
+        assert "ask.csv" not in resp.text
+
+    def test_ask_throttled_falls_through(self, client, db_session, test_user):
+        entity = {"best_match": None, "groups": {}, "total_count": 0}
+        with (
+            patch("app.routers.htmx.search_views.check_rate_limit", return_value=False),
+            patch("app.services.ask_avail_service.answer_question", new_callable=AsyncMock) as mock,
+            patch("app.services.global_search_service.ai_search", new_callable=AsyncMock, return_value=entity),
+        ):
+            resp = client.post("/v2/partials/search/ai", data={"q": "open reqs"}, headers=_HX)
+        assert resp.status_code == 200
+        mock.assert_not_called()  # throttle skips the AI dispatch entirely
+        # …and the response is the entity-search render (fall-through), not an ask table.
+        assert "ask.csv" not in resp.text
+
+    def test_csv_endpoint_streams_same_template(self, client, db_session, test_user):
+        _req(db_session, test_user, name="CSV-OPEN-1")
+        db_session.commit()
+        resp = client.get(
+            "/v2/partials/search/ask.csv", params={"template": "open_requisitions", "params": "{}"}, headers=_HX
+        )
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers.get("content-type", "")
+        assert "CSV-OPEN-1" in resp.text
+
+    def test_csv_endpoint_rejects_unknown_template(self, client, db_session, test_user):
+        resp = client.get("/v2/partials/search/ask.csv", params={"template": "evil", "params": "{}"}, headers=_HX)
+        assert resp.status_code == 404
+
+    def test_csv_endpoint_unauthenticated_401(self, unauthenticated_client):
+        resp = unauthenticated_client.get(
+            "/v2/partials/search/ask.csv", params={"template": "open_requisitions", "params": "{}"}
+        )
+        assert resp.status_code == 401
+
+
+# ── Adversarial-review fixes (7 confirmed findings) ────────────────────────────
+
+
+class TestReviewFixes:
+    async def test_past_deadline_uses_iso_string_compare(self, db_session, test_user):
+        """Deadline is String(50) — the filter must compare against an ISO date string,
+        not a datetime (PG rejects varchar < timestamp; sqlite masks it).
+
+        A past ISO deadline matches; 'ASAP' and a future date do not.
+        """
+        from app.services.ask_avail_service import answer_question
+
+        _req(db_session, test_user, name="PAST", customer="Acme")
+        db_session.query(Requisition).filter_by(name="PAST").update({"deadline": "2000-01-01"})
+        _req(db_session, test_user, name="ASAP-REQ", customer="Acme")
+        db_session.query(Requisition).filter_by(name="ASAP-REQ").update({"deadline": "ASAP"})
+        _req(db_session, test_user, name="FUTURE", customer="Acme")
+        db_session.query(Requisition).filter_by(name="FUTURE").update({"deadline": "2099-01-01"})
+        db_session.commit()
+        intent = {"template": "open_requisitions", "params": {"past_deadline": True}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "open reqs past their deadline")
+        assert out["matched"] is True
+        names = {r["name"] for r in out["rows"]}
+        assert "PAST" in names
+        assert "ASAP-REQ" not in names and "FUTURE" not in names
+
+    def test_csv_past_deadline_does_not_500(self, client, db_session, test_user):
+        """The CSV endpoint runs the template directly — a past_deadline export must not
+        raise (the PG-invalid compare would 500 without the fix)."""
+        _req(db_session, test_user, name="CSVPD")
+        db_session.query(Requisition).filter_by(name="CSVPD").update({"deadline": "2000-01-01"})
+        db_session.commit()
+        resp = client.get(
+            "/v2/partials/search/ask.csv",
+            params={"template": "open_requisitions", "params": '{"past_deadline": true}'},
+            headers=_HX,
+        )
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers.get("content-type", "")
+
+    async def test_approval_cycle_time_gated_for_restricted_role(self, db_session, test_user, sales_user):
+        """A restricted role must not see buy-plan approval timing for requisitions they
+        don't own."""
+        from app.constants import ApprovalGateType, ApprovalRequestStatus, ApprovalSubjectType
+        from app.models.approvals import ApprovalRequest
+        from app.models.buy_plan import BuyPlan
+        from app.models.quotes import Quote
+        from app.services.ask_avail_service import answer_question
+
+        owner_req = _req(db_session, test_user, name="OWNER-APR")
+        db_session.flush()
+        q = Quote(requisition_id=owner_req.id, quote_number="Q-APR", status="sent", created_at=datetime.now(UTC))
+        db_session.add(q)
+        db_session.flush()
+        bp = BuyPlan(
+            requisition_id=owner_req.id,
+            quote_id=q.id,
+            status="active",
+            so_status="approved",
+            submitted_by_id=test_user.id,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(bp)
+        db_session.flush()
+        ar = ApprovalRequest(
+            gate_type=ApprovalGateType.BUY_PLAN.value,
+            status=ApprovalRequestStatus.REQUESTED.value,
+            subject_type=ApprovalSubjectType.BUY_PLAN.value,
+            subject_id=bp.id,
+            requested_by_id=test_user.id,
+            owner_id=test_user.id,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(ar)
+        db_session.commit()
+        intent = {"template": "approval_cycle_time", "params": {}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, sales_user, "approval cycle time")
+        assert out["matched"] is True
+        assert all(row["request_id"] != ar.id for row in out["rows"])  # foreign req's approval hidden
+
+    async def test_effective_params_surface_hidden_defaults(self, db_session, test_user):
+        """A template with a hidden default cutoff reports the EFFECTIVE params it
+        actually ran with, not the AI's empty dict — so the UI can be honest."""
+        from app.services.ask_avail_service import answer_question
+
+        intent = {"template": "unanswered_quotes", "params": {}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "unanswered quotes")
+        assert out["params"].get("older_than_days") == 7  # the applied default is visible
+
+    def test_bare_lookup_does_not_dispatch_ask_avail(self, client, db_session, test_user):
+        """A short entity lookup (bare MPN / vendor name) must NOT spend a second Claude
+        call on the report classifier — only question-shaped input dispatches."""
+        entity = {"best_match": None, "groups": {}, "total_count": 0}
+        with (
+            patch("app.services.ask_avail_service.answer_question", new_callable=AsyncMock) as ask,
+            patch("app.services.global_search_service.ai_search", new_callable=AsyncMock, return_value=entity),
+        ):
+            client.post("/v2/partials/search/ai", data={"q": "LM317T"}, headers=_HX)
+        ask.assert_not_called()
+
+    def test_question_shaped_query_dispatches_ask_avail(self, client, db_session, test_user):
+        _req(db_session, test_user, name="QSHAPE-OPEN")
+        db_session.commit()
+        intent = {"template": "open_requisitions", "params": {}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            resp = client.post("/v2/partials/search/ai", data={"q": "open requisitions past deadline"}, headers=_HX)
+        assert "QSHAPE-OPEN" in resp.text
+
+    async def test_until_includes_the_named_final_day(self, db_session, test_user):
+        from app.services.ask_avail_service import answer_question
+
+        r = _req(db_session, test_user, name="ONLAST", customer="Acme")
+        db_session.query(Requisition).filter_by(id=r.id).update(
+            {"created_at": datetime(2026, 6, 15, 14, 0, tzinfo=UTC)}
+        )
+        db_session.commit()
+        intent = {"template": "requisitions_by_customer", "params": {"customer": "Acme", "until": "2026-06-15"}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "reqs for Acme")
+        assert any(row["name"] == "ONLAST" for row in out["rows"])  # 14:00 on the until day is included
+
+    async def test_like_wildcard_in_customer_is_escaped(self, db_session, test_user):
+        """A '%' in a filter value matches literally, not as a wildcard."""
+        from app.services.ask_avail_service import answer_question
+
+        _req(db_session, test_user, name="R-REAL", customer="Acme Corp")
+        _req(db_session, test_user, name="R-PCT", customer="100% Silicon")
+        db_session.commit()
+        intent = {"template": "open_requisitions", "params": {"customer": "100%"}}
+        with patch("app.services.ask_avail_service.claude_structured", new_callable=AsyncMock, return_value=intent):
+            out = await answer_question(db_session, test_user, "open reqs for 100%")
+        names = {r["name"] for r in out["rows"]}
+        assert "R-PCT" in names
+        assert "R-REAL" not in names  # "%" did not act as a wildcard matching everything


### PR DESCRIPTION
Fifth and final build from the AI opportunity survey (specs/ai-opportunity-survey-2026-08-21.md, idea #18 — the confirmed reporting-page gap from the 08-20 re-audit).

## What
The Enter-key search tries **Ask AVAIL** first: a question-shaped query is mapped by Claude to **one named, parameterized report template** — Claude picks a template NAME from a fixed enum + a params dict, **never free SQL** — run as a hand-written ORM query. The result is a uniform table naming the exact template + effective params that ran, with a **one-tap CSV**. Anything else falls through to entity search.

- **13 templates**: open / by-customer / no-quote requisitions; unanswered & by-customer quotes; stale pending offers; vendor offer history; lines awaiting-PO / pending-verify; outstanding prepayments; top-searched parts; user field-edits; buy-plan approval cycle time.
- Params coerced (ints ≤100 rows, dates ISO, strings capped) and **only ORM-bound**; requisition-scoped templates apply the `_owned_req_ids` RESTRICTED_ROLES gate; `GET /v2/partials/search/ask.csv` re-validates the template name and streams `stream_csv`.
- Dispatch gated to question-shaped input (≥3 words or `?`) + 20/min/user so a bare MPN/vendor lookup never double-spends.

> **Owner note:** the 13-template whitelist is the one genuinely owner-shaped choice — easy to cut/extend. Two dict-shaped reports (coverage_report, pipeline_summary) were deferred (they already have their own surfaces).

## Review
10-agent adversarial find/refute: **7 confirmed findings, all fixed with regression tests** — a HIGH PG-invalid `String(50)` deadline-vs-datetime compare (sqlite-masked; also 500'd the CSV path), the double-Claude-call altitude, `approval_cycle_time` read-gating, effective-params transparency, LIKE-wildcard escaping, and an `until` off-by-a-day.

## Verification
- 21 new tests in `tests/test_ask_avail.py` (dispatch, coercion, read-gating, a smoke-run of **every** template, route + CSV, all 7 fixes)
- **Live dispatch check** vs real Postgres + real Claude: **7/7** realistic questions routed to the correct template (past-deadline exercised the PG-safe fix on real PG)
- Full suite **24349 passed / 0 failed**; hooks + assertion-theater lint clean; APP_MAP updated. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skqbrbYAUTMGwxc3AwNN3