### PR TITLE
Cross-company contact dedupe sweep: suggest-only Data Ops surface (#15)

### DIFF
--- a/app/routers/htmx/settings.py
+++ b/app/routers/htmx/settings.py
@@ -403,11 +403,23 @@ def _render_data_ops(request: Request, user: User, db: Session) -> Response:
         company_scan_failed = True
         logger.warning(f"Company dedup scan failed: {e}")
 
+    contact_dupes: list = []
+    contact_scan_failed = False
+    try:
+        from ...services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        contact_dupes = find_contact_dedup_candidates(db, limit=30)
+    except Exception as e:
+        contact_scan_failed = True
+        logger.warning(f"Contact dedup scan failed: {e}")
+
     ctx = _base_ctx(request, user, "settings")
     ctx["vendor_dupes"] = vendor_dupes
     ctx["company_dupes"] = company_dupes
+    ctx["contact_dupes"] = contact_dupes
     ctx["vendor_scan_failed"] = vendor_scan_failed
     ctx["company_scan_failed"] = company_scan_failed
+    ctx["contact_scan_failed"] = contact_scan_failed
     return template_response("htmx/partials/settings/data_ops.html", ctx)
 
 
@@ -855,6 +867,80 @@ async def admin_company_merge(
         success_msg_fn=_msg,
         error_prefix="Company merge failed",
     )
+
+
+@router.post("/v2/partials/admin/contact-merge", response_class=HTMLResponse)
+async def admin_contact_merge(
+    request: Request,
+    keep_id: int = Form(...),
+    remove_id: int = Form(...),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Merge two cross-site contacts via HTMX (suggest-then-confirm; never
+    automatic)."""
+    from ...models.crm import SiteContact
+    from ...services.contact_merge_service import merge_contacts
+
+    def _msg(result: dict) -> str:
+        kept = db.get(SiteContact, result.get("kept", keep_id))
+        kept_name = kept.full_name if kept and kept.full_name else "contact"
+        return f"Merged into {kept_name}. {result.get('reassigned', 0)} records reassigned."
+
+    return _dedup_single_action(
+        request,
+        user,
+        db,
+        action_fn=lambda: merge_contacts(keep_id, remove_id, db),
+        success_msg_fn=_msg,
+        error_prefix="Contact merge failed",
+    )
+
+
+@router.post("/v2/partials/admin/contact-ai-check", response_class=HTMLResponse)
+async def admin_contact_ai_check(
+    request: Request,
+    id_a: int = Form(...),
+    id_b: int = Form(...),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """On-demand 'AI: same person?' assist for one cross-site contact pair.
+
+    Interactive AI: fast tier, per-user rate limit, single attempt, and a graceful chip on
+    any failure — it must never 500 the Data Ops pane. It only ADVISES; the human still
+    clicks Merge or Dismiss.
+    """
+    from ...dependencies import is_admin
+    from ...models.crm import Company, CustomerSite, SiteContact
+    from ...rate_limit import check_rate_limit
+    from ...services.contact_dedup_candidates import ai_confirm_same_person
+
+    if not is_admin(user):
+        raise HTTPException(403, "Admin only")
+
+    def _load(cid: int) -> dict | None:
+        row = (
+            db.query(SiteContact, Company)
+            .join(CustomerSite, SiteContact.customer_site_id == CustomerSite.id)
+            .join(Company, CustomerSite.company_id == Company.id)
+            .filter(SiteContact.id == cid)
+            .first()
+        )
+        if not row:
+            return None
+        sc, company = row
+        return {"full_name": sc.full_name, "email": sc.email, "company_name": company.name}
+
+    a, b = _load(id_a), _load(id_b)
+    ctx = _base_ctx(request, user, "settings")
+    if a is None or b is None:
+        ctx["verdict"] = {"ok": False, "message": "Contact no longer exists."}
+    elif not check_rate_limit(user.id, "contact_ai_check", limit=15, window_seconds=60):
+        ctx["verdict"] = {"ok": False, "message": "Slow down a moment, then try again."}
+    else:
+        ctx["verdict"] = await ai_confirm_same_person(a, b)
+    return template_response("htmx/partials/settings/_contact_ai_verdict.html", ctx)
 
 
 @router.post("/v2/partials/admin/vendor-delete-both", response_class=HTMLResponse)

--- a/app/services/contact_dedup_candidates.py
+++ b/app/services/contact_dedup_candidates.py
@@ -1,0 +1,249 @@
+"""contact_dedup_candidates.py — cross-company contact-duplicate finder (survey idea
+#15).
+
+The nightly _job_contact_dedup already collapses same-SITE + same-email(case) contacts
+(kept, out of scope). This closes the documented gap — CROSS-site/cross-company contact
+dupes had zero detection — by surfacing high-precision candidate pairs for HUMAN review
+in the Data Ops tab. It NEVER merges: contacts are suggest-only here.
+
+Two high-precision bands (both cross-site, both exclude archived / email-less contacts):
+  - "email"       — identical email (case-insensitive), different customer_site → score 100
+  - "name+domain" — fuzzy full_name (>= _NAME_THRESHOLD) AND shared email domain,
+                    different customer_site → the fuzzy score
+Pure name-only cross-company pairs (no shared email/domain) are deliberately NOT surfaced
+— too noisy, and the plan's own risk note is "respect same-name-different-company".
+
+Computed live on each Data Ops render (mirrors find_vendor/company_dedup_candidates) — no
+storage, so no migration. rapidfuzz token_sort_ratio; grouping by email/domain keeps the
+pairwise scan bounded (never a full O(n^2) over the whole table).
+
+Called by: app/routers/htmx/settings.py (_render_data_ops).
+Depends on: models.crm (SiteContact/CustomerSite/Company), contact_dedup.normalize_contact_name.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections import defaultdict
+
+from loguru import logger
+from rapidfuzz import fuzz
+from sqlalchemy.orm import Session
+
+from app.models.crm import Company, CustomerSite, SiteContact
+from app.services.contact_dedup import normalize_contact_name
+
+_NAME_THRESHOLD = 82  # token_sort_ratio floor for the name+domain band
+_LIMIT = 30
+# Hard cap on the driving query so a huge contacts table never materializes wholesale (the
+# sibling SQLite dedup finders cap at 500 the same way). Contacts are far fewer than sightings.
+_SCAN_CAP = 20000
+
+# A shared email spread across MANY contacts is a generic inbox (info@, sales@) or a data-
+# entry default, not one person — skip such groups (also caps the O(n^2) pairwise work).
+_MAX_EMAIL_GROUP = 6
+# Likewise cap a single email-domain bucket before the name pairwise scan.
+_MAX_DOMAIN_GROUP = 60
+
+# Free/public mailbox providers: a shared domain here means nothing about "same org", and the
+# buckets are huge — never use them for the name+domain band (email-exact still applies).
+_PUBLIC_EMAIL_DOMAINS = frozenset(
+    {
+        "gmail.com",
+        "googlemail.com",
+        "yahoo.com",
+        "ymail.com",
+        "hotmail.com",
+        "outlook.com",
+        "live.com",
+        "msn.com",
+        "aol.com",
+        "icloud.com",
+        "me.com",
+        "mac.com",
+        "protonmail.com",
+        "proton.me",
+        "gmx.com",
+        "gmx.net",
+        "zoho.com",
+        "yandex.com",
+        "mail.com",
+        "qq.com",
+        "163.com",
+        "126.com",
+        "sina.com",
+        "comcast.net",
+        "verizon.net",
+        "sbcglobal.net",
+    }
+)
+
+# Optional scalar fields whose presence signals a more-complete contact (keeper choice).
+_COMPLETENESS_FIELDS = ("title", "phone", "linkedin_url", "contact_role", "secondary_email", "secondary_phone")
+
+
+def _pair(a: dict, b: dict, *, score: int, match: str) -> dict:
+    # Keeper = the more-complete record; tie → lower id (stable, older row wins).
+    keep = a if (a["completeness"], -a["id"]) >= (b["completeness"], -b["id"]) else b
+    return {
+        "contact_a": {k: a[k] for k in ("id", "full_name", "email", "company_name", "site_name")},
+        "contact_b": {k: b[k] for k in ("id", "full_name", "email", "company_name", "site_name")},
+        "score": score,
+        "match": match,
+        "auto_keep_id": keep["id"],
+    }
+
+
+def find_contact_dedup_candidates(
+    db: Session, *, limit: int = _LIMIT, name_threshold: int = _NAME_THRESHOLD
+) -> list[dict]:
+    """Cross-site contact-duplicate pairs for human review.
+
+    Suggest-only; never merges.
+    """
+    # Project ONLY the scalar columns the scan needs (not full ORM entities) — this keeps a
+    # large contacts table out of the session identity map and sidesteps SiteContact's
+    # lazy="joined" reports_to self-join. Bounded by _SCAN_CAP like the sibling finders.
+    completeness_cols = [getattr(SiteContact, f) for f in _COMPLETENESS_FIELDS]
+    rows = (
+        db.query(
+            SiteContact.id,
+            SiteContact.email,
+            SiteContact.full_name,
+            CustomerSite.id,
+            CustomerSite.site_name,
+            Company.name,
+            *completeness_cols,
+        )
+        .join(CustomerSite, SiteContact.customer_site_id == CustomerSite.id)
+        .join(Company, CustomerSite.company_id == Company.id)
+        .filter(SiteContact.is_archived.is_(False))
+        .filter(SiteContact.email.isnot(None), SiteContact.email != "")
+        .limit(_SCAN_CAP + 1)
+        .all()
+    )
+    if len(rows) > _SCAN_CAP:
+        rows = rows[:_SCAN_CAP]
+        logger.warning("contact dedup scan hit the {}-row cap — some contacts were not compared this pass", _SCAN_CAP)
+
+    views: list[dict] = []
+    for cid, email, full_name, site_id, site_name, company_name, *comp in rows:
+        email_lc = (email or "").strip().lower()
+        if "@" not in email_lc:
+            continue
+        views.append(
+            {
+                "id": cid,
+                "site_id": site_id,
+                "company_name": company_name,
+                "site_name": site_name,
+                "full_name": full_name or "",
+                "email": email,
+                "email_lc": email_lc,
+                "domain": email_lc.rsplit("@", 1)[1],
+                "name_norm": normalize_contact_name(full_name or ""),
+                "completeness": sum(1 for c in comp if c),
+            }
+        )
+
+    pairs: list[dict] = []
+    seen: set[tuple[int, int]] = set()
+
+    # Band 1 — identical email, different site (strongest).
+    by_email: dict[str, list[dict]] = defaultdict(list)
+    for v in views:
+        by_email[v["email_lc"]].append(v)
+    oversized_emails: set[str] = set()
+    for email_lc, group in by_email.items():
+        if len(group) > _MAX_EMAIL_GROUP:
+            oversized_emails.add(email_lc)  # a generic shared inbox — excluded from BOTH bands
+            continue
+        for a, b in itertools.combinations(group, 2):
+            if a["site_id"] == b["site_id"]:
+                continue  # same-site same-email is the nightly job's domain
+            key = (min(a["id"], b["id"]), max(a["id"], b["id"]))
+            if key not in seen:
+                seen.add(key)
+                pairs.append(_pair(a, b, score=100, match="email"))
+
+    # Band 2 — shared CORPORATE email domain + fuzzy name, different site. Excludes public
+    # domains, empty domains, and any shared-inbox address band 1 already rejected.
+    by_domain: dict[str, list[dict]] = defaultdict(list)
+    for v in views:
+        dom = v["domain"]
+        if dom and dom not in _PUBLIC_EMAIL_DOMAINS and v["email_lc"] not in oversized_emails:
+            by_domain[dom].append(v)
+    for group in by_domain.values():
+        if len(group) > _MAX_DOMAIN_GROUP:
+            continue  # too big to pairwise-scan meaningfully; would be mostly noise
+        for a, b in itertools.combinations(group, 2):
+            if a["site_id"] == b["site_id"]:
+                continue
+            key = (min(a["id"], b["id"]), max(a["id"], b["id"]))
+            if key in seen:
+                continue
+            if not a["name_norm"] or not b["name_norm"]:
+                continue
+            score = int(fuzz.token_sort_ratio(a["name_norm"], b["name_norm"]))
+            if score >= name_threshold:
+                seen.add(key)
+                pairs.append(_pair(a, b, score=score, match="name+domain"))
+
+    # Email band first, then name+domain by descending score; cap.
+    pairs.sort(key=lambda p: (0 if p["match"] == "email" else 1, -p["score"]))
+    return pairs[:limit]
+
+
+_AI_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "same_person": {"type": "boolean"},
+        "confidence": {"type": "number"},
+        "reason": {"type": ["string", "null"]},
+    },
+    "required": ["same_person"],
+}
+
+_AI_SYSTEM = (
+    "You judge whether two CRM contact records are the SAME real person listed at two "
+    "different companies/sites (e.g. someone who changed jobs, or a duplicate). Weigh the "
+    "name, email local-part, and email domain. Same full name at unrelated companies is "
+    "often DIFFERENT people — say so. Return same_person, a 0..1 confidence, and a one-line "
+    "reason. Never guess high-confidence on a name-only coincidence."
+)
+
+
+async def ai_confirm_same_person(a: dict, b: dict) -> dict:
+    """On-demand 'are these the same person?' advisory for one pair.
+
+    Returns {"ok": True, "same_person": bool, "confidence": float, "reason": str} or
+    {"ok": False, "message": str} on any AI failure — the caller renders a chip either
+    way, never a 500. Interactive: fast tier, single attempt.
+    """
+    from app.utils.claude_client import claude_structured
+    from app.utils.claude_errors import ClaudeError
+
+    prompt = (
+        f"Contact A: name={a.get('full_name')!r}, email={a.get('email')!r}, company={a.get('company_name')!r}\n"
+        f"Contact B: name={b.get('full_name')!r}, email={b.get('email')!r}, company={b.get('company_name')!r}"
+    )
+    try:
+        result = await claude_structured(
+            prompt,
+            _AI_SCHEMA,
+            system=_AI_SYSTEM,
+            model_tier="fast",
+            max_tokens=200,
+            max_attempts=1,
+            cost_bucket="contact_dedup_ai_check",
+        )
+    except ClaudeError:
+        return {"ok": False, "message": "Couldn't reach the AI just now."}
+    if not isinstance(result, dict) or "same_person" not in result:
+        return {"ok": False, "message": "Couldn't reach the AI just now."}
+    try:
+        confidence = round(float(result.get("confidence") or 0.0), 2)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    reason = str(result["reason"]).strip()[:240] if result.get("reason") else None
+    return {"ok": True, "same_person": bool(result["same_person"]), "confidence": confidence, "reason": reason}

--- a/app/templates/htmx/partials/settings/_contact_ai_verdict.html
+++ b/app/templates/htmx/partials/settings/_contact_ai_verdict.html
@@ -1,0 +1,15 @@
+{# _contact_ai_verdict.html — on-demand "AI: same person?" chip for one contact pair.
+   Receives: verdict — {ok:True, same_person, confidence, reason} or {ok:False, message}.
+   Advisory only; the human still clicks Merge / Dismiss. Swapped into #ai-verdict-<k>-<l>.
+#}
+{% if not verdict.ok %}
+<span class="inline-block text-xs text-gray-500 italic">{{ verdict.message }}</span>
+{% elif verdict.same_person %}
+<span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-emerald-50 text-emerald-700 border border-emerald-200">
+  ✦ Likely same person ({{ (verdict.confidence * 100)|round|int }}%){% if verdict.reason %} — {{ verdict.reason }}{% endif %}
+</span>
+{% else %}
+<span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-gray-50 text-gray-600 border border-gray-200">
+  ✦ Likely different people ({{ (verdict.confidence * 100)|round|int }}%){% if verdict.reason %} — {{ verdict.reason }}{% endif %}
+</span>
+{% endif %}

--- a/app/templates/htmx/partials/settings/data_ops.html
+++ b/app/templates/htmx/partials/settings/data_ops.html
@@ -186,4 +186,70 @@
     {% endif %}
   </div>
 
+  {# ── Contact Dedup (cross-company, SUGGEST-ONLY) ────────── #}
+  {# Cross-site/cross-company contact dupes — the gap the nightly same-site job never sees.
+     Contacts NEVER auto-merge here: every pair is a human decision (Merge / Dismiss), with
+     an optional on-demand "AI: same person?" assist for the fuzzy name+domain band. #}
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
+    <div class="px-4 py-3 bg-gray-50 border-b">
+      <h2 class="text-lg font-semibold text-gray-900">Contact Duplicates <span class="text-xs font-normal text-gray-500">· cross-company</span></h2>
+    </div>
+
+    {% if contact_scan_failed %}
+    <div class="px-4 py-8 text-center">
+      <p class="text-sm text-rose-600">Couldn't check for duplicate contacts right now &mdash; try Refresh.</p>
+    </div>
+    {% elif contact_dupes %}
+    <div class="divide-y divide-gray-100">
+      {% for pair in contact_dupes %}
+      {% set keeper = pair.contact_a if pair.auto_keep_id == pair.contact_a.id else pair.contact_b %}
+      {% set loser = pair.contact_b if pair.auto_keep_id == pair.contact_a.id else pair.contact_a %}
+      <div class="px-4 py-3" data-pair="{{ keeper.id }}-{{ loser.id }}"
+           x-data="{ dismissed: false }" x-show="!dismissed">
+        <div class="flex items-start gap-4">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 text-sm flex-wrap">
+              <span class="font-medium text-gray-900">{{ pair.contact_a.full_name }}</span>
+              <span class="text-gray-400 text-xs">{{ pair.contact_a.company_name }}</span>
+              <span class="text-gray-400">&harr;</span>
+              <span class="font-medium text-gray-900">{{ pair.contact_b.full_name }}</span>
+              <span class="text-gray-400 text-xs">{{ pair.contact_b.company_name }}</span>
+            </div>
+            <p class="text-xs text-gray-600 mt-0.5">
+              {% if pair.match == 'email' %}<span class="text-emerald-700 font-medium">same email</span>
+              {% else %}<span class="text-amber-700 font-medium">{{ pair.score }}% name · same domain</span>{% endif %}
+              &middot; {{ pair.contact_a.email }} / {{ pair.contact_b.email }}
+              &middot; suggested keep: <span class="font-medium text-gray-700">{{ keeper.full_name|truncate(24) }}</span>
+            </p>
+            <div class="mt-1" id="ai-verdict-{{ keeper.id }}-{{ loser.id }}"></div>
+          </div>
+          <div class="flex gap-2 shrink-0 flex-wrap justify-end">
+            {{ merge_button('            ', '/v2/partials/admin/contact-merge', '#settings-content', keeper.id, loser.id, keeper.full_name, loser.full_name, true) }}
+            {{ merge_button('            ', '/v2/partials/admin/contact-merge', '#settings-content', loser.id, keeper.id, loser.full_name, keeper.full_name, false) }}
+            {% if pair.match == 'name+domain' %}
+            <button type="button"
+                    hx-post="/v2/partials/admin/contact-ai-check"
+                    hx-vals='{"id_a": {{ keeper.id }}, "id_b": {{ loser.id }}}'
+                    hx-target="#ai-verdict-{{ keeper.id }}-{{ loser.id }}"
+                    hx-swap="innerHTML"
+                    class="px-2 py-1 text-xs rounded bg-white text-accent-600 border border-accent-200 hover:bg-accent-50">
+              AI: same person?
+            </button>
+            {% endif %}
+            <button type="button" @click="dismissed = true"
+                    class="px-2 py-1 text-xs rounded bg-white text-gray-500 border border-gray-300 hover:bg-gray-50">
+              Dismiss
+            </button>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="px-4 py-8 text-center">
+      <p class="text-sm text-gray-600">No cross-company contact duplicates found.</p>
+    </div>
+    {% endif %}
+  </div>
+
 </div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -3803,6 +3803,20 @@ merges different-`account_owner_id` accounts) are reused AS-IS.
   negotiation); Approve → `manufacturer_alias_harvester.approve_manufacturer_alias` appends the
   variant to the canonical `Manufacturer.aliases` JSON (or creates the canonical for a `new`),
   Reject dismisses. Raw source-reported manufacturer columns are NEVER rewritten.
+- **Cross-company Contact Duplicates (idea #15):** a third section on the Data Ops tab,
+  alongside Vendor/Company Duplicates and computed the same way — live on each render, no
+  storage (so NO migration). `contact_dedup_candidates.find_contact_dedup_candidates` returns
+  cross-SITE `SiteContact` pairs in two high-precision bands: `email` (identical email,
+  different `customer_site`) and `name+domain` (fuzzy `full_name` ≥82 + shared email domain).
+  It deliberately does NOT surface pure name-only cross-company pairs (too noisy — "same name,
+  different company" is often different people). This is the complement of the nightly
+  `_job_contact_dedup`, which still auto-merges only SAME-site same-email(case) contacts
+  (unchanged — that narrow exact-key collapse is safe). Contacts NEVER auto-merge here: each
+  pair is a human `Merge` (→ `contact_merge_service.merge_contacts` via
+  `POST /v2/partials/admin/contact-merge`, the shared `_dedup_single_action` skeleton) or a
+  client-side `Dismiss`. The `name+domain` band also gets an on-demand "AI: same person?"
+  assist (`POST /v2/partials/admin/contact-ai-check` → `ai_confirm_same_person`, fast tier,
+  per-user rate-limited, single attempt, graceful chip on failure — advisory only).
 - **Vendor-Duplicates loop (same template) had the identical flat-field bug** — it read
   `pair.name_a/id_a/sightings_a` while `vendor_utils.find_vendor_dedup_candidates` returns
   NESTED `{vendor_a:{id,name,sightings}, vendor_b:{…}, score}` → vendor rows rendered blank

--- a/tests/test_contact_dedup_candidates.py
+++ b/tests/test_contact_dedup_candidates.py
@@ -1,0 +1,319 @@
+"""test_contact_dedup_candidates.py — TDD for the cross-company contact dedupe sweep
+(survey idea #15).
+
+The nightly _job_contact_dedup already auto-merges same-SITE + same-email(case) contacts
+(kept, out of scope). This feature closes the documented gap — CROSS-company/cross-site
+contact dupes had zero detection — as SUGGEST-ONLY:
+  - find_contact_dedup_candidates() surfaces high-precision cross-site pairs:
+      band "email"       — identical email, different customer_site (strong)
+      band "name+domain" — fuzzy full_name + shared email domain, different site (review)
+    (pure name-only cross-company pairs are deliberately NOT surfaced — too noisy; the
+     plan's "respect same-name-different-company" risk).
+  - pairs render in the Data Ops tab (computed live — NO new table), one-tap Merge via the
+    existing contact_merge_service, or Dismiss; contacts NEVER auto-merge here.
+  - an on-demand per-pair "AI: same person?" assist is available for the review band.
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_contact_dedup_candidates.py -v)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.crm import Company, CustomerSite, SiteContact
+
+
+def _company(db: Session, name: str) -> Company:
+    c = Company(name=name)
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _site(db: Session, company: Company, site_name: str = "HQ") -> CustomerSite:
+    s = CustomerSite(company_id=company.id, site_name=site_name)
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _contact(db: Session, site: CustomerSite, full_name: str, email: str | None, **kw) -> SiteContact:
+    c = SiteContact(customer_site_id=site.id, full_name=full_name, email=email, **kw)
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _two_sites(db: Session):
+    """Two distinct companies, each with one site — the cross-company setup."""
+    sa = _site(db, _company(db, "Acme Corp"))
+    sb = _site(db, _company(db, "Beta LLC"))
+    return sa, sb
+
+
+# ── finder: email-exact band ─────────────────────────────────────────────────────
+
+
+class TestEmailBand:
+    def test_same_email_cross_site_is_a_pair(self, db_session):
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "Jane Doe", "jane@acme.com")
+        _contact(db_session, sb, "Jane Doe", "JANE@acme.com")  # case variant, different site
+        db_session.commit()
+        pairs = find_contact_dedup_candidates(db_session)
+        assert len(pairs) == 1
+        p = pairs[0]
+        assert p["match"] == "email"
+        assert p["score"] == 100
+        assert {p["contact_a"]["company_name"], p["contact_b"]["company_name"]} == {"Acme Corp", "Beta LLC"}
+
+    def test_same_email_same_site_is_not_a_pair(self, db_session):
+        """Same-site same-email is the existing nightly job's job — never surfaced
+        here."""
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa = _site(db_session, _company(db_session, "Acme Corp"))
+        _contact(db_session, sa, "Jane Doe", "jane@acme.com")
+        _contact(db_session, sa, "Jane D", "JANE@acme.com")  # case variant the case-sensitive uq permits
+        db_session.commit()
+        assert find_contact_dedup_candidates(db_session) == []
+
+    def test_empty_or_null_email_ignored(self, db_session):
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "No Email", "")
+        _contact(db_session, sb, "No Email", None)
+        db_session.commit()
+        assert find_contact_dedup_candidates(db_session) == []
+
+    def test_archived_contacts_excluded(self, db_session):
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "Jane Doe", "jane@acme.com")
+        _contact(db_session, sb, "Jane Doe", "jane@acme.com", is_archived=True)
+        db_session.commit()
+        assert find_contact_dedup_candidates(db_session) == []
+
+    def test_auto_keep_id_prefers_more_complete_contact(self, db_session):
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        sparse = _contact(db_session, sa, "Jane Doe", "jane@acme.com")
+        rich = _contact(
+            db_session,
+            sb,
+            "Jane Doe",
+            "jane@acme.com",
+            title="Buyer",
+            phone="555-1212",
+            linkedin_url="x",
+            contact_role="buyer",
+        )
+        db_session.commit()
+        p = find_contact_dedup_candidates(db_session)[0]
+        assert p["auto_keep_id"] == rich.id  # richer record kept, not the sparse one
+        assert sparse.id != rich.id
+
+
+# ── finder: name+domain band ─────────────────────────────────────────────────────
+
+
+class TestNameDomainBand:
+    def test_fuzzy_name_shared_domain_cross_site_is_a_pair(self, db_session):
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "Jonathan Smith", "j.smith@acme.com")
+        _contact(db_session, sb, "Jonathon Smith", "jonathon.smith@acme.com")  # spelling variant, same domain
+        db_session.commit()
+        pairs = find_contact_dedup_candidates(db_session)
+        assert len(pairs) == 1
+        assert pairs[0]["match"] == "name+domain"
+        assert pairs[0]["score"] >= 82
+
+    def test_similar_name_different_domain_not_surfaced(self, db_session):
+        """Name-only cross-company (no shared email/domain) is too noisy — excluded."""
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "John Smith", "john@acme.com")
+        _contact(db_session, sb, "John Smith", "john@beta.com")  # different domain
+        db_session.commit()
+        assert find_contact_dedup_candidates(db_session) == []
+
+    def test_shared_domain_unrelated_names_not_surfaced(self, db_session):
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "Alice Wong", "alice@acme.com")
+        _contact(db_session, sb, "Bob Vance", "bob@acme.com")  # same domain, unrelated names
+        db_session.commit()
+        assert find_contact_dedup_candidates(db_session) == []
+
+    def test_public_email_domain_excluded_from_name_band(self, db_session):
+        """gmail.com et al.
+
+        carry no 'same org' signal — similar names there are not a pair.
+        """
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "Jonathan Smith", "jonathan.smith@gmail.com")
+        _contact(db_session, sb, "Jonathon Smith", "jonathon.smith@gmail.com")  # public domain
+        db_session.commit()
+        assert find_contact_dedup_candidates(db_session) == []
+
+
+class TestGuards:
+    def test_generic_shared_inbox_fully_suppressed(self, db_session):
+        """A single email shared by many contacts is a generic inbox — suppressed in
+        BOTH bands (the oversized email must not leak back through the shared-domain
+        band)."""
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        # 8 sites, each a contact at the SAME shared inbox address → group size 8 > cap.
+        for i in range(8):
+            s = _site(db_session, _company(db_session, f"Co{i}"))
+            _contact(db_session, s, f"Person {i}", "info@vendor.com")
+        db_session.commit()
+        # Not one email pair AND not one name+domain pair — the shared inbox is fully skipped.
+        assert find_contact_dedup_candidates(db_session) == []
+
+    def test_trailing_at_empty_domain_not_grouped(self, db_session):
+        """A malformed 'foo@' address has an empty domain — it must not bucket unrelated
+        contacts together in the name+domain band."""
+        from app.services.contact_dedup_candidates import find_contact_dedup_candidates
+
+        sa, sb = _two_sites(db_session)
+        _contact(db_session, sa, "Jonathan Smith", "jonathan@")  # empty domain
+        _contact(db_session, sb, "Jonathon Smith", "jonathon@")  # empty domain, similar name
+        db_session.commit()
+        assert find_contact_dedup_candidates(db_session) == []
+
+
+# ── Data Ops surface + merge + AI-check routes ───────────────────────────────────
+
+
+@pytest.fixture()
+def admin_client(db_session, admin_user):
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: admin_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in (get_db, require_user):
+            app.dependency_overrides.pop(dep, None)
+
+
+def _email_pair(db):
+    sa, sb = _two_sites(db)
+    a = _contact(db, sa, "Jane Doe", "jane@acme.com")
+    b = _contact(db, sb, "Jane Doe", "JANE@acme.com")
+    db.commit()
+    return a, b
+
+
+class TestDataOpsRoutes:
+    def test_data_ops_renders_contacts_section(self, admin_client, db_session):
+        _email_pair(db_session)
+        resp = admin_client.get("/v2/partials/settings/data-ops", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Contact Duplicates" in resp.text
+        assert "Acme Corp" in resp.text and "Beta LLC" in resp.text
+        assert "same email" in resp.text
+
+    def test_admin_contact_merge_merges_and_rerenders(self, admin_client, db_session):
+        from app.models.crm import SiteContact
+
+        a, b = _email_pair(db_session)
+        resp = admin_client.post(
+            "/v2/partials/admin/contact-merge",
+            data={"keep_id": a.id, "remove_id": b.id},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # loser deleted, keeper survives → the pair is gone from the re-rendered pane
+        assert db_session.get(SiteContact, b.id) is None
+        assert db_session.get(SiteContact, a.id) is not None
+        assert "No cross-company contact duplicates found." in resp.text
+
+    def test_contact_merge_non_admin_403(self, client, db_session):
+        a, b = _email_pair(db_session)
+        resp = client.post(
+            "/v2/partials/admin/contact-merge",
+            data={"keep_id": a.id, "remove_id": b.id},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 403
+
+    def test_ai_check_renders_verdict(self, admin_client, db_session):
+        a, b = _email_pair(db_session)
+        with patch(
+            "app.utils.claude_client.claude_structured",
+            new_callable=AsyncMock,
+            return_value={"same_person": True, "confidence": 0.9, "reason": "identical email"},
+        ):
+            resp = admin_client.post(
+                "/v2/partials/admin/contact-ai-check",
+                data={"id_a": a.id, "id_b": b.id},
+                headers={"HX-Request": "true"},
+            )
+        assert resp.status_code == 200
+        assert "Likely same person" in resp.text
+        assert "90%" in resp.text
+
+    def test_ai_check_different_people_verdict(self, admin_client, db_session):
+        a, b = _email_pair(db_session)
+        with patch(
+            "app.utils.claude_client.claude_structured",
+            new_callable=AsyncMock,
+            return_value={"same_person": False, "confidence": 0.8, "reason": "different companies, no other match"},
+        ):
+            resp = admin_client.post(
+                "/v2/partials/admin/contact-ai-check",
+                data={"id_a": a.id, "id_b": b.id},
+                headers={"HX-Request": "true"},
+            )
+        assert resp.status_code == 200
+        assert "Likely different people" in resp.text
+        assert "80%" in resp.text
+
+    def test_ai_check_graceful_on_failure(self, admin_client, db_session):
+        """An AI error renders an advisory chip, never a 500."""
+        from app.utils.claude_errors import ClaudeError
+
+        a, b = _email_pair(db_session)
+        with patch(
+            "app.utils.claude_client.claude_structured",
+            new_callable=AsyncMock,
+            side_effect=ClaudeError("boom"),
+        ):
+            resp = admin_client.post(
+                "/v2/partials/admin/contact-ai-check",
+                data={"id_a": a.id, "id_b": b.id},
+                headers={"HX-Request": "true"},
+            )
+        assert resp.status_code == 200
+        assert "reach the AI just now" in resp.text  # graceful chip (apostrophe is HTML-escaped)
+
+    def test_ai_check_non_admin_403(self, client, db_session):
+        a, b = _email_pair(db_session)
+        resp = client.post(
+            "/v2/partials/admin/contact-ai-check",
+            data={"id_a": a.id, "id_b": b.id},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
## Cross-company contact dedupe sweep (survey idea #15)

Duplicate contacts that span **different companies/sites** had **zero detection** — the nightly job only collapses same-site same-email contacts. This closes that gap as a **suggest-only** review surface. No migration.

### What it does
- **`find_contact_dedup_candidates`** (new, computed live like the vendor/company finders — no table) surfaces two high-precision cross-site bands:
  - **email** — identical email, different `customer_site`
  - **name+domain** — fuzzy `full_name` (≥82 token_sort_ratio) + shared **corporate** email domain
- Pure name-only cross-company pairs are deliberately **not** surfaced ("same name, different company" is often different people). Public mailbox domains (gmail/yahoo/…), shared inboxes, and empty domains are excluded.
- **Surface**: a **Contact Duplicates** section on the admin Data Ops tab. Each pair is a human decision — one-tap **Merge** (→ existing `contact_merge_service.merge_contacts`) or **Dismiss** (client-side). Contacts **never auto-merge** here; the nightly `_job_contact_dedup` is untouched.
- **On-demand "AI: same person?"** assist for the name+domain band (fast tier, per-user rate-limited, single attempt, graceful chip — advisory only).

### Adversarial review — 5 findings (2 HIGH, 1 MED, 2 LOW), all addressed
| Severity | Finding | Fix |
|---|---|---|
| HIGH | Finder materialized the whole contacts table as ORM entities on every render (+ `reports_to` joined-load) | Project only needed scalar columns; cap the driving query at 20k rows |
| HIGH | Shared-inbox guard covered only the email band → the same contacts re-exploded via the domain band (28 pairs); the test masked it | Exclude oversized-email contacts from the name+domain band too; test now asserts full suppression (`== []`) |
| MED | (same root as above) | (same fix) |
| LOW | Trailing-`@` empty domain bucketed unrelated contacts | Skip empty domains in the name band |
| LOW | Policy fidelity — no auto-merge, nightly job untouched | Confirmed, no change |
(13 further findings were raised and refuted on verification.)

### Tests
18 tests in `tests/test_contact_dedup_candidates.py` — both bands, same-site exclusion, archived exclusion, keeper choice, public-domain / shared-inbox / empty-domain guards, Data Ops render, merge-and-re-render, non-admin 403 on both POSTs, AI verdicts (same/different/graceful-failure). Full suite green; projected query validated on real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
