### PR TITLE
QP draft-from-deal: suggest-only section prefill from deal + prior QPs + pasted TSO (#8+#19)

### DIFF
--- a/app/routers/quality_plans.py
+++ b/app/routers/quality_plans.py
@@ -413,8 +413,14 @@ def _section_approved(qp: QualityPlan, gate_type: str) -> bool:
     return qp.purchasing_section_reviewed_at is not None
 
 
-def _render_sales_section(request: Request, db: Session, qp: QualityPlan, user) -> HTMLResponse:
-    """Render the refreshed Sales section partial."""
+def _render_sales_section(
+    request: Request, db: Session, qp: QualityPlan, user, *, draft: dict | None = None
+) -> HTMLResponse:
+    """Render the refreshed Sales section partial.
+
+    *draft* (optional) carries AI-suggested values for empty fields — prefilled behind
+    an amber banner, never written until accepted.
+    """
     return template_response(
         "htmx/partials/qp/_section_sales.html",
         {
@@ -422,12 +428,18 @@ def _render_sales_section(request: Request, db: Session, qp: QualityPlan, user) 
             "user": user,
             "qp": qp,
             "sales_errors": validate_section(qp, ApprovalGateType.QP_SALES),
+            "draft": draft or {},
         },
     )
 
 
-def _render_purchasing_section(request: Request, db: Session, qp: QualityPlan, user) -> HTMLResponse:
-    """Render the refreshed Purchasing section partial."""
+def _render_purchasing_section(
+    request: Request, db: Session, qp: QualityPlan, user, *, draft: dict | None = None
+) -> HTMLResponse:
+    """Render the refreshed Purchasing section partial (see _render_sales_section re:
+
+    draft).
+    """
     return template_response(
         "htmx/partials/qp/_section_purchasing.html",
         {
@@ -435,6 +447,7 @@ def _render_purchasing_section(request: Request, db: Session, qp: QualityPlan, u
             "user": user,
             "qp": qp,
             "purchasing_errors": validate_section(qp, ApprovalGateType.QP_PURCHASING),
+            "draft": draft or {},
         },
     )
 
@@ -504,6 +517,59 @@ async def qp_patch_purchasing(
                 setattr(qp, field, _coerce(kind, form.get(field)))
         db.commit()
     qp = _load_qp_for_edit(db, qp_id, user)
+    return _render_purchasing_section(request, db, qp, user)
+
+
+@router.post("/v2/qp/{qp_id}/draft/{section}", response_class=HTMLResponse)
+async def qp_draft_section(
+    request: Request,
+    qp_id: int,
+    section: str,
+    pasted_text: str = Form(""),
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+) -> HTMLResponse:
+    """Draft the empty free-text fields of a QP section from the deal (+ optional pasted
+    customer TSO/PO), for HUMAN review.
+
+    Suggest-only: re-renders the section with the suggestions prefilled behind an amber
+    "AI — verify" banner; nothing is written until the human clicks Accept (the existing
+    section PATCH). A no-op on an already-reviewed (locked) section. A pasted-text AI call
+    is per-user rate-limited and falls through to deterministic-only on limit/failure.
+    """
+    if section not in ("sales", "purchasing"):
+        raise HTTPException(status_code=404, detail="Unknown QP section")
+    qp = _load_qp_for_edit(db, qp_id, user)
+    gate = ApprovalGateType.QP_SALES if section == "sales" else ApprovalGateType.QP_PURCHASING
+    draft: dict = {}
+    if not _section_approved(qp, gate):
+        from ..rate_limit import check_rate_limit
+        from ..services.qp_draft_service import build_section_draft, extract_qp_fields_from_paste
+
+        paste_values = None
+        if pasted_text.strip() and check_rate_limit(user.id, "qp_draft_paste", limit=10, window_seconds=60):
+            paste_values = await extract_qp_fields_from_paste(pasted_text, section)
+        draft = build_section_draft(db, qp, section, paste_values=paste_values)
+    if section == "sales":
+        return _render_sales_section(request, db, qp, user, draft=draft)
+    return _render_purchasing_section(request, db, qp, user, draft=draft)
+
+
+@router.get("/v2/qp/{qp_id}/section/{section}", response_class=HTMLResponse)
+async def qp_section(
+    request: Request,
+    qp_id: int,
+    section: str,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+) -> HTMLResponse:
+    """Render one QP section partial CLEAN (no draft) — used to Discard a draft without
+    writing anything."""
+    if section not in ("sales", "purchasing"):
+        raise HTTPException(status_code=404, detail="Unknown QP section")
+    qp = _load_qp_for_edit(db, qp_id, user)
+    if section == "sales":
+        return _render_sales_section(request, db, qp, user)
     return _render_purchasing_section(request, db, qp, user)
 
 

--- a/app/services/qp_draft_service.py
+++ b/app/services/qp_draft_service.py
@@ -1,0 +1,241 @@
+"""qp_draft_service.py — draft the empty free-text Quality-Plan fields from the deal
+(survey ideas #8 + #19, merged).
+
+Pure, read-only suggestion builder — it NEVER writes the QP. The router renders the
+suggestions into the section form (fill-empty-only) behind an amber "AI — verify" banner;
+the human accepts and the existing section PATCH persists. Three clearly-separated sources:
+  - "deal"  — deterministic copy from this buy plan's Requirement + chosen Offer + commodity
+  - "prior" — carry-forward from the most-recent section-reviewed QP for the same
+              company + commodity
+  - "ai"    — Claude extraction from a pasted customer TSO/PO (extract_qp_fields_from_paste)
+
+Called by: app/routers/quality_plans.py (the draft routes).
+Depends on: models (quality_plan / buy_plan / sourcing / crm / intelligence), claude_client.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.buy_plan import BuyPlan, BuyPlanLine
+from app.models.intelligence import MaterialCard
+from app.models.quality_plan import QualityPlan
+from app.models.sourcing import Requirement, Requisition
+from app.utils.claude_client import claude_structured
+from app.utils.claude_errors import ClaudeError
+
+# The draftable (non-boolean) free-text/number fields per section. Booleans are deliberately
+# excluded — a yes/no policy is never auto-suggested from a different deal. Mirrors the
+# section PATCH whitelists in routers/quality_plans.py (the writer for accepted values).
+_SALES_DRAFT_FIELDS = (
+    "sales_condition",
+    "sales_quantity",
+    "sales_fw_hw_rev",
+    "sales_product_commodity",
+    "sales_testing_option",
+    "sales_testing_specifics",
+    "sales_test_location",
+    "sales_routing_prescreening_whs",
+    "sales_vendor_rating",
+    "sales_pkg_requirements",
+    "sales_bom_matrix_links",
+    "sales_notes",
+)
+_PURCHASING_DRAFT_FIELDS = (
+    "purchasing_po_number",
+    "purchasing_condition",
+    "purchasing_fw_hw_rev",
+    "purchasing_product_commodity",
+    "purchasing_testing_option",
+    "purchasing_routing_prescreening_whs",
+    "purchasing_packaging",
+    "purchasing_tpo_notes",
+)
+_SECTION_FIELDS = {"sales": _SALES_DRAFT_FIELDS, "purchasing": _PURCHASING_DRAFT_FIELDS}
+
+
+def _is_empty(value) -> bool:
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def _fw_hw_string(*parts: str | None) -> str | None:
+    """Join present FW/HW/date fragments into one 'FW1.2 / HWA' string (None if all
+    blank)."""
+    kept = [str(p).strip() for p in parts if p and str(p).strip()]
+    return " / ".join(kept) or None
+
+
+def _first_line(bp: BuyPlan) -> BuyPlanLine | None:
+    """The first buy-plan line that carries a requirement (the deal source).
+
+    Most QPs are single-line; a multi-line QP drafts from its first requirement-bearing
+    line.
+    """
+    lines: list[BuyPlanLine] = bp.lines or []
+    for line in sorted(lines, key=lambda ln: ln.id):
+        if line.requirement is not None:
+            return line
+    return None
+
+
+def _deal_context(db: Session, qp: QualityPlan) -> dict:
+    """Gather the deal's draftable values (Requirement + chosen Offer + commodity)."""
+    bp = qp.buy_plan
+    if bp is None:
+        return {}
+    line = _first_line(bp)
+    if line is None:
+        return {}
+    req = line.requirement
+    offer = line.offer
+    commodity = None
+    if req is not None and req.material_card_id is not None:
+        card = db.get(MaterialCard, req.material_card_id)
+        commodity = card.category if card else None
+    return {
+        "commodity": commodity,
+        "condition": req.condition if req else None,
+        "quantity": (req.target_qty if req and req.target_qty else None) or line.quantity,
+        "sales_fw_hw": _fw_hw_string(req.firmware, req.hardware_codes, req.date_codes) if req else None,
+        "offer_condition": offer.condition if offer else None,
+        "offer_packaging": offer.packaging if offer else None,
+        "offer_fw_hw": _fw_hw_string(offer.firmware, offer.hardware_code) if offer else None,
+        "po_number": line.po_number,
+    }
+
+
+def _deterministic_values(section: str, ctx: dict) -> dict:
+    """Map the deal context onto this section's QP fields (deterministic, no AI)."""
+    if section == "sales":
+        return {
+            "sales_condition": ctx.get("condition"),
+            "sales_quantity": ctx.get("quantity"),
+            "sales_product_commodity": ctx.get("commodity"),
+            "sales_fw_hw_rev": ctx.get("sales_fw_hw"),
+        }
+    return {
+        "purchasing_po_number": ctx.get("po_number"),
+        "purchasing_condition": ctx.get("offer_condition") or ctx.get("condition"),
+        "purchasing_product_commodity": ctx.get("commodity"),
+        "purchasing_packaging": ctx.get("offer_packaging"),
+        "purchasing_fw_hw_rev": ctx.get("offer_fw_hw") or ctx.get("sales_fw_hw"),
+    }
+
+
+def _prior_reviewed_values(db: Session, qp: QualityPlan, section: str, fields: list[str]) -> dict:
+    """Carry-forward: values for *fields* from recent section-reviewed QPs (same company +
+    commodity), most-recent first. Only fills a field once (first non-empty prior wins)."""
+    bp = qp.buy_plan
+    if bp is None or bp.requisition is None or bp.requisition.company_id is None:
+        return {}
+    ctx = _deal_context(db, qp)
+    commodity = ctx.get("commodity")
+    if not commodity:
+        return {}  # no commodity → carry-forward would be too broad
+    reviewed_at = getattr(QualityPlan, f"{section}_section_reviewed_at")
+    # Match the commodity via an EXISTS semi-join, NOT a row-multiplying inner join on
+    # BuyPlanLine: a prior QP whose buy plan has several matching (split) lines must count
+    # once, or the SQL-level LIMIT would count fanned-out rows and starve older prior QPs.
+    commodity_match = (
+        select(BuyPlanLine.id)
+        .join(Requirement, BuyPlanLine.requirement_id == Requirement.id)
+        .join(MaterialCard, Requirement.material_card_id == MaterialCard.id)
+        .where(BuyPlanLine.buy_plan_id == BuyPlan.id, MaterialCard.category == commodity)
+        .exists()
+    )
+    stmt = (
+        select(QualityPlan)
+        .join(BuyPlan, QualityPlan.buy_plan_id == BuyPlan.id)
+        .join(Requisition, BuyPlan.requisition_id == Requisition.id)
+        .where(
+            Requisition.company_id == bp.requisition.company_id,
+            reviewed_at.isnot(None),
+            QualityPlan.id != qp.id,
+            commodity_match,
+        )
+        .order_by(reviewed_at.desc())
+        .limit(3)
+    )
+    out: dict = {}
+    for prior in db.execute(stmt).scalars():
+        for field in fields:
+            if field not in out:
+                val = getattr(prior, field, None)
+                if not _is_empty(val):
+                    out[field] = val
+    return out
+
+
+def build_section_draft(
+    db: Session, qp: QualityPlan, section: str, *, paste_values: dict | None = None
+) -> dict[str, dict]:
+    """Suggested values for the EMPTY fields of *section*.
+
+    Precedence for a still-empty field:
+    deterministic deal-copy ("deal") → pasted-document extraction ("ai") → carry-forward
+    ("prior"). Returns {field: {"value": v, "source": ...}}. Never touches already-set fields.
+    """
+    fields = _SECTION_FIELDS.get(section, ())
+    empty = [f for f in fields if _is_empty(getattr(qp, f, None))]
+    if not empty:
+        return {}
+
+    draft: dict[str, dict] = {}
+    for field, value in _deterministic_values(section, _deal_context(db, qp)).items():
+        if field in empty and not _is_empty(value):
+            draft[field] = {"value": value, "source": "deal"}
+
+    for field, value in (paste_values or {}).items():
+        if field in empty and field not in draft and not _is_empty(value):
+            draft[field] = {"value": value, "source": "ai"}
+
+    still_empty = [f for f in empty if f not in draft]
+    for field, value in _prior_reviewed_values(db, qp, section, still_empty).items():
+        draft[field] = {"value": value, "source": "prior"}
+    return draft
+
+
+def _paste_schema(section: str) -> dict:
+    props = {f: {"type": ["string", "null"]} for f in _SECTION_FIELDS.get(section, ())}
+    return {"type": "object", "properties": props}
+
+
+def _paste_system(section: str) -> str:
+    return (
+        f"You extract Quality-Plan {section.upper()} fields from a pasted customer TSO/PO/quote. "
+        "Return ONLY fields the document actually states; use null for anything not present — "
+        "NEVER guess or infer. Copy values verbatim (trimmed). Fields: " + ", ".join(_SECTION_FIELDS.get(section, ()))
+    )
+
+
+async def extract_qp_fields_from_paste(raw_text: str, section: str) -> dict:
+    """Claude-extract QP fields from a pasted customer document.
+
+    Returns {field: value} for the whitelisted section fields only; {} on empty text or
+    any AI failure (never raises).
+    """
+    if not raw_text or not raw_text.strip():
+        return {}
+    allowed = set(_SECTION_FIELDS.get(section, ()))
+    if not allowed:
+        return {}
+    try:
+        result = await claude_structured(
+            raw_text.strip()[:8000],
+            _paste_schema(section),
+            system=_paste_system(section),
+            model_tier="fast",
+            max_tokens=1024,
+            max_attempts=1,
+            cost_bucket="qp_draft_paste",
+        )
+    except ClaudeError:
+        return {}
+    if not isinstance(result, dict):
+        return {}
+    out: dict = {}
+    for field, value in result.items():
+        if field in allowed and value is not None and str(value).strip():
+            out[field] = str(value).strip()
+    return out

--- a/app/templates/htmx/partials/qp/_section_purchasing.html
+++ b/app/templates/htmx/partials/qp/_section_purchasing.html
@@ -13,6 +13,8 @@
               Swaps into its own #qp-section-purchasing wrapper.
 #}
 {% set locked = qp.purchasing_section_reviewed_at is not none %}
+{% set draft = draft|default({}) %}
+{% set src_labels = {'deal': 'from deal', 'prior': 'prior QP', 'ai': 'AI — verify'} %}
 
 <div id="qp-section-purchasing">
   {% if locked %}
@@ -54,23 +56,51 @@
   </div>
 
   {% else %}
-  <form hx-patch="/v2/qp/{{ qp.id }}/purchasing"
-        hx-target="#qp-section-purchasing"
-        hx-swap="outerHTML"
-        hx-trigger="change"
+  {# ── AI-draft toolbar ── #}
+  <div x-data="{ paste: false }" class="mb-2 flex flex-wrap items-center gap-2">
+    <button type="button"
+            hx-post="/v2/qp/{{ qp.id }}/draft/purchasing" hx-target="#qp-section-purchasing" hx-swap="outerHTML"
+            data-loading-disable class="btn btn-secondary btn-sm">✦ Draft with AI</button>
+    <button type="button" @click="paste = !paste" class="text-xs text-accent-600 hover:underline">from a pasted TSO/PO…</button>
+    <div x-show="paste" x-cloak class="w-full">
+      <form hx-post="/v2/qp/{{ qp.id }}/draft/purchasing" hx-target="#qp-section-purchasing" hx-swap="outerHTML">
+        <textarea name="pasted_text" rows="3" placeholder="Paste the customer TSO / PO / quote…"
+                  class="w-full rounded border-gray-300 text-xs"></textarea>
+        <button type="submit" data-loading-disable class="btn btn-secondary btn-sm mt-1">✦ Draft from paste</button>
+      </form>
+    </div>
+  </div>
+
+  {% if draft %}
+  <div class="mb-2 rounded border border-amber-300 bg-amber-50 p-2">
+    <p class="text-xs font-semibold text-amber-800">AI drafted {{ draft|length }} empty field{{ 's' if draft|length != 1 }} from the deal / prior QPs — verify each, then save. Nothing is written yet.</p>
+    <div class="mt-1 flex gap-2">
+      <button type="button"
+              hx-patch="/v2/qp/{{ qp.id }}/purchasing" hx-include="#qp-purchasing-form"
+              hx-target="#qp-section-purchasing" hx-swap="outerHTML"
+              data-loading-disable class="btn btn-primary btn-sm">Accept &amp; save</button>
+      <button type="button"
+              hx-get="/v2/qp/{{ qp.id }}/section/purchasing" hx-target="#qp-section-purchasing" hx-swap="outerHTML"
+              class="btn btn-secondary btn-sm">Discard</button>
+    </div>
+  </div>
+  {% endif %}
+
+  <form id="qp-purchasing-form"
+        {% if not draft %}hx-patch="/v2/qp/{{ qp.id }}/purchasing" hx-target="#qp-section-purchasing" hx-swap="outerHTML" hx-trigger="change"{% endif %}
         class="grid grid-cols-1 gap-3 md:grid-cols-2">
-    {% macro txt(name, label, value) %}
+    {% macro txt(name, label, value, src) %}
     <label class="block text-xs">
-      <span class="text-gray-600">{{ label }}</span>
+      <span class="text-gray-600">{{ label }}{% if src %} <span class="ml-1 rounded bg-amber-100 px-1 text-[11px] font-medium text-amber-700">{{ src }}</span>{% endif %}</span>
       <input type="text" name="{{ name }}" value="{{ value if value is not none else '' }}"
-             class="mt-0.5 w-full rounded border-gray-300 text-xs">
+             class="mt-0.5 w-full rounded text-xs {{ 'border-amber-300 bg-amber-50' if src else 'border-gray-300' }}">
     </label>
     {% endmacro %}
-    {% macro area(name, label, value) %}
+    {% macro area(name, label, value, src) %}
     <label class="block text-xs md:col-span-2">
-      <span class="text-gray-600">{{ label }}</span>
+      <span class="text-gray-600">{{ label }}{% if src %} <span class="ml-1 rounded bg-amber-100 px-1 text-[11px] font-medium text-amber-700">{{ src }}</span>{% endif %}</span>
       <textarea name="{{ name }}" rows="2"
-                class="mt-0.5 w-full rounded border-gray-300 text-xs">{{ value if value is not none else '' }}</textarea>
+                class="mt-0.5 w-full rounded text-xs {{ 'border-amber-300 bg-amber-50' if src else 'border-gray-300' }}">{{ value if value is not none else '' }}</textarea>
     </label>
     {% endmacro %}
     {% macro yn(name, label, value) %}
@@ -83,16 +113,22 @@
       </select>
     </label>
     {% endmacro %}
-    {{ txt('purchasing_po_number', 'Purchase Order #', qp.purchasing_po_number) }}
-    {{ txt('purchasing_condition', 'Condition', qp.purchasing_condition) }}
-    {{ txt('purchasing_product_commodity', 'Product Commodity', qp.purchasing_product_commodity) }}
-    {{ area('purchasing_fw_hw_rev', 'FW / HW / REV / Date & Week Codes', qp.purchasing_fw_hw_rev) }}
+    {% macro fld(name, kind, label) %}
+      {% set d = draft.get(name) %}
+      {% set val = d.value if d else qp|attr(name) %}
+      {% set src = src_labels.get(d.source) if d else none %}
+      {% if kind == 'area' %}{{ area(name, label, val, src) }}{% else %}{{ txt(name, label, val, src) }}{% endif %}
+    {% endmacro %}
+    {{ fld('purchasing_po_number', 'txt', 'Purchase Order #') }}
+    {{ fld('purchasing_condition', 'txt', 'Condition') }}
+    {{ fld('purchasing_product_commodity', 'txt', 'Product Commodity') }}
+    {{ fld('purchasing_fw_hw_rev', 'area', 'FW / HW / REV / Date & Week Codes') }}
     {{ yn('purchasing_testing_required', 'Testing Required', qp.purchasing_testing_required) }}
-    {{ txt('purchasing_testing_option', 'Testing Option', qp.purchasing_testing_option) }}
-    {{ txt('purchasing_routing_prescreening_whs', 'Routing / Prescreening WHS', qp.purchasing_routing_prescreening_whs) }}
-    {{ area('purchasing_packaging', 'Packaging', qp.purchasing_packaging) }}
+    {{ fld('purchasing_testing_option', 'txt', 'Testing Option') }}
+    {{ fld('purchasing_routing_prescreening_whs', 'txt', 'Routing / Prescreening WHS') }}
+    {{ fld('purchasing_packaging', 'area', 'Packaging') }}
     {{ yn('purchasing_tpo_ship_complete', 'Will TPO Ship Complete', qp.purchasing_tpo_ship_complete) }}
-    {{ area('purchasing_tpo_notes', 'TPO Notes / Shipping Schedule', qp.purchasing_tpo_notes) }}
+    {{ fld('purchasing_tpo_notes', 'area', 'TPO Notes / Shipping Schedule') }}
   </form>
 
   {% if purchasing_errors %}

--- a/app/templates/htmx/partials/qp/_section_sales.html
+++ b/app/templates/htmx/partials/qp/_section_sales.html
@@ -13,6 +13,8 @@
               Swaps into its own #qp-section-sales wrapper.
 #}
 {% set locked = qp.sales_section_reviewed_at is not none %}
+{% set draft = draft|default({}) %}
+{% set src_labels = {'deal': 'from deal', 'prior': 'prior QP', 'ai': 'AI — verify'} %}
 
 {# One field roster drives BOTH branches (editable form + read-only grid).
    Each entry: (name, kind, label, ro_label) — kind picks the edit widget
@@ -74,31 +76,62 @@
   </div>
 
   {% else %}
-  {# ── Editable grid: one form PATCHes the whole section on any field change ── #}
-  <form hx-patch="/v2/qp/{{ qp.id }}/sales"
-        hx-target="#qp-section-sales"
-        hx-swap="outerHTML"
-        hx-trigger="change"
+  {# ── AI-draft toolbar ── #}
+  <div x-data="{ paste: false }" class="mb-2 flex flex-wrap items-center gap-2">
+    <button type="button"
+            hx-post="/v2/qp/{{ qp.id }}/draft/sales" hx-target="#qp-section-sales" hx-swap="outerHTML"
+            data-loading-disable class="btn btn-secondary btn-sm">✦ Draft with AI</button>
+    <button type="button" @click="paste = !paste" class="text-xs text-accent-600 hover:underline">from a pasted TSO/PO…</button>
+    <div x-show="paste" x-cloak class="w-full">
+      <form hx-post="/v2/qp/{{ qp.id }}/draft/sales" hx-target="#qp-section-sales" hx-swap="outerHTML">
+        <textarea name="pasted_text" rows="3" placeholder="Paste the customer TSO / PO / quote…"
+                  class="w-full rounded border-gray-300 text-xs"></textarea>
+        <button type="submit" data-loading-disable class="btn btn-secondary btn-sm mt-1">✦ Draft from paste</button>
+      </form>
+    </div>
+  </div>
+
+  {% if draft %}
+  {# Amber review banner — while a draft is shown the section form does NOT auto-save; the
+     only write path is Accept & save, so nothing persists until the human confirms. #}
+  <div class="mb-2 rounded border border-amber-300 bg-amber-50 p-2">
+    <p class="text-xs font-semibold text-amber-800">AI drafted {{ draft|length }} empty field{{ 's' if draft|length != 1 }} from the deal / prior QPs — verify each, then save. Nothing is written yet.</p>
+    <div class="mt-1 flex gap-2">
+      <button type="button"
+              hx-patch="/v2/qp/{{ qp.id }}/sales" hx-include="#qp-sales-form"
+              hx-target="#qp-section-sales" hx-swap="outerHTML"
+              data-loading-disable class="btn btn-primary btn-sm">Accept &amp; save</button>
+      <button type="button"
+              hx-get="/v2/qp/{{ qp.id }}/section/sales" hx-target="#qp-section-sales" hx-swap="outerHTML"
+              class="btn btn-secondary btn-sm">Discard</button>
+    </div>
+  </div>
+  {% endif %}
+
+  {# ── Editable grid: one form PATCHes the whole section on change — UNLESS a draft is under
+     review, when auto-save is suppressed (Accept & save is the only writer). ── #}
+  <form id="qp-sales-form"
+        {% if not draft %}hx-patch="/v2/qp/{{ qp.id }}/sales" hx-target="#qp-section-sales" hx-swap="outerHTML" hx-trigger="change"{% endif %}
         class="grid grid-cols-1 gap-3 md:grid-cols-2">
-    {% macro txt(name, label, value) %}
+    {% macro txt(name, label, value, src) %}
     <label class="block text-xs">
-      <span class="text-gray-600">{{ label }}</span>
+      <span class="text-gray-600">{{ label }}{% if src %} <span class="ml-1 rounded bg-amber-100 px-1 text-[11px] font-medium text-amber-700">{{ src }}</span>{% endif %}</span>
       <input type="text" name="{{ name }}" value="{{ value if value is not none else '' }}"
-             class="mt-0.5 w-full rounded border-gray-300 text-xs">
+             class="mt-0.5 w-full rounded text-xs {{ 'border-amber-300 bg-amber-50' if src else 'border-gray-300' }}">
     </label>
     {% endmacro %}
-    {% macro num(name, label, value) %}
+    {% macro num(name, label, value, src) %}
     <label class="block text-xs">
-      <span class="text-gray-600">{{ label }}</span>
+      <span class="text-gray-600">{{ label }}{% if src %} <span class="ml-1 rounded bg-amber-100 px-1 text-[11px] font-medium text-amber-700">{{ src }}</span>{% endif %}</span>
       <input type="number" name="{{ name }}" value="{{ value if value is not none else '' }}"
-             class="mt-0.5 w-full rounded border-gray-300 text-xs">
+             class="mt-0.5 w-full rounded text-xs {{ 'border-amber-300 bg-amber-50' if src else 'border-gray-300' }}">
     </label>
     {% endmacro %}
-    {% macro area(name, label, value) %}
+    {% macro area(name, label, value, src) %}
     <label class="block text-xs md:col-span-2">
-      <span class="text-gray-600">{{ label }}</span>
+      <span class="text-gray-600">{{ label }}{% if src %} <span class="ml-1 rounded bg-amber-100 px-1 text-[11px] font-medium text-amber-700">{{ src }}</span>{% endif %}</span>
       <textarea name="{{ name }}" rows="2"
-                class="mt-0.5 w-full rounded border-gray-300 text-xs">{{ value if value is not none else '' }}</textarea>
+                class="mt-0.5 w-full rounded text-xs {{ 'border-amber-300 bg-amber-50' if src else 'border-gray-300' }}">{{ value if value is not none else '' }}</textarea>
     </label>
     {% endmacro %}
     {% macro yn(name, label, value) %}
@@ -112,10 +145,13 @@
     </label>
     {% endmacro %}
     {% for name, kind, label, _ro_label in sales_fields %}
+    {% set d = draft.get(name) %}
+    {% set val = d.value if d else qp|attr(name) %}
+    {% set src = src_labels.get(d.source) if d else none %}
     {% if kind == 'yn' %}{{ yn(name, label, qp|attr(name)) }}
-    {% elif kind == 'num' %}{{ num(name, label, qp|attr(name)) }}
-    {% elif kind == 'area' %}{{ area(name, label, qp|attr(name)) }}
-    {% else %}{{ txt(name, label, qp|attr(name)) }}{% endif %}
+    {% elif kind == 'num' %}{{ num(name, label, val, src) }}
+    {% elif kind == 'area' %}{{ area(name, label, val, src) }}
+    {% else %}{{ txt(name, label, val, src) }}{% endif %}
     {% endfor %}
   </form>
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -7444,6 +7444,19 @@ section partials — `qp/_section_sales.html`, `_section_purchasing.html`, `_sec
   an arbitrary column), coercing Y/N→tri-state Boolean, qty→int, else stripped string|None. A PATCH
   is a no-op once the section is approved (read-only). The grid is read-only while a request is
   `requested` or the section is approved.
+- *AI draft-from-deal (ideas #8+#19):* each editable section carries a "✦ Draft with AI" button (+
+  an optional "from a pasted TSO/PO" fold). `POST /v2/qp/{id}/draft/{section}` calls
+  `qp_draft_service.build_section_draft` — SUGGEST-ONLY, it never writes the QP. It fills only the
+  EMPTY non-boolean free-text fields from three precedence-ordered sources: deterministic deal-copy
+  (`"deal"` — the buy plan's first requirement-bearing line's Requirement + chosen Offer +
+  `MaterialCard.category`), pasted-document extraction (`"ai"` — `extract_qp_fields_from_paste`,
+  claude fast tier, per-user rate-limited, single attempt, graceful `{}`), and carry-forward
+  (`"prior"` — the 3 most-recent section-reviewed QPs for the same `company_id` + commodity category).
+  The route re-renders the section with the suggestions prefilled into the inputs behind an amber
+  banner + per-field source chips; **while a draft is shown the form drops its `hx-patch`/
+  `hx-trigger="change"`** so an edit can't silently auto-save. "Accept & save" (`hx-include` the form)
+  fires the existing section PATCH to persist; "Discard" `GET /v2/qp/{id}/section/{section}` re-renders
+  the clean section. A no-op on an already-reviewed (locked) section. NO migration.
 - *Completeness gate:* `validate_section(qp, gate_type)` → `_validate_sales_section`/
   `_validate_purchasing_section` (required: the SO#/PO# + condition + product commodity + testing-
   required, plus quantity for Sales). `submit_section` now calls it FIRST and raises

--- a/tests/test_qp_draft_service.py
+++ b/tests/test_qp_draft_service.py
@@ -1,0 +1,289 @@
+"""test_qp_draft_service.py — TDD for QP draft-from-deal (survey ideas #8+#19).
+
+Drafts the empty free-text Quality-Plan fields from three clearly-separated sources, for
+human review (section prefill + amber "AI — verify" banner; nothing writes until the human
+accepts and the existing section PATCH saves):
+  - deterministic deal-copy   — this deal's Requirement + chosen Offer + commodity (source "deal")
+  - carry-forward             — most-recent section-reviewed QP for same company+commodity ("prior")
+  - pasted TSO/PO extraction  — Claude reads a pasted customer document ("ai")
+Fill-EMPTY-only: a field already set on the QP is never overwritten or re-suggested.
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_qp_draft_service.py -v)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.models import Company, Requirement, Requisition, User
+from app.models.buy_plan import BuyPlan, BuyPlanLine
+from app.models.intelligence import MaterialCard
+from app.models.offers import Offer
+from app.models.quality_plan import QualityPlan
+
+_MPN_SEQ = [0]
+
+
+def _make_deal(
+    db: Session,
+    user: User,
+    *,
+    company_name: str = "Acme Electronics",
+    category: str | None = "capacitors",
+    req: dict | None = None,
+    offer: dict | None = None,
+) -> tuple[QualityPlan, BuyPlan, Requirement, Offer]:
+    """Assemble
+    Company→Requisition→Requirement(+MaterialCard)→Offer→BuyPlan(+line)→QP."""
+    _MPN_SEQ[0] += 1
+    mpn = f"LM{_MPN_SEQ[0]:04d}"
+    # Get-or-create the Company by name so two deals for the "same customer" share one
+    # company_id (that FK is how carry-forward matches "same company").
+    company = db.query(Company).filter(Company.name == company_name).first()
+    if company is None:
+        company = Company(name=company_name)
+        db.add(company)
+        db.flush()
+    requisition = Requisition(
+        name="REQ", customer_name=company_name, company_id=company.id, status="open", created_by=user.id
+    )
+    db.add(requisition)
+    db.flush()
+    card = None
+    if category is not None:
+        card = MaterialCard(normalized_mpn=mpn, display_mpn=mpn, category=category)
+        db.add(card)
+        db.flush()
+    rq = Requirement(
+        requisition_id=requisition.id,
+        primary_mpn=mpn,
+        material_card_id=card.id if card else None,
+        **{"condition": "New", "target_qty": 250, "firmware": "FW1.2", "hardware_codes": "HWA", **(req or {})},
+    )
+    db.add(rq)
+    db.flush()
+    off = Offer(
+        requisition_id=requisition.id,
+        requirement_id=rq.id,
+        vendor_name="Arrow",
+        vendor_name_normalized="arrow",
+        mpn=mpn,
+        normalized_mpn=mpn,
+        status="active",
+        entered_by_id=user.id,
+        created_at=datetime.now(UTC),
+        **{"condition": "New", "packaging": "Tape & Reel", "firmware": "FW1.2", **(offer or {})},
+    )
+    db.add(off)
+    db.flush()
+    bp = BuyPlan(requisition_id=requisition.id, status="draft")
+    db.add(bp)
+    db.flush()
+    db.add(BuyPlanLine(buy_plan_id=bp.id, requirement_id=rq.id, offer_id=off.id, quantity=250, po_number="PO-77"))
+    db.flush()
+    qp = QualityPlan(created_by_id=user.id, buy_plan_id=bp.id)
+    db.add(qp)
+    db.commit()
+    return qp, bp, rq, off
+
+
+class TestDeterministicDealCopy:
+    def test_sales_draft_fills_empty_fields_from_deal(self, db_session, test_user):
+        from app.services.qp_draft_service import build_section_draft
+
+        qp, *_ = _make_deal(db_session, test_user, category="capacitors")
+        draft = build_section_draft(db_session, qp, "sales")
+        assert draft["sales_condition"]["value"] == "New"
+        assert draft["sales_condition"]["source"] == "deal"
+        assert draft["sales_quantity"]["value"] == 250
+        assert draft["sales_product_commodity"]["value"] == "capacitors"
+        assert "FW1.2" in draft["sales_fw_hw_rev"]["value"]
+        assert "HWA" in draft["sales_fw_hw_rev"]["value"]
+
+    def test_purchasing_draft_pulls_from_chosen_offer(self, db_session, test_user):
+        from app.services.qp_draft_service import build_section_draft
+
+        qp, *_ = _make_deal(db_session, test_user, offer={"packaging": "Tray", "condition": "Refurbished"})
+        draft = build_section_draft(db_session, qp, "purchasing")
+        assert draft["purchasing_packaging"]["value"] == "Tray"
+        assert draft["purchasing_condition"]["value"] == "refurb"  # Offer.condition normalizes to the enum value
+        assert draft["purchasing_po_number"]["value"] == "PO-77"
+        assert draft["purchasing_product_commodity"]["value"] == "capacitors"
+
+    def test_already_set_field_is_not_suggested(self, db_session, test_user):
+        from app.services.qp_draft_service import build_section_draft
+
+        qp, *_ = _make_deal(db_session, test_user)
+        qp.sales_condition = "Manually Entered"
+        db_session.commit()
+        draft = build_section_draft(db_session, qp, "sales")
+        assert "sales_condition" not in draft  # never overwrite a human value
+
+    def test_missing_commodity_card_omits_commodity(self, db_session, test_user):
+        from app.services.qp_draft_service import build_section_draft
+
+        qp, *_ = _make_deal(db_session, test_user, category=None)
+        draft = build_section_draft(db_session, qp, "sales")
+        assert "sales_product_commodity" not in draft
+
+
+class TestCarryForward:
+    def test_carry_forward_from_prior_reviewed_qp(self, db_session, test_user):
+        from app.services.qp_draft_service import build_section_draft
+
+        # A prior QP for the SAME company+commodity, sales section reviewed, with a policy field set.
+        prior, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="capacitors")
+        prior.sales_testing_option = "Full functional"
+        prior.sales_test_location = "TRIO Lab"
+        prior.sales_section_reviewed_at = datetime.now(UTC)
+        prior.sales_section_reviewed_by_id = test_user.id
+        db_session.commit()
+
+        qp, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="capacitors")
+        draft = build_section_draft(db_session, qp, "sales")
+        assert draft["sales_testing_option"]["value"] == "Full functional"
+        assert draft["sales_testing_option"]["source"] == "prior"
+        assert draft["sales_test_location"]["value"] == "TRIO Lab"
+
+    def test_no_carry_forward_across_different_commodity(self, db_session, test_user):
+        from app.services.qp_draft_service import build_section_draft
+
+        prior, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="resistors")
+        prior.sales_testing_option = "Full functional"
+        prior.sales_section_reviewed_at = datetime.now(UTC)
+        db_session.commit()
+
+        qp, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="capacitors")
+        draft = build_section_draft(db_session, qp, "sales")
+        assert "sales_testing_option" not in draft  # different commodity → no carry-forward
+
+    def test_unreviewed_prior_qp_does_not_carry(self, db_session, test_user):
+        from app.services.qp_draft_service import build_section_draft
+
+        prior, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="capacitors")
+        prior.sales_testing_option = "Full functional"  # NOT reviewed
+        db_session.commit()
+
+        qp, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="capacitors")
+        draft = build_section_draft(db_session, qp, "sales")
+        assert "sales_testing_option" not in draft
+
+    def test_multiline_recent_prior_does_not_starve_older_prior(self, db_session, test_user):
+        """A newer multi-line prior QP must not consume the whole 3-QP window (the
+        carry-forward query must count distinct QPs, not fanned-out lines)."""
+        from datetime import timedelta
+
+        from app.services.qp_draft_service import build_section_draft
+
+        # OLDER prior: single line, HAS the policy field, reviewed earlier.
+        old, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="capacitors")
+        old.sales_test_location = "TRIO Lab"
+        old.sales_section_reviewed_at = datetime.now(UTC) - timedelta(days=2)
+        db_session.commit()
+
+        # NEWER prior: THREE capacitor lines, does NOT set the field, reviewed later.
+        new, new_bp, new_rq, _ = _make_deal(
+            db_session, test_user, company_name="Acme Electronics", category="capacitors"
+        )
+        for _ in range(2):  # +2 more capacitor lines → 3 total (would fan the old inner join to 3 rows)
+            _MPN_SEQ[0] += 1
+            mpn = f"LM{_MPN_SEQ[0]:04d}"
+            card = MaterialCard(normalized_mpn=mpn, display_mpn=mpn, category="capacitors")
+            db_session.add(card)
+            db_session.flush()
+            r = Requirement(requisition_id=new_bp.requisition_id, primary_mpn=mpn, material_card_id=card.id)
+            db_session.add(r)
+            db_session.flush()
+            db_session.add(BuyPlanLine(buy_plan_id=new_bp.id, requirement_id=r.id, quantity=1))
+        new.sales_section_reviewed_at = datetime.now(UTC) - timedelta(days=1)
+        db_session.commit()
+
+        qp, *_ = _make_deal(db_session, test_user, company_name="Acme Electronics", category="capacitors")
+        draft = build_section_draft(db_session, qp, "sales")
+        assert draft["sales_test_location"]["value"] == "TRIO Lab"  # older prior not starved by the 3-line newer QP
+
+
+class TestPasteExtraction:
+    async def test_extract_from_paste_returns_fields(self, db_session, test_user):
+        from app.services.qp_draft_service import extract_qp_fields_from_paste
+
+        with patch(
+            "app.services.qp_draft_service.claude_structured",
+            new_callable=AsyncMock,
+            return_value={"sales_condition": "Factory New", "sales_testing_specifics": "Burn-in 48h"},
+        ):
+            out = await extract_qp_fields_from_paste("customer TSO text...", "sales")
+        assert out["sales_condition"] == "Factory New"
+        assert out["sales_testing_specifics"] == "Burn-in 48h"
+
+    async def test_extract_drops_unknown_fields(self, db_session, test_user):
+        from app.services.qp_draft_service import extract_qp_fields_from_paste
+
+        with patch(
+            "app.services.qp_draft_service.claude_structured",
+            new_callable=AsyncMock,
+            return_value={"sales_condition": "New", "not_a_field": "x", "purchasing_packaging": "wrong section"},
+        ):
+            out = await extract_qp_fields_from_paste("text", "sales")
+        assert out == {"sales_condition": "New"}  # only whitelisted sales fields survive
+
+    async def test_extract_empty_text_no_ai_call(self, db_session, test_user):
+        from app.services.qp_draft_service import extract_qp_fields_from_paste
+
+        with patch("app.services.qp_draft_service.claude_structured", new_callable=AsyncMock) as ai:
+            out = await extract_qp_fields_from_paste("   ", "sales")
+        assert out == {}
+        ai.assert_not_called()
+
+
+class TestDraftRoutes:
+    def test_draft_route_prefills_but_writes_nothing(self, client, db_session, test_user):
+        qp, *_ = _make_deal(db_session, test_user, category="capacitors")
+        resp = client.post(f"/v2/qp/{qp.id}/draft/sales", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "capacitors" in resp.text  # commodity prefilled from the deal
+        assert "Nothing is written yet" in resp.text  # amber review banner
+        assert "Accept &amp; save" in resp.text
+        # Suggest-only: the draft POST must NOT persist anything.
+        db_session.expire_all()
+        assert db_session.get(QualityPlan, qp.id).sales_condition is None
+
+    def test_draft_route_locked_section_shows_no_draft(self, client, db_session, test_user):
+        qp, *_ = _make_deal(db_session, test_user, category="capacitors")
+        qp.sales_section_reviewed_at = datetime.now(UTC)
+        db_session.commit()
+        resp = client.post(f"/v2/qp/{qp.id}/draft/sales", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Nothing is written yet" not in resp.text  # locked → read-only, no draft
+
+    def test_draft_from_paste_route(self, client, db_session, test_user):
+        qp, *_ = _make_deal(db_session, test_user, category="capacitors")
+        qp.sales_condition = "Preset"  # so the deal deterministic doesn't fill it; paste will
+        db_session.commit()
+        with patch(
+            "app.services.qp_draft_service.claude_structured",
+            new_callable=AsyncMock,
+            return_value={"sales_testing_specifics": "Burn-in 48h per customer TSO"},
+        ):
+            resp = client.post(
+                f"/v2/qp/{qp.id}/draft/sales",
+                data={"pasted_text": "customer TSO says burn-in 48h"},
+                headers={"HX-Request": "true"},
+            )
+        assert resp.status_code == 200
+        assert "Burn-in 48h per customer TSO" in resp.text
+        assert "AI — verify" in resp.text  # the AI source chip
+
+    def test_discard_route_renders_clean(self, client, db_session, test_user):
+        qp, *_ = _make_deal(db_session, test_user, category="capacitors")
+        resp = client.get(f"/v2/qp/{qp.id}/section/sales", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Nothing is written yet" not in resp.text  # clean render, no draft banner
+
+    def test_draft_unknown_section_404(self, client, db_session, test_user):
+        qp, *_ = _make_deal(db_session, test_user)
+        resp = client.post(f"/v2/qp/{qp.id}/draft/serial", headers={"HX-Request": "true"})
+        assert resp.status_code == 404


### PR DESCRIPTION
## QP draft-from-deal (survey ideas #8 + #19, merged)

Filling a Quality Plan's ~27 free-text fields by hand is slow and repetitive. This drafts the **empty** fields from what AVAIL already holds — **suggest-only**, nothing writes until the human accepts. No migration.

### What it does
Each editable QP section (Sales, Purchasing) gets a **✦ Draft with AI** button (+ an optional pasted-TSO/PO fold). `POST /v2/qp/{id}/draft/{section}` fills only the empty non-boolean fields from three precedence-ordered sources:
- **deal** — deterministic copy from the buy plan's first requirement-bearing line's Requirement + chosen Offer + `MaterialCard.category`
- **ai** — Claude extraction from a pasted customer TSO/PO (fast tier, per-user rate-limited, single attempt, graceful on failure)
- **prior** — carry-forward from the 3 most-recent section-reviewed QPs for the same company + commodity

### Suggest-only write model (no silent writes)
The route re-renders the section with suggestions **prefilled into the inputs** behind an amber banner + per-field source chips. **While a draft is shown the form drops its `hx-patch`/`hx-trigger=change`**, so editing a field can't silently auto-save. The only writer is **Accept & save** (fires the existing section PATCH); **Discard** (`GET /v2/qp/{id}/section/{section}`) restores the clean section. A no-op on an already-reviewed (locked) section. QP has no "approved" status, so "approved" = `section_reviewed_at` set.

### Adversarial review — 1 real issue (reported 3 ways, all MEDIUM), fixed
The carry-forward query used a 1:many `BuyPlanLine` inner join with `LIMIT` applied **before** the Python-side `.unique()` — so a multi-line (split) prior QP could fan out to 3 rows and consume the whole window, starving older prior QPs (suggest-only, so no bad data, but under-delivered the "3 most-recent distinct QPs" contract). Rewritten to match the commodity via an **EXISTS semi-join** (one row per QP). A regression test with a 3-line newer prior QP now locks it. (Other findings were the same root cause or refuted.)

### Tests
16 tests in `tests/test_qp_draft_service.py` — deterministic deal-copy (sales + purchasing), fill-empty-only, carry-forward (match / different-commodity / unreviewed / multi-line-no-starve), paste extraction (fields / drop-unknown / empty-no-call), and routes (prefill-writes-nothing, locked no-op, paste, discard, unknown-section 404). Full suite green; EXISTS query validated on real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
