### PR TITLE
Vendor dup nudge on the offer form (deterministic, one-tap adopt)

### DIFF
--- a/app/routers/htmx/offers/crud.py
+++ b/app/routers/htmx/offers/crud.py
@@ -357,6 +357,42 @@ async def review_offer(
     return await requisition_tab(request=request, req_id=req_id, tab="offers", user=user, db=db)
 
 
+@router.get("/v2/partials/offers/vendor-dup-check", response_class=HTMLResponse)
+async def offer_vendor_dup_check(
+    request: Request,
+    vendor_name: str = "",
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Deterministic vendor duplicate nudge for the offer form's vendor_name field.
+
+    The offer form's ``vendor_name`` input hx-gets this route with its own value on
+    blur. Reuses vendor_duplicates.check_vendor_duplicate (exact normalized + pg_trgm
+    fuzzy — NO AI on this per-blur path) and renders a one-tap adopt nudge into
+    #vendor-dup-nudge, or an empty 200 when blank / no match. Adopting only swaps
+    the input's name string; it never blocks the save and never re-links rows.
+    """
+    from ....services.vendor_duplicates import check_vendor_duplicate
+    from . import template_response
+
+    if not vendor_name.strip():
+        return HTMLResponse("")
+    matches = check_vendor_duplicate(vendor_name.strip(), db)
+    if not matches:
+        return HTMLResponse("")
+    top = matches[0]
+    # On an OFFER form an EXACT match is the normal, desired case (this offer just
+    # references an existing vendor — no new row is minted, no fragmentation). Only
+    # FUZZY near-misses are worth a nudge; suppressing exact also means adopting the
+    # canonical name (→ exact on the next blur) never re-nudges.
+    if top["match"] != "fuzzy":
+        return HTMLResponse("")
+    return template_response(
+        "htmx/partials/offers/_vendor_dup_nudge.html",
+        {"request": request, "user": user, "match": top},
+    )
+
+
 @router.get("/v2/partials/requisitions/{req_id}/add-offer-form", response_class=HTMLResponse)
 async def add_offer_form(
     request: Request,

--- a/app/templates/htmx/partials/offers/_offer_form_fields.html
+++ b/app/templates/htmx/partials/offers/_offer_form_fields.html
@@ -12,9 +12,16 @@
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
   <div>
     <label class="block text-xs text-gray-600 mb-1">Vendor Name *</label>
-    <input type="text" name="vendor_name" required value="{{ p.get('vendor_name', '') }}"
+    {# Deterministic dup nudge (idea #10): on blur, check the name against existing
+       vendors and offer a one-tap adopt into #vendor-dup-nudge. Never blocks save. #}
+    <input type="text" name="vendor_name" id="offer-vendor-name" required value="{{ p.get('vendor_name', '') }}"
            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded input-focus"
-           placeholder="e.g. Arrow Electronics">
+           placeholder="e.g. Arrow Electronics"
+           hx-get="/v2/partials/offers/vendor-dup-check"
+           hx-trigger="blur changed"
+           hx-target="#vendor-dup-nudge"
+           hx-swap="innerHTML">
+    <div id="vendor-dup-nudge"></div>
   </div>
   <div>
     <label class="block text-xs text-gray-600 mb-1">MPN *</label>

--- a/app/templates/htmx/partials/offers/_vendor_dup_nudge.html
+++ b/app/templates/htmx/partials/offers/_vendor_dup_nudge.html
@@ -1,0 +1,22 @@
+{#
+  offers/_vendor_dup_nudge.html — one-tap vendor duplicate nudge (survey idea #10).
+  Swapped into #vendor-dup-nudge when the offer form's vendor_name blurs onto an
+  existing/near vendor. Adopting sets ONLY the input's value to the canonical name
+  (carried in an autoescaped data-name attribute, read via $el.dataset.name so a
+  name with quotes can't break out) and clears the nudge — never blocks the save,
+  never re-links rows. Deterministic: no AI on this path.
+  Receives: match ({id, name, match: exact|fuzzy, score}).
+  Called by: routers/htmx/offers/crud.py (offer_vendor_dup_check).
+#}
+<div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-amber-700">
+  <span>
+    {% if match.match == 'exact' %}“{{ match.name }}” already exists.
+    {% else %}Did you mean “{{ match.name }}” ({{ match.score }}% match)?{% endif %}
+  </span>
+  <button type="button"
+          data-name="{{ match.name }}"
+          @click="document.getElementById('offer-vendor-name').value = $el.dataset.name; document.getElementById('vendor-dup-nudge').innerHTML = ''"
+          class="rounded border border-amber-300 bg-white px-1.5 py-0.5 font-medium text-amber-700 hover:bg-amber-50">
+    Use “{{ match.name }}”
+  </button>
+</div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -977,6 +977,16 @@ the unavailability states). A test guards the header↔cell count
 prefilled from the VendorSightingSummary. The modal and the requisitions add-offer
 form share one field grid (offers/_offer_form_fields.html). Offer creation logs
 OFFER_CREATED, so converted/entered offers appear in the Activity tab automatically.
+Vendor dup nudge (idea #10): the shared grid's `vendor_name` input (id
+`offer-vendor-name`) hx-gets `GET /v2/partials/offers/vendor-dup-check` on blur →
+`offers.crud.offer_vendor_dup_check` reuses the DETERMINISTIC
+`vendor_duplicates.check_vendor_duplicate` (exact normalized + pg_trgm fuzzy, NO AI
+on the per-blur path) and swaps `offers/_vendor_dup_nudge.html` into `#vendor-dup-nudge`
+(empty on blank/no-match). Only FUZZY near-misses nudge — an EXACT match is the
+normal offer case (logging against an existing vendor, no new row minted), so it is
+suppressed (which also means adopting the canonical name never re-nudges on the next blur). The nudge's one-tap "Use …" adopt carries the canonical
+name in an autoescaped `data-name` attr and, on `@click`, sets the input's value and
+clears the nudge — never blocks the save, never re-links existing rows.
 
 Vendor rows (_vendor_row.html) also carry a row-level status treatment keyed off
 the server-computed vendor status `vs` (precedence resolved in

--- a/specs/ai-queue-phase-plan-2026-08-23.md
+++ b/specs/ai-queue-phase-plan-2026-08-23.md
@@ -1,0 +1,113 @@
+# AI-queue "Do all" — phased plan (2026-08-23)
+
+Owner said "do all" of the remaining survey backlog. Seven features, three phases,
+built in the same proven loop each: worktree → TDD → multi-agent adversarial review
+→ every finding fixed with a regression test → full suite alone → real-Postgres +
+real-Claude dry run → PR → CI green → squash-merge → deploy → live check → cleanup.
+Owner merge/deploy word is NOT required (standing authorization this session), but
+each ships as its own PR so anything can be paused.
+
+Already shipped this session (context): #2 QP serial paste (#905), #6 PO-confirm
+prefill (#907), #21 equivalence search (#908), #3 resell reply prefill (#909),
+#18 Ask AVAIL (#910) — all live.
+
+Migration numbers in flight reach 212. New migrations below claim 213+ in
+MIGRATION_NUMBERS_IN_FLIGHT.txt before writing.
+
+---
+
+## Phase 1 — Finish the skipped approved item  (1 feature, S)
+
+### 1. Vendor-name dup nudge  [idea #10 · S · NO migration · NO AI on hot path]
+The offer form's `vendor_name` is a bare `<input>` (the single biggest source of
+vendor-row fragmentation). Add an `hx-trigger="blur"` check → new GET
+`/v2/partials/offers/check-vendor?name=…` → reuse `vendor_duplicates.check_vendor_duplicate`
+(exact normalized + pg_trgm ≥0.3; already deterministic) → render "Did you mean
+Arrow Electronics (existing vendor)?" into a sibling `#vendor-dup-nudge` div with a
+one-tap adopt that swaps ONLY the input's name string (never re-links rows, never
+blocks save). Verifier build-note honored: keep AI out of the blur path — pure
+deterministic. Touches `_offer_form_fields.html`, `routers/htmx/offers/crud.py`.
+Review risk: XSS on vendor names in the nudge; adopt must not mutate DB.
+
+---
+
+## Phase 2 — Data hygiene  (3 features)  "clean the data we now capture faster"
+
+### 2. Offer free-text structurizer  [idea #12 · M · MIGRATION 213]
+`Offer.lead_time / date_code / packaging` are `String(100)` prose ("2-3wk"). Add
+sibling normalized columns (`lead_time_days` int, date-code bounds) via migration.
+At offer save AND a nightly backfill sweep: deterministic normalizers first
+(`utils/normalization`), only the leftovers go to one Haiku structured call
+hard-guarded to return null rather than guess; AI-produced values get the amber
+"AI — verify" chip on the offer row. Payoff: a buyer can filter/sort offers by
+"ships inside 2 weeks" / "stock newer than 2023". Review risk: money/qty never
+touched; AI must not overwrite a deterministic parse.
+
+### 3. Manufacturer alias harvester  [idea #11 · M · maybe small MIGRATION 214]
+`Manufacturer` model already has `canonical_name` + `aliases` JSON. Nightly batch
+collects distinct manufacturer strings from sightings/offers/requirements that miss
+`normalize_brand_name`, clusters them, and asks Claude (Batch API, overnight/cheap)
+to map each variant → an existing canonical or "new/unknown". Proposals land in a
+pending-approval admin list (spec_codes pattern — human approves before promotion);
+approval appends the alias. Verifier: DROP the "backfill raw columns" step — aliases
+only, never rewrite vendor-reported raw strings. Confirm-queue may need a small
+pending table (→ migration) or reuse an existing pending pattern.
+
+### 4. Contact / vendor dedupe sweep  [idea #15 · M · NO migration]
+Extend the nightly `auto_dedup_service` with a contact pass: cluster `site_contacts`
+across companies on normalized email (exact) + fuzzy name+domain, Claude confirms
+only ambiguous name-only pairs. Contacts NEVER auto-merge — every pair lands in a
+suggestion list (one-tap merge via existing `contact_merge_service`, or dismiss).
+Closes the documented "cross-company contact dupes have zero detection" gap.
+Review risk: never auto-merge; respect policy-allowed same-name-different-company.
+
+---
+
+## Phase 3 — Deal-context AI  (3 features)  "answer deal questions from what we hold"
+
+### 5. QP draft-from-deal  [ideas #8 + #19 merged · M · NO migration]
+ONE drafting service (verifier said 8 and 19 collide → merge). Primary source =
+THIS deal's records (requirement condition/qty/FW-HW-rev, chosen offer terms) via
+deterministic copy + extraction from an optional pasted customer TSO/PO; secondary
+= carry-forward from the 2-3 most recent approved QPs for the same customer+commodity
+(plain SQL similarity, no vectors). Drafts the ~28 free-text sales+purchasing QP
+fields; every AI-sourced field renders amber "AI — verify"; nothing PATCHes until
+the human accepts per-field (the QP grid already auto-PATCHes per field). Review
+risk: accept-per-field write model; no silent writes; deterministic-copy vs AI-extract
+clearly separated.
+
+### 6. Buy-plan handoff brief  [idea #17 · M · NO migration]
+Extend the existing `activity_digest_service` (get_or_build_digest: claude_structured
++ anti-stampede Redis lock + cooldown) to a BUY_PLAN entity: a one-tap AI summary
+over SQL-computed deal facts (line/offer/quote status counts, QP gate states,
+ApprovalAction→**ApprovalEvent** timeline, recent ActivityLog) → "what the customer
+asked for, where each line stands, blockers, next actions" for handing a deal to a
+backup. Cached HTMX panel. Review risk: reuse the digest anti-stampede pattern; the
+requisition digest already exists — this is the buy-plan delta only.
+
+### 7. Customer-360 sibling pooling  [idea #22 · M · NO migration · read-only]
+Extend `account_summary_service`: before the Claude summary runs, gather sibling
+`Company` rows sharing `normalized_name` (the policy-allowed different-owner
+duplicates auto-dedup deliberately skips) and pool their part history/open reqs/
+quotes/last-activity into the summary context. Panel gains an "includes N sibling
+accounts (owned by X, Y)" banner; rows stay unmerged. Review risk: read-only, never
+merges; the customer-identity-hiding rules still hold.
+
+---
+
+## Cross-cutting guardrails (every phase)
+- AI drafts, human confirms — no silent DB writes; amber "AI — verify" chip on every
+  AI-sourced value; one-tap human override outranks AI permanently.
+- Ownership/read-gating (`_owned_req_ids` / RESTRICTED_ROLES) on anything req-scoped.
+- Interactive AI calls: fast tier, `max_attempts=1`, per-user throttle, fall through
+  on failure — never 500 a page.
+- Nightly/batch AI: cheap tier, best-effort, own session, safe_background_task.
+- Verify every model field/enum at build time; claim migration numbers before writing;
+  run pytest INSIDE the worktree; throwaway-docker-PG (not sqlite) for dry runs.
+- No new financial/margin logic; nothing integrates with Acctivate.
+
+## Suggested order & rationale
+Phase 1 first (closes an approved-but-open item, smallest, recon done). Phase 2 next
+(data hygiene compounds the value of the entry-speed features just shipped). Phase 3
+last (higher-touch, biggest reach, each self-contained). Ships as 7 independent PRs;
+owner can redirect between any of them.

--- a/tests/test_offer_vendor_dup_nudge.py
+++ b/tests/test_offer_vendor_dup_nudge.py
@@ -1,0 +1,108 @@
+"""test_offer_vendor_dup_nudge.py — TDD tests for the offer-form vendor dup nudge
+(survey idea #10).
+
+The offer form's vendor_name was a bare input — the biggest source of vendor-row
+fragmentation. A blur-check reuses the deterministic vendor_duplicates matcher
+(exact normalized + pg_trgm fuzzy — NO AI on the hot path) and renders a
+"Did you mean Arrow Electronics?" nudge with a one-tap adopt that swaps ONLY the
+input's name string (never blocks save, never re-links rows).
+
+Covers: the GET /v2/partials/offers/vendor-dup-check endpoint (exact/fuzzy nudge
+with an adopt button carrying the canonical name in an autoescaped data attribute;
+empty on blank/no-match), and the offer form field wiring (hx blur trigger + id +
+#vendor-dup-nudge target).
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_offer_vendor_dup_nudge.py -v)
+Depends on: app.routers.htmx.offers.crud, conftest (client, db_session, test_user).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from app.models import User
+from app.models.sourcing import Requisition
+from app.models.vendors import VendorCard
+
+_HX = {"HX-Request": "true"}
+
+
+def _vendor(db: Session, display: str, norm: str) -> VendorCard:
+    vc = VendorCard(normalized_name=norm, display_name=display)
+    db.add(vc)
+    db.commit()
+    return vc
+
+
+def _req(db: Session, user: User) -> Requisition:
+    r = Requisition(
+        name="VDN-REQ", customer_name="Acme", status="open", created_by=user.id, created_at=datetime.now(UTC)
+    )
+    db.add(r)
+    db.commit()
+    return r
+
+
+class TestNudgeEndpoint:
+    _URL = "/v2/partials/offers/vendor-dup-check"
+
+    def test_exact_match_gives_no_nudge_on_offer_form(self, client, db_session, test_user):
+        """On an OFFER form an exact match is the normal case (logging an offer against
+        an existing vendor — no fragmentation risk), so it must NOT nudge.
+
+        This also kills the post-adopt re-nudge wrinkle (adopting → exact → silent).
+        """
+        _vendor(db_session, "Arrow Electronics", "arrow electronics")
+        resp = client.get(self._URL, params={"vendor_name": "Arrow Electronics"}, headers=_HX)
+        assert resp.status_code == 200
+        assert resp.text.strip() == ""
+
+    def test_fuzzy_match_renders_adopt_nudge(self, client, db_session, test_user):
+        _vendor(db_session, "Arrow Electronics", "arrow electronics")
+        resp = client.get(self._URL, params={"vendor_name": "Arow Electronic"}, headers=_HX)  # near-miss
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Arrow Electronics" in body
+        assert 'data-name="Arrow Electronics"' in body  # autoescaped canonical name to adopt
+        assert "@click" in body  # tappable adopt
+
+    def test_no_match_returns_empty(self, client, db_session, test_user):
+        _vendor(db_session, "Arrow Electronics", "arrow electronics")
+        resp = client.get(self._URL, params={"vendor_name": "Zorblax Unlimited"}, headers=_HX)
+        assert resp.status_code == 200
+        assert resp.text.strip() == ""
+
+    def test_blank_returns_empty_without_query(self, client, db_session, test_user):
+        resp = client.get(self._URL, params={"vendor_name": "   "}, headers=_HX)
+        assert resp.status_code == 200
+        assert resp.text.strip() == ""
+
+    def test_adopt_name_is_attribute_escaped(self, client, db_session, test_user):
+        """A vendor display name with a quote can't break out of the data attribute.
+
+        Query a FUZZY near-miss so the nudge actually renders the malicious name.
+        """
+        _vendor(db_session, 'Ac"me <x> Corp', "acme x corp")
+        resp = client.get(self._URL, params={"vendor_name": "Acme x Corpp"}, headers=_HX)  # near-miss → fuzzy
+        assert resp.status_code == 200
+        assert resp.text.strip()  # the nudge did render (fuzzy hit on the malicious name)
+        # raw double-quote/angle brackets never appear unescaped in the attribute
+        assert 'data-name="Ac"me' not in resp.text
+        assert "<x>" not in resp.text
+
+    def test_unauthenticated_401(self, unauthenticated_client, db_session):
+        resp = unauthenticated_client.get(self._URL, params={"vendor_name": "Arrow"}, headers=_HX)
+        assert resp.status_code == 401
+
+
+def test_offer_form_field_wires_the_blur_check(client, db_session, test_user):
+    r = _req(db_session, test_user)
+    resp = client.get(f"/v2/partials/requisitions/{r.id}/add-offer-form", headers=_HX)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "/v2/partials/offers/vendor-dup-check" in body
+    assert 'id="offer-vendor-name"' in body
+    assert 'id="vendor-dup-nudge"' in body
+    assert "blur" in body  # hx-trigger fires on blur, not per keystroke


### PR DESCRIPTION
Phase 1 of the "do all" queue (survey idea #10 — the one owner-approved item skipped in the first pass). Full phased plan for the remaining 7 features rides along in `specs/ai-queue-phase-plan-2026-08-23.md`.

## What
The offer form's `vendor_name` was a bare input — the biggest source of vendor-row fragmentation ("Arrow Elec." minting a new row next to "Arrow Electronics"). On blur it now hx-gets `/v2/partials/offers/vendor-dup-check`, which reuses the **deterministic** `vendor_duplicates.check_vendor_duplicate` (exact normalized + pg_trgm fuzzy — **no AI on the per-blur path**, per the survey verifier's build note) and renders a one-tap **"Use 'Arrow Electronics'"** nudge. Adopting sets only the input's value (canonical name carried in an autoescaped `data-name` attr) and clears the nudge — never blocks the save, never re-links rows.

Only **fuzzy near-misses** nudge: an exact match is the normal offer case (logging against an existing vendor — no new row minted), so it's suppressed.

## Review
5-agent adversarial find/refute: **1 low finding fixed** — a post-adopt blur re-showed the nudge; fixed by suppressing exact-match nudges, which is also the correct semantics for an offer form. **2 findings refuted** — the shared field grid's hardcoded IDs can't collide (all three including templates render mutually exclusively), and the `@click` adopt is guaranteed non-null.

## Verification
- 7 tests in `tests/test_offer_vendor_dup_nudge.py` — endpoint (fuzzy/exact/blank/no-match/authz), a **fuzzy-path XSS-escaping assertion** on a malicious vendor name, and the form-field wiring. Deterministic feature, so route-tested + review-verified (both verifier agents independently traced the 2-assignment `@click` safe) rather than browser-driven.
- Full suite **24358 passed / 0 failed**; hooks + assertion-theater lint clean; APP_MAP updated. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017skqbrbYAUTMGwxc3AwNN3