### PR TITLE
fix(quotes): Copy Table pastes Cost under the "Sell" label

### DIFF
--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -210,7 +210,11 @@
 
     <button @click="
       const rows = document.querySelectorAll('#quote-lines-body tr:not(#empty-lines-row)');
-      let text = 'MPN\tManufacturer\tQty\tCost\tSell\tMargin %\n';
+      {# Header MUST match the first 6 <td>s of line_row.html (MPN, Description,
+         Manufacturer, Qty, Cost, Sell) — the old header omitted Description, so
+         every value after MPN pasted under the WRONG label (Cost under "Sell").
+         Guarded by tests/test_quote_copy_table_header.py. #}
+      let text = 'MPN\tDescription\tManufacturer\tQty\tCost\tSell\n';
       rows.forEach(r => {
         const cells = r.querySelectorAll('td');
         if (cells.length >= 6) {

--- a/tests/test_quote_copy_table_header.py
+++ b/tests/test_quote_copy_table_header.py
@@ -1,0 +1,27 @@
+"""tests/test_quote_copy_table_header.py — Copy Table header matches the real cell
+order.
+
+The Copy Table button copies the first 6 <td>s of each quote line row; its header line
+must label them in the SAME order (MPN, Description, Manufacturer, Qty, Cost, Sell). The
+pre-fix header omitted Description, shifting every label one column left — Cost values
+pasted under "Sell" (a customer-facing cost leak when the paste left the building).
+"""
+
+from pathlib import Path
+
+DETAIL = Path("app/templates/htmx/partials/quotes/detail.html")
+LINE_ROW = Path("app/templates/htmx/partials/quotes/line_row.html")
+
+
+def test_copy_header_matches_line_row_cells():
+    detail = DETAIL.read_text()
+    assert "let text = 'MPN\\tDescription\\tManufacturer\\tQty\\tCost\\tSell\\n';" in detail
+    # The shifted pre-fix header must never come back.
+    assert "'MPN\\tManufacturer\\tQty\\tCost\\tSell\\tMargin %" not in detail
+    # Sanity: line_row's display cells still start MPN → Description → Manufacturer
+    # → Qty → Cost → Sell (cost/sell recognizable by their format calls, in order).
+    line_row = LINE_ROW.read_text()
+    cost_pos = line_row.find("line.cost_price|float")
+    sell_pos = line_row.find("line.sell_price|float")
+    mfr_pos = line_row.find("line.manufacturer")
+    assert -1 < mfr_pos < cost_pos < sell_pos


### PR DESCRIPTION
The Copy Table button's header line said `MPN Manufacturer Qty Cost Sell Margin %` while the copied cells are `MPN Description Manufacturer Qty Cost Sell` — every value after MPN landed under the wrong label, most damagingly **Cost under "Sell"** wherever the paste went. Header now matches the real cell order; a drift-guard test pins header ↔ cell-order agreement.

Phase 0 of the do-all plan (pre-approved bug fix; customer-safe copy variant is a Phase 3 item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)