### PR TITLE
Phase 0 hygiene: webhook limit parity, ratchet floor, mirror perf

### DIFF
--- a/app/routers/v13_features/activity.py
+++ b/app/routers/v13_features/activity.py
@@ -63,7 +63,7 @@ def _validation_echo_response(validation_token: str) -> PlainTextResponse:
 
 
 @router.post("/api/webhooks/graph")
-@limiter.limit("60/minute")
+@limiter.limit("600/minute")
 async def graph_webhook(
     request: Request,
     db: Session = Depends(get_db),

--- a/app/services/excess_mirror.py
+++ b/app/services/excess_mirror.py
@@ -180,12 +180,20 @@ def _find_mirror(db: Session, excess_line_item_id: int) -> Sighting | None:
     )
 
 
-def mirror_line(db: Session, line: ExcessLineItem, *, existing: Sighting | None = None) -> Sighting | None:
+def mirror_line(
+    db: Session,
+    line: ExcessLineItem,
+    *,
+    existing: Sighting | None = None,
+    requirement: Requirement | None = None,
+) -> Sighting | None:
     """Upsert the mirrored Sighting for one ``ExcessLineItem``.
 
     ``existing`` lets a caller that already ran :func:`_find_mirror` (sync_list_mirror's
     revive check) hand over the row instead of paying a second identical lookup; when
-    omitted (or None — no mirror yet) the lookup runs here.
+    omitted (or None — no mirror yet) the lookup runs here. ``requirement`` works the
+    same way for the list's virtual requirement — sync_list_mirror resolves it once
+    for the whole list instead of one query per line.
 
     Builds the row via ``sighting_from_row`` (the dict→ORM single source of truth) then
     sets the excess-specific fields the contract requires:
@@ -217,7 +225,7 @@ def mirror_line(db: Session, line: ExcessLineItem, *, existing: Sighting | None 
             return None
         line.material_card_id = card.id
 
-    requirement = ensure_virtual_requirement(db, excess_list)
+    requirement = requirement or ensure_virtual_requirement(db, excess_list)
     norm_key = normalize_mpn_key(line.part_number)
 
     # Synthesize the market-result dict sighting_from_row consumes. vendor_name is the
@@ -465,7 +473,7 @@ def sync_list_mirror(db: Session, excess_list: ExcessList) -> dict:
     ``skip_ai_estimates=True`` so this never issues a synchronous Claude call inside the
     locked transaction. Returns ``{"mirrored": int, "retired": int}``.
     """
-    ensure_virtual_requirement(db, excess_list)
+    requirement = ensure_virtual_requirement(db, excess_list)
     lines = db.query(ExcessLineItem).filter_by(excess_list_id=excess_list.id).all()
 
     posting_closed = _posting_is_closed(excess_list)
@@ -480,7 +488,7 @@ def sync_list_mirror(db: Session, excess_list: ExcessList) -> dict:
             # not (routine syncs must not fan out rebuilds; see docstring).
             prior = _find_mirror(db, line.id)
             was_live = prior is not None and not prior.is_unavailable
-            if mirror_line(db, line, existing=prior) is not None:
+            if mirror_line(db, line, existing=prior, requirement=requirement) is not None:
                 mirrored += 1
                 if not was_live:
                     revived_card_ids.add(line.material_card_id)

--- a/tests/query_api_baseline.json
+++ b/tests/query_api_baseline.json
@@ -1,4 +1,4 @@
 {
-  "total": 1545,
+  "total": 1473,
   "note": "Legacy SQLAlchemy 1.x Query-API call count under app/. DOWN-only ratchet enforced by tests/test_query_api_ratchet.py. Regenerate with: python -m scripts.query_api_baseline --write (only after intentionally REMOVING sites)."
 }

--- a/tests/test_resell_mirror.py
+++ b/tests/test_resell_mirror.py
@@ -933,3 +933,33 @@ def test_unresolvable_part_skips_mirror(db_session: Session):
 
     assert result is None
     assert _customer_excess_sightings(db_session, company.id) == []
+
+
+# ---------------------------------------------------------------------------
+# Virtual-requirement resolve: once per sync, not once per line
+# ---------------------------------------------------------------------------
+
+
+def test_sync_resolves_virtual_requirement_once_for_whole_list(db_session: Session, monkeypatch):
+    """sync_list_mirror resolves the virtual requirement ONCE and hands it to every
+    mirror_line call — not one lookup per line (the old per-line re-resolve)."""
+    import app.services.excess_mirror as em
+
+    company = _make_company(db_session)
+    owner = _make_user(db_session)
+    el = _make_list_with_lines(db_session, owner, company, ["LM358N", "NE555P", "LM317T"])
+
+    calls = 0
+    real = em.ensure_virtual_requirement
+
+    def counting(db, excess_list):
+        nonlocal calls
+        calls += 1
+        return real(db, excess_list)
+
+    monkeypatch.setattr(em, "ensure_virtual_requirement", counting)
+
+    result = em.sync_list_mirror(db_session, el)
+    db_session.commit()
+    assert result["mirrored"] == 3
+    assert calls == 1


### PR DESCRIPTION
Three pre-approved Phase-0 items from the do-all plan:

1. **Graph webhook rate limit 60→600/min** — parity with the /teams webhook; Graph notification bursts were hitting the old cap.
2. **SQLA Query-API ratchet baseline 1545→1473** — locks in the simplify sweep's ~70 removed `db.query` sites so the ratchet is genuinely down-only again.
3. **`sync_list_mirror` resolves the virtual requirement once per list** instead of once per line inside the loop (same pass-through pattern as the existing `existing=` param); guarded by a call-count test.

Suite slices green: 56 passed (mirror/excess/backfill). Full CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)