### PR TITLE
Hotlist amber chip + server-enforced AI-variant send gate

### DIFF
--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -1017,8 +1017,17 @@ async def proactive_prepared_send(
     token = await get_valid_token(user, db)
     if not token:
         raise HTTPException(400, "No valid Microsoft token — sign in again to send")
+    form = await request.form()
+    confirm_ai_variants = str(form.get("confirm_ai_variants") or "") == "1"
     try:
-        result = await send_draft_offer(db, user, token, po_id, allow_all=is_manager_or_admin(user))
+        result = await send_draft_offer(
+            db,
+            user,
+            token,
+            po_id,
+            allow_all=is_manager_or_admin(user),
+            confirm_ai_variants=confirm_ai_variants,
+        )
     except ValueError as e:
         raise HTTPException(403 if "Not your" in str(e) else 400, str(e)) from e
     recipients = ", ".join(result.get("recipient_emails", []))

--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -199,7 +199,13 @@ async def proactive_prepare_page(
         .all()
     )
 
+    from ...services.proactive_matching import compute_offer_rollups
     from ...services.proactive_service import DEFAULT_PROACTIVE_MARKUP
+
+    # AI-variant flags for the row chips + Task 5's server-side send gate.
+    # ONE batch call for every distinct part (PERF guard pattern —
+    # services/proactive_service.py:105-109).
+    rollups = compute_offer_rollups(db, parts={(m.mpn or "").strip().upper() for m in matches if m.mpn})
 
     match_data = []
     for m in matches:
@@ -218,6 +224,7 @@ async def proactive_prepare_page(
                 "suggested_sell": f"{(unit_price * DEFAULT_PROACTIVE_MARKUP) if unit_price else 0:.4f}",
                 "margin_pct": m.margin_pct,
                 "match_score": m.match_score or 0,
+                "has_ai_variants": (rollups.get((m.mpn or "").strip().upper()) or {}).get("has_ai_variants", False),
             }
         )
 
@@ -240,6 +247,7 @@ async def proactive_prepare_page(
             "company_name": company.name if company else "Customer",
             "site_name": site.site_name if site else "",
             "matches": match_data,
+            "any_ai_variants": any(m["has_ai_variants"] for m in match_data),
             "match_ids_json": json.dumps([m["id"] for m in match_data]),
             "contacts": contact_data,
             "error_msg": "",

--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -500,6 +500,7 @@ async def proactive_send_offer(
     contact_ids = [int(cid) for cid in contact_ids_raw if cid and str(cid).isdigit()]
     subject = form.get("subject", "").strip()
     body = form.get("body", "").strip()
+    confirm_ai_variants = str(form.get("confirm_ai_variants") or "") == "1"
 
     # Parse rep-entered sell prices keyed as sell_price_<match_id>
     sell_prices: dict[str, float] = {}
@@ -546,6 +547,7 @@ async def proactive_send_offer(
             subject=subject or None,
             email_html=email_html,
             allow_all=is_manager_or_admin(user),
+            confirm_ai_variants=confirm_ai_variants,
         )
 
         # Honest outcome (QC 2026-08-13): send_proactive_offer swallows a Graph

--- a/app/services/proactive_matching.py
+++ b/app/services/proactive_matching.py
@@ -685,6 +685,11 @@ def _find_hotlist_matches(
     same suppression + dedup + surface pipeline. Salesperson falls back to the
     hotlist requisition's owner when the company has no account owner.
 
+    The match's display identity is the CUSTOMER requirement's spelling
+    (2026-08-24 amber-chip fix) — the same rule as the requirement and
+    part-hotlist passes — so the read-time rollup pools the offer's variant
+    spellings under it and flags AI variants.
+
     ``skip_company_ids`` carries the company_ids the requirement pass already
     produced in THIS call (their ``db.add()``s are uncommitted, so a fresh DB
     query won't see them) — union them into the existing-match set so dedup
@@ -702,7 +707,7 @@ def _find_hotlist_matches(
         class_keys, class_spellings = class_keys_and_spellings(db, part)
 
     rows = (
-        db.query(Requisition, CustomerSite, Company)
+        db.query(Requisition, CustomerSite, Company, Requirement)
         .join(Requirement, Requirement.requisition_id == Requisition.id)
         .join(CustomerSite, CustomerSite.id == Requisition.customer_site_id)
         .join(Company, Company.id == func.coalesce(Requisition.company_id, CustomerSite.company_id))
@@ -711,6 +716,10 @@ def _find_hotlist_matches(
             Requirement.normalized_mpn.in_(class_keys),
             CustomerSite.is_active.is_(True),
         )
+        # Deterministic display identity: every row's requirement matched the
+        # offer's class (the filter above); the lowest-id one wins via the
+        # first-row-per-company dedup below.
+        .order_by(Requirement.id.asc())
         .all()
     )
     if not rows:
@@ -723,10 +732,10 @@ def _find_hotlist_matches(
     )
     existing |= skip_company_ids or set()
 
-    dno = build_batch_dno_set_multi(db, class_spellings, {c.id for _, _, c in rows})
+    dno = build_batch_dno_set_multi(db, class_spellings, {c.id for _, _, c, _ in rows})
 
     out: list[ProactiveMatch] = []
-    for req, site, company in rows:
+    for req, site, company, requirement in rows:
         salesperson_id = company.account_owner_id or req.created_by
         if not salesperson_id:
             continue
@@ -738,7 +747,10 @@ def _find_hotlist_matches(
             requisition_id=req.id,
             customer_site_id=site.id,
             salesperson_id=salesperson_id,
-            mpn=part,
+            # Display identity = the customer's own spelling (mirrors the
+            # requirement pass at line 632); equivalence classes make the offer's
+            # variants reachable from it, which is what lights the amber chip.
+            mpn=part_key(requirement.primary_mpn) or part,
             material_card_id=source_offer.material_card_id if source_offer else None,
             company_id=company.id,
             match_score=60,  # baseline — explicit monitor request, no ask history to weight

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -342,11 +342,13 @@ def _upsert_throttles(db: Session, matches: list, site_id: int, po_id: int, now:
             throttle_by_mpn[m.mpn] = new_throttle
 
 
-def _build_line_items(matches: list, sell_prices: dict) -> tuple[list, Decimal, Decimal]:
+def _build_line_items(matches: list, sell_prices: dict, rollups: dict | None = None) -> tuple[list, Decimal, Decimal]:
     """Line items + totals for a customer offer email.
 
     Shared by the prepare-page send and the Process draft builder. Missing sell prices
-    default to cost x 1.3.
+    default to cost x 1.3. ``rollups`` (compute_offer_rollups output keyed by uppercased
+    part) stamps a per-line ``ai_variant`` display hint; send paths re-derive the flag
+    at send time, so a missing/None rollups only affects display, never the gate.
     """
     line_items = []
     total_sell = Decimal("0")
@@ -384,6 +386,9 @@ def _build_line_items(matches: list, sell_prices: dict) -> tuple[list, Decimal, 
                 "sell_price": float(sell),
                 "condition": offer.condition,
                 "lead_time": offer.lead_time,
+                "ai_variant": bool(
+                    ((rollups or {}).get((m.mpn or "").strip().upper()) or {}).get("has_ai_variants", False)
+                ),
             }
         )
     return line_items, total_sell, total_cost
@@ -505,8 +510,11 @@ async def send_proactive_offer(
     if not recipient_emails:
         raise ValueError("Selected contacts have no email addresses")
 
-    # Build line items
-    line_items, total_sell, total_cost = _build_line_items(matches, sell_prices)
+    # Build line items (rollups also feed the AI-variant send gate — Task 5)
+    from .proactive_matching import compute_offer_rollups
+
+    rollups = compute_offer_rollups(db, parts={(m.mpn or "").strip().upper() for m in matches if m.mpn})
+    line_items, total_sell, total_cost = _build_line_items(matches, sell_prices, rollups)
 
     # Build email HTML — signed by the relationship owner (the matches' rep),
     # even when a manager is the one clicking send.
@@ -655,6 +663,12 @@ def build_draft_offers(db: Session, user: User, match_ids: list[int], *, allow_a
         else:
             skipped_backorder += 1  # no customer account — nowhere to email
 
+    from .proactive_matching import compute_offer_rollups
+
+    # ONE batch rollup call for every staged part (PERF guard — see
+    # get_matches_for_user lines 105-109); stamps the per-line ai_variant hint.
+    rollups = compute_offer_rollups(db, parts={(m.mpn or "").strip().upper() for m in matches if m.mpn})
+
     drafts_created = 0
     needs_contact = 0
     for site_id, site_matches in by_site.items():
@@ -678,7 +692,7 @@ def build_draft_offers(db: Session, user: User, match_ids: list[int], *, allow_a
             if anchor and anchor["price"]:
                 sell_prices[str(m.id)] = float(anchor["price"])
 
-        line_items, total_sell, total_cost = _build_line_items(site_matches, sell_prices)
+        line_items, total_sell, total_cost = _build_line_items(site_matches, sell_prices, rollups)
         if not line_items:
             continue
 
@@ -744,6 +758,7 @@ def list_draft_offers(db: Session, user: User, *, allow_all: bool = False) -> li
                 "line_count": len(po.line_items or []),
                 "match_ids": [li.get("match_id") for li in (po.line_items or []) if li.get("match_id")],
                 "total_sell": float(po.total_sell) if po.total_sell else 0.0,
+                "has_ai_variants": any(li.get("ai_variant") for li in (po.line_items or [])),
             }
         )
     return out

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -290,6 +290,9 @@ def get_top_picks(db: Session, user_id: int, *, limit: int = 10) -> list[dict]:
                 "score": m.match_score or 0,
                 "available_qty": rollup["available_qty"],
                 "low_cost": rollup["low_cost"],
+                # Equivalence-pooled AI hint (2026-08-24): parity with the
+                # Matches-tab rows this strip sits above.
+                "has_ai_variants": rollup.get("has_ai_variants", False),
                 "requirement_count": m.requirement_count or 0,
                 "last_asked_display": (
                     f"{m.last_asked_at.month}/{m.last_asked_at.day}/{m.last_asked_at.year}" if m.last_asked_at else ""

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -467,12 +467,17 @@ async def send_proactive_offer(
     notes: str | None = None,
     email_html: str | None = None,
     allow_all: bool = False,
+    confirm_ai_variants: bool = False,
 ) -> dict:
     """Send a proactive offer email to a customer.
 
     ``allow_all`` lets a manager/admin send on a rep's matches; the offer is
     always attributed to the matches' salesperson, the mail goes out from the
     ACTOR's mailbox. Returns the created ProactiveOffer dict.
+
+    Raises ValueError when the live rollup pools AI-matched variant spellings
+    for any selected match and ``confirm_ai_variants`` was not passed — the
+    same server-enforced confirm as the prepared-send path.
     """
     # Load and validate matches
     query = db.query(ProactiveMatch).filter(ProactiveMatch.id.in_(match_ids))
@@ -514,6 +519,12 @@ async def send_proactive_offer(
     from .proactive_matching import compute_offer_rollups
 
     rollups = compute_offer_rollups(db, parts={(m.mpn or "").strip().upper() for m in matches if m.mpn})
+
+    # AI-variant send gate (2026-08-24): same rule as send_draft_offer, enforced
+    # before the ProactiveOffer row is created so a refusal leaves no residue.
+    if any(r["has_ai_variants"] for r in rollups.values()) and not confirm_ai_variants:
+        raise ValueError("This offer includes AI-matched variant part numbers — verify before sending")
+
     line_items, total_sell, total_cost = _build_line_items(matches, sell_prices, rollups)
 
     # Build email HTML — signed by the relationship owner (the matches' rep),

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -764,12 +764,22 @@ def list_draft_offers(db: Session, user: User, *, allow_all: bool = False) -> li
     return out
 
 
-async def send_draft_offer(db: Session, user: User, token: str, po_id: int, *, allow_all: bool = False) -> dict:
+async def send_draft_offer(
+    db: Session,
+    user: User,
+    token: str,
+    po_id: int,
+    *,
+    allow_all: bool = False,
+    confirm_ai_variants: bool = False,
+) -> dict:
     """Send one staged draft to its customer with the ACTOR's mailbox.
 
     Marks the offer SENT, flips its matches to SENT, and writes the same throttle
     entries as the prepare-page send. Raises ValueError on wrong status / no recipients
-    / no permission.
+    / no permission / an AI-variant offer sent without the explicit confirm (the flag is
+    re-derived from the live rollup at send time — the staged per-line stamps are
+    display hints only, and legacy drafts without them re-derive, never assume clean).
     """
     from ..utils.graph_client import GraphAPIError, GraphClient, build_sendmail_payload
 
@@ -781,6 +791,18 @@ async def send_draft_offer(db: Session, user: User, token: str, po_id: int, *, a
     recipient_emails = po.recipient_emails or []
     if not recipient_emails:
         raise ValueError("No contact on file — open Prepare to pick or add one")
+
+    # AI-variant send gate (2026-08-24): re-derive at send time — authoritative
+    # over the staged ai_variant stamps. Runs BEFORE the DRAFT→SENT claim so a
+    # blocked send never strands a draft in SENT.
+    from .proactive_matching import compute_offer_rollups
+
+    line_parts = {
+        (li.get("mpn") or "").strip().upper() for li in (po.line_items or []) if (li.get("mpn") or "").strip()
+    }
+    rollups = compute_offer_rollups(db, parts=line_parts)
+    if any(r["has_ai_variants"] for r in rollups.values()) and not confirm_ai_variants:
+        raise ValueError("This offer includes AI-matched variant part numbers — verify before sending")
 
     # Atomic claim (QC 2026-08-14): flip DRAFT→SENT in ONE conditional UPDATE BEFORE the
     # Graph send. A concurrent send_draft_offer — or the digest-draft "supersede" sweep —

--- a/app/templates/htmx/partials/proactive/_prepared_offers.html
+++ b/app/templates/htmx/partials/proactive/_prepared_offers.html
@@ -20,7 +20,14 @@
         </svg>
       </button>
       <div class="flex-1 min-w-0">
-        <p class="text-sm font-medium text-gray-900 truncate">{{ p.company_name }}</p>
+        <p class="text-sm font-medium text-gray-900 truncate">{{ p.company_name }}
+          {% if p.has_ai_variants %}
+          <span class="badge-mini bg-amber-100 text-amber-800 border border-amber-300 ml-1"
+                title="This offer includes AI-matched variant part numbers — verify before sending">
+            AI match — verify
+          </span>
+          {% endif %}
+        </p>
         <p class="text-xs text-gray-500 truncate">
           {{ p.line_count }} part{{ 's' if p.line_count != 1 }} · ${{ p.total_sell|money }}
           {% if scope == 'all' %} · {{ p.salesperson_name }}{% endif %}
@@ -42,14 +49,22 @@
               class="btn-secondary btn-sm">
         Discard
       </button>
-      <button hx-post="/v2/partials/proactive/prepared/{{ p.id }}/send"
-              hx-target="#main-content"
-              hx-confirm="Email this offer to {{ p.company_name | e }} ({{ p.recipient_emails | join(', ') | e }})?"
-              data-loading-disable
-              {% if not p.recipient_emails %}disabled title="No contact on file — open Prepare to pick or add one"{% endif %}
-              class="btn-primary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
-        Send
-      </button>
+      <form hx-post="/v2/partials/proactive/prepared/{{ p.id }}/send"
+            hx-target="#main-content"
+            {% if p.has_ai_variants %}
+            hx-confirm="This offer includes AI-matched variant part numbers — verify before sending. Email {{ p.company_name | e }} ({{ p.recipient_emails | join(', ') | e }})?"
+            {% else %}
+            hx-confirm="Email this offer to {{ p.company_name | e }} ({{ p.recipient_emails | join(', ') | e }})?"
+            {% endif %}
+            class="inline">
+        {% if p.has_ai_variants %}<input type="hidden" name="confirm_ai_variants" value="1">{% endif %}
+        <button type="submit"
+                data-loading-disable
+                {% if not p.recipient_emails %}disabled title="No contact on file — open Prepare to pick or add one"{% endif %}
+                class="btn-primary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
+          Send
+        </button>
+      </form>
     </div>
     <div x-show="open" x-cloak class="border-t border-line-base px-4 py-3 text-sm bg-gray-50">
       <p class="text-xs text-gray-500 mb-2">Subject: {{ p.subject }}</p>

--- a/app/templates/htmx/partials/proactive/prepare.html
+++ b/app/templates/htmx/partials/proactive/prepare.html
@@ -71,6 +71,12 @@
               {% if m.manufacturer %}
               <span class="text-secondary ml-1">{{ m.manufacturer }}</span>
               {% endif %}
+              {% if m.has_ai_variants %}
+              <span class="badge-mini bg-amber-100 text-amber-800 border border-amber-300 ml-1"
+                    title="Availability includes AI-matched variant part numbers — expand the offers to verify">
+                AI match — verify
+              </span>
+              {% endif %}
             </td>
             <td class="text-sm text-gray-700">{{ m.vendor_name }}</td>
             <td class="text-sm text-gray-700 text-right tabular-nums">
@@ -170,6 +176,12 @@
       {% for m in matches %}
       <input type="hidden" name="match_ids" value="{{ m.id }}">
       {% endfor %}
+      {% if any_ai_variants %}
+      {# Server gate parity (2026-08-24): /v2/proactive/send re-derives the
+         AI-variant flag and refuses without this confirm — the flagged rows
+         above carry the amber chip the rep is confirming past. #}
+      <input type="hidden" name="confirm_ai_variants" value="1">
+      {% endif %}
       {# Hidden contact_ids (populated by Alpine) #}
       <template x-for="id in contactIds" :key="id">
         <input type="hidden" name="contact_ids" :value="id">

--- a/tests/test_proactive_hotlist.py
+++ b/tests/test_proactive_hotlist.py
@@ -17,13 +17,16 @@ from app.models import (
     CustomerSite,
     MaterialCard,
     Offer,
+    PartEquivalence,
     ProactiveMatch,
     Requirement,
     Requisition,
     User,
 )
 from app.models.purchase_history import CustomerPartHistory
+from app.services.part_equivalence import norm_key
 from app.services.proactive_matching import find_matches_for_offer
+from app.services.proactive_service import get_matches_for_user
 from tests.conftest import engine  # noqa: F401
 
 
@@ -157,3 +160,44 @@ def test_hotlist_and_cph_dedup_one_match(db_session):
     assert len([m for m in matches if m.company_id == co.id]) == 1
     # The hotlist pass owns the slot — purchase history is context, not a seed.
     assert rows[0].match_source == "hotlist"
+
+
+def test_ai_variant_hotlist_match_displays_customer_spelling_with_amber_flag(db_session):
+    """An AI-verdict variant offer against a hotlisted ask stores the CUSTOMER spelling,
+    so the Matches-tab rollup pools the variant supply under it and sets has_ai_variants
+    — the amber 'AI match — verify' chip's data source."""
+    db = db_session
+    d = _setup(db, mpn="GSOT36C")  # hotlist ask under the customer spelling
+    ka, kb = sorted([norm_key("GSOT36C"), norm_key("GSOT36C-E3-08")])
+    db.add(
+        PartEquivalence(
+            key_a=ka,
+            key_b=kb,
+            example_a="GSOT36C",
+            example_b="GSOT36C-E3-08",
+            verdict="same",
+            source="ai",
+            reason="pkg suffix",
+        )
+    )
+    variant_offer = Offer(
+        vendor_name="Sierra",
+        mpn="GSOT36C-E3-08",
+        qty_available=177_630,
+        unit_price=Decimal("0.05"),
+        status="active",
+    )
+    db.add(variant_offer)
+    db.commit()
+
+    matches = find_matches_for_offer(variant_offer.id, db)
+    db.commit()
+    hot = [m for m in matches if m.company_id == d["company"].id]
+    assert len(hot) == 1
+    assert hot[0].mpn == "GSOT36C"  # customer's own spelling wins the display
+
+    result = get_matches_for_user(db, d["owner"].id)
+    rows = [m for g in result["groups"] for m in g["matches"]]
+    row = next(r for r in rows if r["mpn"] == "GSOT36C")
+    assert row["has_ai_variants"] is True
+    assert "GSOT36C-E3-08" in row["variants"]

--- a/tests/test_proactive_matching.py
+++ b/tests/test_proactive_matching.py
@@ -13,11 +13,12 @@ from unittest.mock import patch
 
 import pytest
 
-from app.constants import ProactiveMatchSource, ProactiveMatchStatus
+from app.constants import ProactiveMatchSource, ProactiveMatchStatus, RequisitionStatus
 from app.models import (
     Company,
     CustomerSite,
     Offer,
+    PartEquivalence,
     ProactiveMatch,
     Requirement,
     Requisition,
@@ -25,6 +26,7 @@ from app.models import (
 )
 from app.models.intelligence import ProactiveDoNotOffer, ProactiveThrottle
 from app.models.purchase_history import CustomerPartHistory
+from app.services.part_equivalence import norm_key
 from app.services.proactive_matching import (
     _score_ask_recency,
     _score_margin,
@@ -635,3 +637,108 @@ def test_expire_old_matches(db_session):
     assert expire_old_matches(db_session) == 1
     db_session.refresh(m)
     assert m.status == ProactiveMatchStatus.EXPIRED
+
+
+# ── Requisition-hotlist display identity (2026-08-24 amber-chip fix) ─────
+
+
+def _eq(db, a, b, verdict, *, source="ai", reason="pkg suffix"):
+    """Store an equivalence verdict — copied from
+    tests/test_part_equivalence.py:44-47."""
+    ka, kb = sorted([norm_key(a), norm_key(b)])
+    db.add(PartEquivalence(key_a=ka, key_b=kb, example_a=a, example_b=b, verdict=verdict, source=source, reason=reason))
+    db.commit()
+
+
+def _setup_hotlist_ask(db, *, customer_mpn, owner_email="hot@trioscs.com", company_name="Hotlist Co"):
+    """Owner + company + active site + HOTLIST requisition asking for customer_mpn.
+
+    Requirement.normalized_mpn auto-derives from primary_mpn (model validator), so the
+    hotlist pass's class-key join finds it without explicit normalization.
+    """
+    owner = User(email=owner_email, name="Hotlist Owner", role="sales", azure_id=f"az-{owner_email}")
+    db.add(owner)
+    db.flush()
+    company = Company(name=company_name, is_active=True, account_owner_id=owner.id)
+    db.add(company)
+    db.flush()
+    site = CustomerSite(company_id=company.id, site_name=f"{company_name} HQ", is_active=True)
+    db.add(site)
+    db.flush()
+    req = Requisition(
+        name=f"watch-{customer_mpn}",
+        status=RequisitionStatus.HOTLIST.value,
+        customer_site_id=site.id,
+        company_id=company.id,
+        created_by=owner.id,
+    )
+    db.add(req)
+    db.flush()
+    requirement = Requirement(requisition_id=req.id, primary_mpn=customer_mpn)
+    db.add(requirement)
+    db.commit()
+    return {"owner": owner, "company": company, "site": site, "req": req, "requirement": requirement}
+
+
+def test_requisition_hotlist_ai_match_stores_customer_spelling(db_session):
+    """An AI-verdict variant offer against a hotlist ask stores the CUSTOMER spelling
+    (the pattern _find_requirement_matches line 632 / _find_part_hotlist_matches line
+    901 already use) — keying the read-time rollup so the amber chip can light."""
+    _eq(db_session, "GSOT36C", "GSOT36C-E3-08", "same")
+    s = _setup_hotlist_ask(db_session, customer_mpn="GSOT36C")
+    offer = _make_offer(db_session, mpn="GSOT36C-E3-08", qty_available=177_630, unit_price=Decimal("0.05"))
+
+    matches = find_matches_for_offer(offer.id, db_session)
+    db_session.commit()
+
+    hot = [m for m in matches if m.company_id == s["company"].id]
+    assert len(hot) == 1
+    assert hot[0].match_source == ProactiveMatchSource.HOTLIST
+    assert hot[0].mpn == "GSOT36C"  # customer's own spelling wins the display
+    assert hot[0].requisition_id == s["req"].id
+
+
+def test_requisition_hotlist_pick_is_deterministic_lowest_requirement_id(db_session):
+    """Two requirements on one hotlist requisition both match the offer's class — the
+    lowest-id one supplies the display spelling, deterministically."""
+    _eq(db_session, "GSOT36C", "GSOT36C-E3-08", "same")
+    s = _setup_hotlist_ask(db_session, customer_mpn="GSOT36C")
+    db_session.add(Requirement(requisition_id=s["req"].id, primary_mpn="GSOT36C-E3-08"))
+    db_session.commit()
+    offer = _make_offer(db_session, mpn="GSOT36C-E3-08", qty_available=100, unit_price=Decimal("0.05"))
+
+    matches = find_matches_for_offer(offer.id, db_session)
+    db_session.commit()
+
+    hot = [m for m in matches if m.company_id == s["company"].id]
+    assert len(hot) == 1
+    assert hot[0].mpn == "GSOT36C"  # lowest-id class-matching requirement wins
+
+
+def test_requisition_hotlist_existing_offer_spelling_match_still_dedupes(db_session):
+    """Regression: pre-fix historical rows stored the OFFER spelling. class_spellings
+    covers every observed spelling of the class, so such a row still holds the
+    one-active-match-per-(part, company) slot after the write-time change."""
+    _eq(db_session, "GSOT36C", "GSOT36C-E3-08", "same")
+    s = _setup_hotlist_ask(db_session, customer_mpn="GSOT36C")
+    offer = _make_offer(db_session, mpn="GSOT36C-E3-08", qty_available=100, unit_price=Decimal("0.05"))
+    db_session.add(
+        ProactiveMatch(
+            offer_id=offer.id,
+            requisition_id=s["req"].id,
+            customer_site_id=s["site"].id,
+            salesperson_id=s["owner"].id,
+            mpn="GSOT36C-E3-08",  # pre-fix: the offer's spelling
+            company_id=s["company"].id,
+            status=ProactiveMatchStatus.NEW,
+            match_score=60,
+            match_source=ProactiveMatchSource.HOTLIST,
+        )
+    )
+    db_session.commit()
+
+    matches = find_matches_for_offer(offer.id, db_session)
+    db_session.commit()
+
+    assert [m for m in matches if m.company_id == s["company"].id] == []
+    assert db_session.query(ProactiveMatch).filter(ProactiveMatch.company_id == s["company"].id).count() == 1

--- a/tests/test_proactive_prepare.py
+++ b/tests/test_proactive_prepare.py
@@ -855,3 +855,57 @@ def test_afterswap_reinits_alpine_on_proactive_contact_list():
     assert "rfq-affinity-section" in allowlist
     assert "settings-content" in allowlist
     assert "lead-drawer-content" in allowlist
+
+
+def _flag_lm358n_class_as_ai(db):
+    """Verdict 'same' against a variant spelling + live supply under it — LM358N's
+    rollup then pools the variant and reports has_ai_variants."""
+    from app.models import PartEquivalence
+    from app.services.part_equivalence import norm_key
+
+    ka, kb = sorted([norm_key("LM358N"), norm_key("LM358N-E3")])
+    db.add(
+        PartEquivalence(
+            key_a=ka,
+            key_b=kb,
+            example_a="LM358N",
+            example_b="LM358N-E3",
+            verdict="same",
+            source="ai",
+            reason="pkg suffix",
+        )
+    )
+    db.add(Offer(vendor_name="Sierra", mpn="LM358N-E3", qty_available=100, unit_price=Decimal("0.40"), status="active"))
+    db.commit()
+
+
+def test_prepare_page_flags_ai_variant_rows(db_session):
+    """Flagged rows carry the amber chip; the send form carries the hidden confirm."""
+    data = _setup_send_scenario(db_session)
+    _flag_lm358n_class_as_ai(db_session)
+    client, app = _add_contact_client(db_session, data["owner"])
+    try:
+        resp = client.post(
+            "/v2/proactive/prepare/{}".format(data["site"].id),
+            data={"match_ids": str(data["match"].id)},
+        )
+    finally:
+        _cleanup_overrides(app)
+    assert resp.status_code == 200, resp.text
+    assert "AI match" in resp.text  # the amber chip on the flagged row
+    assert 'name="confirm_ai_variants"' in resp.text  # posted to the send gate
+
+
+def test_prepare_page_clean_rows_have_no_ai_chip_or_confirm(db_session):
+    data = _setup_send_scenario(db_session)
+    client, app = _add_contact_client(db_session, data["owner"])
+    try:
+        resp = client.post(
+            "/v2/proactive/prepare/{}".format(data["site"].id),
+            data={"match_ids": str(data["match"].id)},
+        )
+    finally:
+        _cleanup_overrides(app)
+    assert resp.status_code == 200, resp.text
+    assert "AI match" not in resp.text
+    assert 'name="confirm_ai_variants"' not in resp.text

--- a/tests/test_proactive_prepare.py
+++ b/tests/test_proactive_prepare.py
@@ -526,7 +526,17 @@ def test_send_form_path_includes_sell_price(db_session):
     captured: dict = {}
 
     async def _fake_send(
-        *, db, user, token, match_ids, contact_ids, sell_prices, subject=None, email_html=None, allow_all=False
+        *,
+        db,
+        user,
+        token,
+        match_ids,
+        contact_ids,
+        sell_prices,
+        subject=None,
+        email_html=None,
+        allow_all=False,
+        confirm_ai_variants=False,
     ):
         captured["sell_prices"] = sell_prices
         # Return minimal result the route needs to render success
@@ -909,3 +919,75 @@ def test_prepare_page_clean_rows_have_no_ai_chip_or_confirm(db_session):
     assert resp.status_code == 200, resp.text
     assert "AI match" not in resp.text
     assert 'name="confirm_ai_variants"' not in resp.text
+
+
+@pytest.mark.anyio
+async def test_oneshot_send_blocks_ai_variants_without_confirm(db_session, mock_graph_client):
+    """The gate fires before the ProactiveOffer row exists — nothing to clean up."""
+    from app.services.proactive_service import send_proactive_offer
+
+    data = _setup_send_scenario(db_session)
+    _flag_lm358n_class_as_ai(db_session)
+
+    with pytest.raises(ValueError, match="AI-matched variant"):
+        await send_proactive_offer(
+            db=db_session,
+            user=data["owner"],
+            token="tok",
+            match_ids=[data["match"].id],
+            contact_ids=[data["contact1"].id],
+            sell_prices={},
+        )
+    mock_graph_client.post_json.assert_not_called()
+    db_session.rollback()
+    assert db_session.query(ProactiveOffer).count() == 0
+
+
+@pytest.mark.anyio
+async def test_oneshot_send_with_confirm_sends_and_stamps_lines(db_session, mock_graph_client):
+    from app.constants import ProactiveOfferStatus
+    from app.services.proactive_service import send_proactive_offer
+
+    data = _setup_send_scenario(db_session)
+    _flag_lm358n_class_as_ai(db_session)
+
+    result = await send_proactive_offer(
+        db=db_session,
+        user=data["owner"],
+        token="tok",
+        match_ids=[data["match"].id],
+        contact_ids=[data["contact1"].id],
+        sell_prices={},
+        confirm_ai_variants=True,
+    )
+    mock_graph_client.post_json.assert_called_once()
+    assert result["status"] == ProactiveOfferStatus.SENT
+    po = db_session.query(ProactiveOffer).one()
+    assert po.line_items[0]["ai_variant"] is True  # one-shot lines carry the stamp too
+
+
+def test_oneshot_send_route_threads_confirm(db_session):
+    from unittest.mock import AsyncMock, patch
+
+    data = _setup_send_scenario(db_session)
+    _flag_lm358n_class_as_ai(db_session)
+    client, app = _add_contact_client(db_session, data["owner"])
+    form = {
+        "match_ids": str(data["match"].id),
+        "contact_ids": str(data["contact1"].id),
+        "subject": "",
+        "body": "",
+    }
+    try:
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock),
+        ):
+            r = client.post("/v2/proactive/send", data=form)
+            assert r.status_code == 400
+            assert "AI-matched" in r.text
+            r = client.post("/v2/proactive/send", data={**form, "confirm_ai_variants": "1"})
+            assert r.status_code == 200, r.text
+            assert "Offer sent to" in r.text
+    finally:
+        _cleanup_overrides(app)

--- a/tests/test_proactive_process.py
+++ b/tests/test_proactive_process.py
@@ -496,3 +496,51 @@ def test_top_picks_carry_ai_variant_flag(db_session):
     by_mpn = {p["mpn"]: p for p in picks}
     assert by_mpn["GSOT36C"]["has_ai_variants"] is True
     assert by_mpn["LTSR15-NP"]["has_ai_variants"] is False
+
+
+def test_build_draft_offers_stamps_ai_variant_flags(db_session):
+    s = _scenario(db_session)
+    ai = _mk_ai_match(
+        db_session,
+        customer_mpn="GSOT36C",
+        variant_mpn="GSOT36C-E3-08",
+        owner=s["rep"],
+        company=s["beckhoff"],
+        site=s["beckhoff_site"],
+    )
+    build_draft_offers(db_session, s["rep"], [s["m1"].id, ai.id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+    flags = {li["mpn"]: li["ai_variant"] for li in draft.line_items}
+    assert flags["GSOT36C"] is True
+    assert flags["LTSR15-NP"] is False
+
+
+def test_list_draft_offers_exposes_has_ai_variants(db_session):
+    s = _scenario(db_session)
+    ai = _mk_ai_match(
+        db_session,
+        customer_mpn="GSOT36C",
+        variant_mpn="GSOT36C-E3-08",
+        owner=s["rep"],
+        company=s["beckhoff"],
+        site=s["beckhoff_site"],
+    )
+    build_draft_offers(db_session, s["rep"], [ai.id, s["m3"].id])
+    db_session.commit()
+    by_company = {d["company_name"]: d for d in list_draft_offers(db_session, s["rep"])}
+    assert by_company["Beckhoff"]["has_ai_variants"] is True
+    assert by_company["Siemens"]["has_ai_variants"] is False
+
+
+def test_list_draft_offers_legacy_lines_without_key_read_false(db_session):
+    """Drafts staged before this change have no 'ai_variant' key — the list flag
+    defaults False (the send gate re-derives authoritatively either way)."""
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+    draft.line_items = [{k: v for k, v in li.items() if k != "ai_variant"} for li in draft.line_items]
+    db_session.commit()
+    drafts = list_draft_offers(db_session, s["rep"])
+    assert drafts[0]["has_ai_variants"] is False

--- a/tests/test_proactive_process.py
+++ b/tests/test_proactive_process.py
@@ -96,6 +96,48 @@ def _mk_match(db, *, mpn, owner, company, site, price="8.00", qty=500, target=30
     return m
 
 
+def _mk_ai_match(db, *, customer_mpn, variant_mpn, owner, company, site, price="0.05", qty=1000, target=300):
+    """Match displayed under the CUSTOMER spelling whose live supply sits under an AI-
+    verdict variant spelling — compute_offer_rollups flags it has_ai_variants."""
+    from app.models import PartEquivalence, Requirement
+    from app.services.part_equivalence import norm_key
+
+    ka, kb = sorted([norm_key(customer_mpn), norm_key(variant_mpn)])
+    db.add(
+        PartEquivalence(
+            key_a=ka,
+            key_b=kb,
+            example_a=customer_mpn,
+            example_b=variant_mpn,
+            verdict="same",
+            source="ai",
+            reason="pkg suffix",
+        )
+    )
+    offer = Offer(vendor_name="Arrow", mpn=variant_mpn, qty_available=qty, unit_price=Decimal(price), status="active")
+    db.add(offer)
+    db.flush()
+    req = Requisition(name=f"req-{customer_mpn}", customer_site_id=site.id, status="open", created_by=owner.id)
+    db.add(req)
+    db.flush()
+    requirement = Requirement(requisition_id=req.id, primary_mpn=customer_mpn, target_qty=target)
+    db.add(requirement)
+    db.flush()
+    m = ProactiveMatch(
+        offer_id=offer.id,
+        requirement_id=requirement.id,
+        salesperson_id=owner.id,
+        mpn=customer_mpn,
+        company_id=company.id,
+        customer_site_id=site.id,
+        status="new",
+        match_score=70,
+    )
+    db.add(m)
+    db.commit()
+    return m
+
+
 def _scenario(db):
     rep = _mk_user(db, "Sales Rep", "rep@trio.com")
     other = _mk_user(db, "Other Rep", "other@trio.com")
@@ -433,3 +475,24 @@ def test_proactive_offer_claim_is_exclusive(pg_session, pg_engine):
 
     assert first == 1  # this caller won the claim and sends
     assert second == 0  # the racer finds no DRAFT row and must not send
+
+
+# ── AI-variant flag surfaces (2026-08-24) ────────────────────────────────
+
+
+def test_top_picks_carry_ai_variant_flag(db_session):
+    from app.services.proactive_service import get_top_picks
+
+    s = _scenario(db_session)
+    _mk_ai_match(
+        db_session,
+        customer_mpn="GSOT36C",
+        variant_mpn="GSOT36C-E3-08",
+        owner=s["rep"],
+        company=s["beckhoff"],
+        site=s["beckhoff_site"],
+    )
+    picks = get_top_picks(db_session, s["rep"].id)
+    by_mpn = {p["mpn"]: p for p in picks}
+    assert by_mpn["GSOT36C"]["has_ai_variants"] is True
+    assert by_mpn["LTSR15-NP"]["has_ai_variants"] is False

--- a/tests/test_proactive_process.py
+++ b/tests/test_proactive_process.py
@@ -544,3 +544,132 @@ def test_list_draft_offers_legacy_lines_without_key_read_false(db_session):
     db_session.commit()
     drafts = list_draft_offers(db_session, s["rep"])
     assert drafts[0]["has_ai_variants"] is False
+
+
+@pytest.mark.anyio
+async def test_send_draft_blocks_ai_variants_without_confirm(db_session):
+    """The gate fires BEFORE the DRAFT→SENT claim: no Graph call, draft stays DRAFT
+    (never stranded in SENT), matches stay NEW, no throttles."""
+    s = _scenario(db_session)
+    ai = _mk_ai_match(
+        db_session,
+        customer_mpn="GSOT36C",
+        variant_mpn="GSOT36C-E3-08",
+        owner=s["rep"],
+        company=s["beckhoff"],
+        site=s["beckhoff_site"],
+    )
+    build_draft_offers(db_session, s["rep"], [ai.id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+
+    with patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock) as mock_send:
+        with pytest.raises(ValueError, match="AI-matched variant"):
+            await send_draft_offer(db_session, s["rep"], "tok", draft.id)
+
+    mock_send.assert_not_called()
+    db_session.rollback()
+    db_session.refresh(draft)
+    assert draft.status == ProactiveOfferStatus.DRAFT
+    db_session.refresh(ai)
+    assert ai.status == ProactiveMatchStatus.NEW
+    assert db_session.query(ProactiveThrottle).count() == 0
+
+
+@pytest.mark.anyio
+async def test_send_draft_with_confirm_sends_ai_variant_offer(db_session):
+    s = _scenario(db_session)
+    ai = _mk_ai_match(
+        db_session,
+        customer_mpn="GSOT36C",
+        variant_mpn="GSOT36C-E3-08",
+        owner=s["rep"],
+        company=s["beckhoff"],
+        site=s["beckhoff_site"],
+    )
+    build_draft_offers(db_session, s["rep"], [ai.id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+
+    with patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock) as mock_send:
+        result = await send_draft_offer(db_session, s["rep"], "tok", draft.id, confirm_ai_variants=True)
+
+    mock_send.assert_called_once()
+    assert result["status"] == ProactiveOfferStatus.SENT
+
+
+@pytest.mark.anyio
+async def test_send_draft_legacy_lines_clean_rederive_sends(db_session):
+    """A pre-change draft (no ai_variant keys) whose live supply re-derives clean sends
+    without any confirm — a missing key means re-derive, never block."""
+    s = _scenario(db_session)
+    build_draft_offers(db_session, s["rep"], [s["m1"].id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+    draft.line_items = [{k: v for k, v in li.items() if k != "ai_variant"} for li in draft.line_items]
+    db_session.commit()
+
+    with patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock):
+        result = await send_draft_offer(db_session, s["rep"], "tok", draft.id)
+
+    assert result["status"] == ProactiveOfferStatus.SENT
+
+
+def test_prepared_send_route_gates_and_threads_confirm(db_session):
+    s = _scenario(db_session)
+    ai = _mk_ai_match(
+        db_session,
+        customer_mpn="GSOT36C",
+        variant_mpn="GSOT36C-E3-08",
+        owner=s["rep"],
+        company=s["beckhoff"],
+        site=s["beckhoff_site"],
+    )
+    build_draft_offers(db_session, s["rep"], [ai.id])
+    db_session.commit()
+    draft = db_session.query(ProactiveOffer).one()
+    try:
+        client = _make_client(db_session, s["rep"])
+        with (
+            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock),
+        ):
+            r = client.post(f"/v2/partials/proactive/prepared/{draft.id}/send", headers=HX)
+            assert r.status_code == 400
+            assert "AI-matched" in r.text
+            db_session.rollback()
+            db_session.refresh(draft)
+            assert draft.status == ProactiveOfferStatus.DRAFT
+            r = client.post(
+                f"/v2/partials/proactive/prepared/{draft.id}/send",
+                data={"confirm_ai_variants": "1"},
+                headers=HX,
+            )
+            assert r.status_code == 200
+            assert "Offer sent to" in r.text
+    finally:
+        _clear_overrides()
+
+
+def test_prepared_card_renders_ai_badge_and_confirm_input(db_session):
+    s = _scenario(db_session)
+    ai = _mk_ai_match(
+        db_session,
+        customer_mpn="GSOT36C",
+        variant_mpn="GSOT36C-E3-08",
+        owner=s["rep"],
+        company=s["beckhoff"],
+        site=s["beckhoff_site"],
+    )
+    build_draft_offers(db_session, s["rep"], [ai.id])
+    db_session.commit()
+    try:
+        client = _make_client(db_session, s["rep"])
+        r = client.get("/v2/partials/proactive?tab=matches", headers=HX)
+        assert r.status_code == 200
+        assert "Prepared offers" in r.text
+        # The card form's hidden confirm — only flagged cards render it.
+        assert 'name="confirm_ai_variants"' in r.text
+        assert "verify before sending" in r.text  # the explicit hx-confirm copy
+    finally:
+        _clear_overrides()


### PR DESCRIPTION
## What

Phase 1 hotlist workstream — two gaps closed:

**1. The amber "AI match — verify" chip now lights on requisition-hotlist matches.** The hotlist seeding pass stored the OFFER's spelling, so an AI-derived match rolled up under its own spelling, found no divergent offers, and the chip never rendered. It now stores the CUSTOMER requirement's spelling (the rule the other two seeding passes already use), deterministically (lowest-id class-matching requirement). Historical offer-spelling rows keep deduping — regression-tested; no backfill needed. The chip also reaches the top-picks data and the Prepare page.

**2. Server-enforced confirm gate on AI-variant customer sends.** Staged draft lines carry a display-only `ai_variant` stamp (inside the existing `line_items` JSON — no migration); the review-strip card badges flagged offers and its Send posts an explicit confirm. Both send paths — the prepared-send strip and the Prepare-page one-shot — **re-derive the flag live at send time** (authoritative; legacy drafts re-derive, never assume clean) and refuse with a 400 without the confirm. The check runs before the atomic DRAFT→SENT claim, so a blocked send never strands a draft; on the one-shot path it runs before the ProactiveOffer row exists, so a refusal leaves no residue.

Untouched by design: the digest (already flags AI variants, mails the salesperson), the human-verdict endpoint (stays the escalation path), `hotlist_research_enabled` (OFF).

## Evidence

- Full suite: **24477 passed, 35 skipped, 0 failed**; pre-commit green. 20 new tests across matcher, surfaces, staging, and both gates (block leaves draft DRAFT / no Graph call / matches NEW / zero throttles; confirm sends; legacy re-derive).
- Independent final review verdict: **ready to merge** — enumerated every `build_sendmail_payload` caller (no ungated path to a customer email), confirmed fail-CLOSED on rollup errors, and verified dedupe/throttle/DNO safety across mixed historical spellings.

## Post-deploy checks

- Open the Matches tab on staging PG and confirm a hotlist-seeded match renders (the one query change is plain SQLAlchemy, but SQLite masks PG-invalid SQL — house rule).
- Historical hotlist matches keep their old offer-spelling display until they expire or re-seed; behavior holds either way.

## Fast follows (non-blocking, queued)

- Gate-message copy tweak: append "— open Prepare to review and send" so an unbadged legacy draft's 400 points at the recovery path.
- Coverage: a stamped-False-then-flagged block test; ActivityLog subject still logs the offer spelling (backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)