### PR TITLE
Prepayment money-loop UI: pane actions, resend pay link, live approved-unpaid, modal input fix

### DIFF
--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -898,7 +898,7 @@ def render_prepayment_pane(request: Request, user: User, db: Session, prepayment
     gate as render_plan_pane / render_po_pane): a restricted non-owner 404s.
     """
     from ...constants import PREPAYMENT_METHODS, ApprovalSubjectType
-    from ...dependencies import get_buyplan_for_user
+    from ...dependencies import get_buyplan_for_user, is_manager_or_admin
     from ...models.quality_plan import Prepayment
     from ...services.approvals.queue import _beneficiary
     from ...services.stale_guard import stale_token
@@ -959,6 +959,10 @@ def render_prepayment_pane(request: Request, user: User, db: Session, prepayment
             ],
             "method_label": (pp.payment_method or "").upper() or "—",
             "pp_stale_token": stale_token(pp),
+            # Undo-paid is a manager/admin oversight action — this flag MUST mirror the
+            # unmark-paid route's is_manager_or_admin 403 so the button never renders
+            # where the POST would refuse.
+            "can_undo_paid": is_manager_or_admin(user),
             # Notes + attachments (2.4): the prepayment's own thread.
             **_notes_ctx(db, user, plan_id=pp.buy_plan_id, prepayment_id=pp.id),
         }

--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -46,6 +46,7 @@ from ...models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecip
 from ...rate_limit import check_rate_limit
 from ...services.approvals.po_queue import build_po_queue_view
 from ...services.approvals.queue import (
+    approved_unpaid_rows,
     buy_plan_tracking_rows,
     pending_rows_for_gate,
     resolved_rows_for_gate,
@@ -1574,7 +1575,13 @@ def _prepayment_rows(db: Session, user: User, *, q: str, scope: str, show_closed
     if show_closed:
         source = resolved_rows_for_gate(db, ApprovalGateType.PREPAYMENT, scope=scope, user=user)
     else:
+        # Live = open requests (decidable) + the approved-but-unwired window (its
+        # requests are terminal, so pending_rows_for_gate can never surface it — yet
+        # mark-paid / resend live exactly there). Dedupe on the prepayment id
+        # defensively: one row per prepayment, the REQUESTED row winning.
         source = pending_rows_for_gate(db, user, ApprovalGateType.PREPAYMENT, scope=scope)
+        seen = {vm.subject_id for vm in source if vm.subject_id is not None}
+        source = source + [vm for vm in approved_unpaid_rows(db, user, scope=scope) if vm.subject_id not in seen]
 
     for vm in source:
         if vm.subject_id is None:
@@ -1602,7 +1609,16 @@ def _prepayment_rows(db: Session, user: User, *, q: str, scope: str, show_closed
                 closed=show_closed,
             )
         )
-    return [r for r in rows if _matches(q, r.title, r.subtitle, r.copy_number)]
+    rows = [r for r in rows if _matches(q, r.title, r.subtitle, r.copy_number)]
+    if show_closed:
+        return rows  # the resolved audit feed keeps its coalesce order untouched
+    # Live: decidable rows keep their oldest-first source order; everything else
+    # (waiting-on-someone-else requests + the approved-unwired window) renders
+    # newest-first — the _plan_rows house idiom (id desc off the row key), which
+    # avoids mixing naive/aware datetimes in a sort key.
+    needs = [r for r in rows if r.needs_approval]
+    rest = sorted((r for r in rows if not r.needs_approval), key=lambda r: -int(r.key.split("-")[1]))
+    return needs + rest
 
 
 # ── CSV export (kept from the 3-tab console; legacy tab keys alias) ─────

--- a/app/routers/prepayments.py
+++ b/app/routers/prepayments.py
@@ -51,13 +51,14 @@ _PAYMENT_METHOD_CHOICES: list[tuple[str, str]] = [
 _TRUTHY = {"true", "on", "1", "yes"}
 
 
-def _cod_guard_response(message: str) -> HTMLResponse:
-    """The friendly 400 for a blocked prepayment request (COD line / bad method).
+def _form_error_response(message: str) -> HTMLResponse:
+    """The friendly 400 for a refused prepayment request (COD line, bad method, bad
+    amount, duplicate pending, no eligible approver).
 
-    A small inline partial (rendered into the modal body via response-targets or read
-    by tests) + a toast, with a REAL 400 status so callers and tests see the refusal —
-    unlike ``toast_error_response``'s 200-no-swap, this is a hard guard, not a
-    transient service error.
+    A small inline partial (rendered into the modal's #pp-modal-error via the
+    response-targets ext's hx-target-4xx) + a toast, with a REAL 400 status. Never
+    ``toast_error_response`` here: that returns 200, and close_modal_on_success closes
+    the modal on any 2xx — the buyer's input would be eaten.
     """
     resp = HTMLResponse(
         f'<div class="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">{message}</div>',
@@ -129,8 +130,9 @@ async def prepayment_request_create(
     """HTMX create: parse the request form, spawn the prepayment + approval, toast success.
 
     On a service ValueError (line not on plan / no cut PO / duplicate pending) or
-    NoEligibleApproverError, roll back and return an error toast so the modal surfaces the
-    reason instead of a silent no-op.
+    NoEligibleApproverError, roll back and return the inline 400 partial (rendered into
+    the modal's #pp-modal-error via hx-target-4xx) — a real 4xx keeps the modal open
+    with input intact, where the old 200 error toast closed it.
 
     On success, re-render the caller's surface (threaded via ``origin``, mirroring the
     verify-po / resource routes): ``approvals_hub`` → the PO Approval tab body into
@@ -141,18 +143,18 @@ async def prepayment_request_create(
     try:
         amount = Decimal(total_incl_fees)
     except (InvalidOperation, TypeError):
-        return toast_error_response("Enter a valid prepayment amount.")
+        return _form_error_response("Enter a valid prepayment amount.")
 
     # Method must be one of the frozen prepayment methods (COD is not in the list — a
     # forged/stale form can't smuggle it in).
     if payment_method and payment_method not in {m.value for m in PREPAYMENT_METHODS}:
-        return _cod_guard_response("That payment method can't be prepaid — pick wire, PayPal, credit card, or ACH.")
+        return _form_error_response("That payment method can't be prepaid — pick wire, PayPal, credit card, or ACH.")
 
     # COD guard (spec §8): a COD line has nothing to pay in advance. Enforced HERE, in
     # the router, BEFORE create_prepayment — prepayment_service.py stays untouched.
     guard_line = db.get(BuyPlanLine, buy_plan_line_id)
     if guard_line is not None and guard_line.payment_method == PaymentMethod.COD.value:
-        return _cod_guard_response(
+        return _form_error_response(
             "This PO is COD — payment happens on delivery, so there's nothing to pay in advance."
         )
 
@@ -175,10 +177,10 @@ async def prepayment_request_create(
         db.commit()
     except NoEligibleApproverError as exc:
         db.rollback()
-        return toast_error_response(str(exc))
+        return _form_error_response(str(exc))
     except ValueError as exc:
         db.rollback()
-        return toast_error_response(str(exc))
+        return _form_error_response(str(exc))
 
     # Notify accounting/AP (email + Teams) that a prepayment was requested — DO NOT PAY YET.
     # Fire-and-forget: the runner isolates every error so a failed notice never breaks the

--- a/app/routers/prepayments.py
+++ b/app/routers/prepayments.py
@@ -236,11 +236,29 @@ def _render_prepayment_tab(request: Request, user, db: Session, scope: str) -> H
     return render_tab_body(request, user, db, "prepayment", scope)
 
 
+def _lifecycle_rerender(
+    request: Request, user, db: Session, pp: Prepayment, *, origin: str, scope: str
+) -> HTMLResponse:
+    """Post-action surface re-render for the mark-paid / unmark-paid / resend POSTs,
+    mirroring prepayment_request_create's origin threading: ``approvals_workspace`` →
+    the prepayment detail pane into #aw-pane + an awListRefresh nudge (the workspace
+    list repaints itself); anything else → #ap-hub-body, the Prepayments hub-tab body
+    (the unchanged default)."""
+    if origin == "approvals_workspace":
+        from .htmx.approvals_hub import render_prepayment_pane
+
+        resp = render_prepayment_pane(request, user, db, pp.id)
+        resp.headers["HX-Trigger"] = "awListRefresh"
+        return resp
+    return _render_prepayment_tab(request, user, db, scope)
+
+
 @router.get("/v2/partials/prepayments/{prepayment_id}/mark-paid", response_class=HTMLResponse)
 def prepayment_mark_paid_modal(
     request: Request,
     prepayment_id: int,
     scope: str = "all",
+    origin: str = "",
     db: Session = Depends(get_db),
     current_user=Depends(require_user),
 ):
@@ -263,6 +281,7 @@ def prepayment_mark_paid_modal(
         "pp": pp,
         "amount": pp.total_incl_fees,
         "scope": "mine" if scope == "mine" else "all",
+        "origin": origin if origin == "approvals_workspace" else "",
     }
     return template_response("htmx/partials/prepayments/mark_paid_modal.html", ctx)
 
@@ -274,6 +293,7 @@ async def prepayment_mark_paid(
     wire_reference: str | None = Form(None),
     paid_amount: str | None = Form(None),
     scope: str = Form("all"),
+    origin: str = Form(""),
     db: Session = Depends(get_db),
     current_user=Depends(require_user),
 ):
@@ -305,7 +325,7 @@ async def prepayment_mark_paid(
     except ValueError as exc:
         return toast_error_response(str(exc))
 
-    resp = _render_prepayment_tab(request, current_user, db, scope)
+    resp = _lifecycle_rerender(request, current_user, db, pp, origin=origin, scope=scope)
     set_toast(resp, "Prepayment marked paid.", "success", merge=True)
     return resp
 
@@ -315,6 +335,7 @@ async def prepayment_unmark_paid(
     request: Request,
     prepayment_id: int,
     scope: str = Form("all"),
+    origin: str = Form(""),
     db: Session = Depends(get_db),
     current_user=Depends(require_user),
 ):
@@ -333,7 +354,7 @@ async def prepayment_unmark_paid(
     except ValueError as exc:
         return toast_error_response(str(exc))
 
-    resp = _render_prepayment_tab(request, current_user, db, scope)
+    resp = _lifecycle_rerender(request, current_user, db, pp, origin=origin, scope=scope)
     set_toast(resp, "Payment reversed — prepayment returned to approved.", "success", merge=True)
     return resp
 
@@ -343,6 +364,7 @@ async def prepayment_resend_pay_link(
     request: Request,
     prepayment_id: int,
     scope: str = Form("all"),
+    origin: str = Form(""),
     db: Session = Depends(get_db),
     current_user=Depends(require_user),
 ):
@@ -368,6 +390,6 @@ async def prepayment_resend_pay_link(
 
     await run_prepayment_notify_bg(notify_prepayment_approved, pp.id)
 
-    resp = _render_prepayment_tab(request, current_user, db, scope)
+    resp = _lifecycle_rerender(request, current_user, db, pp, origin=origin, scope=scope)
     set_toast(resp, "OK-to-wire email resent to accounting.", "success", merge=True)
     return resp

--- a/app/routers/prepayments.py
+++ b/app/routers/prepayments.py
@@ -336,3 +336,38 @@ async def prepayment_unmark_paid(
     resp = _render_prepayment_tab(request, current_user, db, scope)
     set_toast(resp, "Payment reversed — prepayment returned to approved.", "success", merge=True)
     return resp
+
+
+@router.post("/v2/partials/prepayments/{prepayment_id}/resend-pay-link", response_class=HTMLResponse)
+async def prepayment_resend_pay_link(
+    request: Request,
+    prepayment_id: int,
+    scope: str = Form("all"),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_user),
+):
+    """Re-send the OK-TO-WIRE accounting email for an APPROVED prepayment (the pay link
+    got lost or accounting never saw it).
+
+    Same access gate as mark-paid (manager/admin or the plan owner). The live single-use
+    ``pay_token`` is NOT re-minted — the originally-emailed link keeps working; the notice
+    simply embeds it again (notify_prepayment_approved reads the token live via
+    _confirm_url). Approved-only, hard 400 otherwise: a requested prepayment is not yet
+    authorized, and a paid/void one has a SPENT token — resending would email a link-less
+    OK-TO-WIRE. Router-thin: no service function, only the existing fire-and-forget
+    notifier runner.
+    """
+    pp = db.get(Prepayment, prepayment_id)
+    if pp is None:
+        raise HTTPException(status_code=404, detail="Prepayment not found")
+    _require_mark_paid_access(db, current_user, pp)
+    if pp.status != PrepaymentStatus.APPROVED.value:
+        raise HTTPException(status_code=400, detail="Only an approved prepayment's pay link can be resent.")
+
+    from ..services.prepayment_notifications import notify_prepayment_approved, run_prepayment_notify_bg
+
+    await run_prepayment_notify_bg(notify_prepayment_approved, pp.id)
+
+    resp = _render_prepayment_tab(request, current_user, db, scope)
+    set_toast(resp, "OK-to-wire email resent to accounting.", "success", merge=True)
+    return resp

--- a/app/services/approvals/queue.py
+++ b/app/services/approvals/queue.py
@@ -10,6 +10,10 @@ Purpose: ``pending_rows_for_gate`` / ``resolved_rows_for_gate`` build the rows o
              mirrors the engine's decide() gate), plus the routed-to approver names so an
              org-wide viewer sees who owns a request they cannot action.
          ``pending_count_for_gate`` is the org-wide REQUESTED total that drives a tab pill.
+         ``approved_unpaid_rows`` is the PREPAYMENT gate's live approved-but-unwired
+         window (terminal request, Prepayment.status still 'approved') — the rows the
+         Prepayments tab keeps live for mark-paid / resend even though nothing is
+         pending decision.
 
          These per-gate helpers are the leaner successor to the retired three-way
          ``build_queue_view``: the new Approvals hub (routers/htmx/approvals_hub.py) owns
@@ -41,6 +45,7 @@ from ...constants import (
     ApprovalRecipientStatus,
     ApprovalRequestStatus,
     ApprovalSubjectType,
+    PrepaymentStatus,
 )
 from ...models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
 from ...models.auth import User
@@ -163,6 +168,52 @@ def resolved_rows_for_gate(db: Session, gate_type, *, scope: str = "all", user: 
             decider_names=decider_names,
         )
         for ar in resolved
+    ]
+
+
+def approved_unpaid_rows(db: Session, user: User, *, scope: str = "all") -> list[RowVM]:
+    """APPROVED-but-unpaid prepayments for the Prepayments tab's LIVE list.
+
+    Once a PREPAYMENT request is decided, its ApprovalRequest goes terminal — so
+    ``pending_rows_for_gate`` can never carry the approved-but-unwired window, yet that
+    window is exactly where the money-loop actions (mark paid / resend pay link) live.
+    This reads the Prepayment lifecycle directly (``status == 'approved'``) via each
+    prepayment's terminal APPROVED request, returning RowVMs with ``can_act=False``
+    (nothing left to decide — a tracking row) and ``prepay_status='approved'``. Newest
+    first (request-id desc). Portable SQLAlchemy only (select/join/in_ — nothing
+    PG-specific); same constant-query contract as the sibling helpers.
+
+    ``scope="mine"`` narrows to requests *user* raised or owns (the SEE-MINE toggle).
+    """
+    q = (
+        select(ApprovalRequest)
+        .join(Prepayment, Prepayment.id == ApprovalRequest.subject_id)
+        .where(
+            ApprovalRequest.gate_type == ApprovalGateType.PREPAYMENT,
+            ApprovalRequest.subject_type == ApprovalSubjectType.PREPAYMENT,
+            ApprovalRequest.status == ApprovalRequestStatus.APPROVED,
+            Prepayment.status == PrepaymentStatus.APPROVED.value,
+        )
+        .order_by(ApprovalRequest.id.desc())
+        .limit(PENDING_CAP)
+    )
+    if scope == "mine":
+        q = q.where(_mine_clause(user))
+    rows = list(db.execute(q).scalars())
+    if not rows:
+        return []
+    requester_names = _requester_names(db, rows)
+    subjects = _load_subjects(db, rows)
+    return [
+        _row_vm(
+            ar,
+            pending=False,
+            actionable=set(),
+            approver_names={},
+            requester_names=requester_names,
+            subjects=subjects,
+        )
+        for ar in rows
     ]
 
 

--- a/app/templates/htmx/partials/approvals/_pane_prepayment.html
+++ b/app/templates/htmx/partials/approvals/_pane_prepayment.html
@@ -9,8 +9,9 @@
   reference; void shows the stand-down reason. Decides post the EXISTING
   prepay-requests/{id}/decide route with origin=approvals_workspace.
   Receives: pp (Prepayment), plan, line, user, open_request (ApprovalRequest|None),
-            can_decide (bool), beneficiary (str), prepay_methods (list[(val,label)]),
-            method_label, pp_stale_token.
+            can_decide (bool), can_undo_paid (bool — manager/admin, mirrors the
+            unmark-paid route's 403), beneficiary (str),
+            prepay_methods (list[(val,label)]), method_label, pp_stale_token.
   Called by: htmx/approvals_hub.py render_prepayment_pane.
   Depends on: HTMX, Alpine.js, Tailwind; shared copy_chip + age_chip macros.
 #}
@@ -104,15 +105,43 @@
     Awaiting a prepayment approver.
   </div>
   {% elif pp.status == 'approved' %}
-  <div class="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
-    OK to pay — {{ method_label }} · approved{% if pp.approved_at %} {{ pp.approved_at | fmtdate('%b %d, %Y') }}{% endif %}.
-    Accounting confirms via the pay link.
+  <div class="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 space-y-2">
+    <div>
+      OK to pay — {{ method_label }} · approved{% if pp.approved_at %} {{ pp.approved_at | fmtdate('%b %d, %Y') }}{% endif %}.
+      Accounting confirms via the pay link.
+    </div>
+    {# Money-loop actions. Anyone who can SEE this pane already cleared the routes'
+       access gate (_require_mark_paid_access = manager/admin OR plan access — and this
+       pane required plan access to render). Mark paid opens the in-app fallback modal
+       (origin threads the workspace surface); Resend re-emails the SAME live pay link
+       — the token is NOT re-minted. Explicit hx-target — never inherit. #}
+    <div class="flex items-center gap-1.5">
+      <button type="button"
+              @click="$dispatch('open-modal', {url: '/v2/partials/prepayments/{{ pp.id }}/mark-paid?origin=approvals_workspace'})"
+              class="btn-primary btn-sm">Mark paid</button>
+      <form hx-post="/v2/partials/prepayments/{{ pp.id }}/resend-pay-link"
+            hx-target="#aw-pane" hx-swap="innerHTML"
+            hx-confirm="Resend the OK-TO-WIRE email with the pay link to accounting?">
+        <input type="hidden" name="origin" value="approvals_workspace">
+        <button type="submit" data-loading-disable class="btn btn-secondary btn-sm">Resend pay link</button>
+      </form>
+    </div>
   </div>
   {% elif pp.status == 'paid' %}
   <div class="rounded-lg border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800">
     Paid{% if pp.paid_at %} · {{ pp.paid_at | fmtdate('%b %d, %Y') }}{% endif %}{% if pp.paid_by_label %} · by {{ pp.paid_by_label }}{% endif %}
     {% if pp.wire_reference %}
     <div class="mt-1 flex items-center gap-1.5">Wire reference {{ copy_chip(pp.wire_reference) }}</div>
+    {% endif %}
+    {% if can_undo_paid %}
+    {# Manager/admin-only correction — the flag mirrors the route's 403. Loud confirm:
+       undo re-mints the single-use token, so the link in the ALREADY-SENT email dies. #}
+    <form class="mt-2" hx-post="/v2/partials/prepayments/{{ pp.id }}/unmark-paid"
+          hx-target="#aw-pane" hx-swap="innerHTML"
+          hx-confirm="Reverse this payment? The prepayment returns to approved and the pay link already emailed to accounting stops working — a fresh link is minted.">
+      <input type="hidden" name="origin" value="approvals_workspace">
+      <button type="submit" data-loading-disable class="btn-danger btn-sm">Undo paid</button>
+    </form>
     {% endif %}
   </div>
   {% elif pp.status == 'void' %}

--- a/app/templates/htmx/partials/prepayments/mark_paid_modal.html
+++ b/app/templates/htmx/partials/prepayments/mark_paid_modal.html
@@ -7,7 +7,9 @@
   (form-encoded) to /v2/partials/prepayments/{id}/mark-paid, which marks the prepayment paid
   (paid_via=in_app), re-renders the Prepayment tab body into #ap-hub-body, and toasts. The
   modal closes on any 2xx.
-  Receives: pp (Prepayment), amount (Decimal, prefill), scope ('all'|'mine').
+  Receives: pp (Prepayment), amount (Decimal, prefill), scope ('all'|'mine'),
+            origin ('approvals_workspace'|'' — threads the caller's surface: workspace
+            origin re-renders the prepayment pane into #aw-pane, default the tab body).
   Depends on: HTMX, Alpine.js ($dispatch close-modal), Tailwind CSS.
 #}
 {% from "htmx/partials/shared/_macros.html" import close_modal_on_success -%}
@@ -25,13 +27,14 @@
   </div>
 
   <form hx-post='/v2/partials/prepayments/{{ pp.id }}/mark-paid'
-        hx-target='#ap-hub-body'
+        hx-target='{% if origin == "approvals_workspace" %}#aw-pane{% else %}#ap-hub-body{% endif %}'
         hx-swap='innerHTML'
         hx-push-url='false'
         {{ close_modal_on_success() }}
         data-loading-disable
         class='space-y-3'>
     <input type='hidden' name='scope' value='{{ scope }}'>
+    <input type='hidden' name='origin' value='{{ origin }}'>
 
     <div class='flex gap-2'>
       <div class='flex-1'>

--- a/app/templates/htmx/partials/prepayments/request_modal.html
+++ b/app/templates/htmx/partials/prepayments/request_modal.html
@@ -5,8 +5,10 @@
   Prefilled from the line: vendor (read-only + a hidden vendor_name fallback), PO#, amount
   (unit_cost*qty, editable), currency (USD default), payment method, test-report flag,
   buyer remarks. Posts (form-encoded) to
-  /v2/partials/prepayments, which spawns the prepayment + its routed approval and returns a
-  success/error toast (no page swap — HX-Reswap:none). The modal closes on any 2xx.
+  /v2/partials/prepayments, which spawns the prepayment + its routed approval; success
+  re-renders the origin surface + toast and closes the modal (any 2xx). Refusals are
+  REAL 400s rendered inline into #pp-modal-error (hx-target-4xx, response-targets ext)
+  so the modal stays open with input intact.
   Receives: line (BuyPlanLine), plan (BuyPlan), vendor_name (str|None), amount (float),
             payment_methods (list of (value, label)).
   Depends on: HTMX, Alpine.js ($dispatch close-modal), Tailwind CSS.
@@ -26,6 +28,11 @@
     <div>Plan #{{ plan.id }}{% if plan.sales_order_number %} · SO <span class='font-mono text-gray-900'>{{ plan.sales_order_number }}</span>{% endif %}</div>
   </div>
 
+  {# Inline refusal surface (SET-03 pattern, settings/users.html): the create route's
+     400s render HERE via hx-target-4xx (response-targets ext, loaded in base.html) —
+     the modal stays open, input intact. Empty div renders zero-height. #}
+  <div id='pp-modal-error'></div>
+
   {# #12: origin/hub_scope thread the caller's surface so the create route re-renders it.
      #2: x-data tracks the PO total (po) vs the entered amount (amt); :data-deviates flags a
      >5% swing that the hx-on::confirm hook turns into a warn-only client confirm. #}
@@ -33,6 +40,7 @@
         hx-target='{% if origin == "approvals_hub" %}#ap-hub-body{% elif origin == "approvals_workspace" %}#aw-pane{% else %}#main-content{% endif %}'
         hx-swap='innerHTML'
         hx-push-url='false'
+        hx-target-4xx='#pp-modal-error'
         x-data='{ po: {{ "%.2f"|format(amount) }}, amt: {{ "%.2f"|format(amount) }} }'
         :data-deviates='po > 0 && isFinite(amt) && Math.abs(amt - po) / po > 0.05 ? "1" : ""'
         hx-on::confirm='if (this.dataset.deviates) { event.preventDefault(); if (window.confirm("The amount differs from the PO line total by more than 5%. Submit anyway?")) event.detail.issueRequest(true); }'

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1956,6 +1956,17 @@ buyplan_workflow/ (state machine — package: buyplan_approval.py owns submit/ap
     |                      the entered amount swings >5% from the PO line total (#2); prepayment_request_create reads
     |                      origin and re-renders the RIGHT surface (approvals_hub → po-approval tab body into
     |                      #ap-hub-body @hub_scope; else → plan detail into #main-content) instead of a blank toast (#12).
+    |  Prepay money loop:  approved pane offers Mark paid (opens mark_paid_modal via open-modal,
+    |                      origin=approvals_workspace) + Resend pay link (POST .../resend-pay-link —
+    |                      approved-only 400 guard, token NOT re-minted, notify_prepayment_approved re-fired);
+    |                      paid pane offers manager/admin-only Undo paid (unmark-paid, re-mints token — old
+    |                      emailed link dies, hx-confirm warns). All three POSTs + the mark-paid modal GET
+    |                      thread origin: approvals_workspace re-renders the prepayment pane into #aw-pane +
+    |                      awListRefresh; default = Prepayments tab body. Live lens: approved-but-unpaid rows
+    |                      (queue.approved_unpaid_rows, terminal request + Prepayment.status='approved') merge
+    |                      into the live list under Everything else, newest-first, deduped per prepayment.
+    |                      Request-modal refusals are inline 400s into #pp-modal-error (hx-target-4xx) — the
+    |                      modal keeps the buyer's input.
     |  Backorder (Ph3):    resource_line already reopens a COMPLETED plan (RESOURCEABLE_LINE_STATUSES includes
     |                      verified); when a cancel fires on a plan that WAS completed, resource_line returns
     |                      was_completed=True (computed pre-reopen) which is threaded to

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -564,7 +564,14 @@ def test_prepayments_list_pending(hub_client: TestClient, db_session: Session, t
     assert f"/v2/partials/approvals/prepayments/{pp.id}/pane" in r.text
 
 
-def test_prepayments_list_closed_shows_resolved(hub_client: TestClient, db_session: Session, test_user: User):
+def test_prepayments_list_approved_unpaid_in_live_and_closed(
+    hub_client: TestClient, db_session: Session, test_user: User
+):
+    """An APPROVED-but-unpaid prepayment is LIVE work (mark-paid / resend live on it):
+
+    it shows in the live list — under Everything else, never Needs your approval — and
+    stays in the Closed audit feed (its request is terminal).
+    """
     req, q, _ = _req_quote(db_session, test_user)
     bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
     ar, pp = _pending_prepay_request(db_session, bp, test_user)
@@ -574,10 +581,50 @@ def test_prepayments_list_closed_shows_resolved(hub_client: TestClient, db_sessi
     db_session.commit()
 
     live_txt = hub_client.get("/v2/partials/approvals/prepayments/list").text
-    assert f"prepay-{pp.id}" not in live_txt
+    assert f"prepay-{pp.id}" in live_txt  # surfaced live now
+    assert "Needs your approval" not in live_txt  # …but never as a decision
 
     closed_txt = hub_client.get("/v2/partials/approvals/prepayments/list?show_closed=true").text
     assert f"prepay-{pp.id}" in closed_txt
+
+
+def test_prepayments_list_paid_stays_out_of_live(hub_client: TestClient, db_session: Session, test_user: User):
+    req, q, _ = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    ar, pp = _pending_prepay_request(db_session, bp, test_user)
+    ar.status = ApprovalRequestStatus.APPROVED.value
+    ar.resolved_at = datetime.now(UTC)
+    pp.status = "paid"
+    db_session.commit()
+
+    live_txt = hub_client.get("/v2/partials/approvals/prepayments/list").text
+    assert f"prepay-{pp.id}" not in live_txt
+    closed_txt = hub_client.get("/v2/partials/approvals/prepayments/list?show_closed=true").text
+    assert f"prepay-{pp.id}" in closed_txt
+
+
+def test_prepayments_list_dedupes_prepay_rows(hub_client: TestClient, db_session: Session, test_user: User):
+    """Defensive: an approved prepayment that ALSO still has a REQUESTED request
+    renders exactly once (the decidable REQUESTED row wins)."""
+    req, q, _ = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    _ar, pp = _pending_prepay_request(db_session, bp, test_user)  # REQUESTED request
+    pp.status = "approved"
+    db_session.add(  # a second, terminal APPROVED request on the SAME prepayment
+        ApprovalRequest(
+            gate_type=ApprovalGateType.PREPAYMENT,
+            status=ApprovalRequestStatus.APPROVED,
+            subject_type=ApprovalSubjectType.PREPAYMENT,
+            subject_id=pp.id,
+            requested_by_id=test_user.id,
+            owner_id=test_user.id,
+            resolved_at=datetime.now(UTC),
+        )
+    )
+    db_session.commit()
+
+    live_txt = hub_client.get("/v2/partials/approvals/prepayments/list").text
+    assert live_txt.count(f'data-row-key="prepay-{pp.id}"') == 1
 
 
 def test_prepayments_list_amount_visible(hub_client: TestClient, db_session: Session, test_user: User):

--- a/tests/test_approvals_queue.py
+++ b/tests/test_approvals_queue.py
@@ -34,6 +34,7 @@ from app.models.quotes import Quote
 from app.models.sourcing import Requisition
 from app.models.vendors import VendorCard
 from app.services.approvals.queue import (
+    approved_unpaid_rows,
     pending_count_for_gate,
     pending_rows_for_gate,
     resolved_rows_for_gate,
@@ -539,3 +540,77 @@ def test_routed_request_via_service_is_actionable(db_session: Session) -> None:
     rows = pending_rows_for_gate(db_session, me, ApprovalGateType.BUY_PLAN)
     assert len(rows) == 1
     assert rows[0].can_act is True
+
+
+# ── approved_unpaid_rows (the live approved-but-unwired window) ──────────
+
+
+def test_approved_unpaid_rows_surface_approved_prepayments(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    pp = _prepay(db_session, bp, me)
+    pp.status = "approved"
+    pp.pay_token = "tok-live"
+    _seed(
+        db_session,
+        ApprovalGateType.PREPAYMENT,
+        subject_type=ApprovalSubjectType.PREPAYMENT,
+        subject_id=pp.id,
+        status=ApprovalRequestStatus.APPROVED,
+        requester=me,
+        owner=me,
+        resolved_at=datetime.now(UTC),
+    )
+    db_session.commit()
+
+    rows = approved_unpaid_rows(db_session, me)
+    assert len(rows) == 1
+    vm = rows[0]
+    assert vm.subject_id == pp.id
+    assert vm.can_act is False  # nothing to decide — a tracking row, never Needs-approval
+    assert vm.prepay_status == "approved"
+    assert vm.beneficiary == "Acme Components"
+    assert vm.amount == Decimal("2500.00")
+
+
+def test_approved_unpaid_rows_skip_paid_void_requested(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    for pp_status in ("paid", "void", "requested"):
+        pp = _prepay(db_session, bp, me)
+        pp.status = pp_status
+        _seed(
+            db_session,
+            ApprovalGateType.PREPAYMENT,
+            subject_type=ApprovalSubjectType.PREPAYMENT,
+            subject_id=pp.id,
+            status=ApprovalRequestStatus.APPROVED,
+            requester=me,
+            resolved_at=datetime.now(UTC),
+        )
+    db_session.commit()
+    assert approved_unpaid_rows(db_session, me) == []
+
+
+def test_approved_unpaid_rows_scope_mine(db_session: Session) -> None:
+    me = _user(db_session)
+    other = _user(db_session, name="Other")
+    bp = _bp(db_session, me)
+    for owner in (me, other):
+        pp = _prepay(db_session, bp, owner)
+        pp.status = "approved"
+        _seed(
+            db_session,
+            ApprovalGateType.PREPAYMENT,
+            subject_type=ApprovalSubjectType.PREPAYMENT,
+            subject_id=pp.id,
+            status=ApprovalRequestStatus.APPROVED,
+            requester=owner,
+            owner=owner,
+            resolved_at=datetime.now(UTC),
+        )
+    db_session.commit()
+    assert len(approved_unpaid_rows(db_session, me, scope="all")) == 2
+    mine = approved_unpaid_rows(db_session, me, scope="mine")
+    assert len(mine) == 1
+    assert mine[0].requester_name == "Approver"  # _user's default name — my row, not Other's

--- a/tests/test_prepayment_mark_paid.py
+++ b/tests/test_prepayment_mark_paid.py
@@ -9,6 +9,8 @@ Plus the routers/prepayments.py HTMX fallback:
     in-app (paid_via=in_app, paid_by_id set); a restricted non-owner is 404;
   - POST /v2/partials/prepayments/{id}/unmark-paid — a manager reverts paid→approved, clears
     the paid fields, re-mints pay_token; a non-manager is 403.
+  - POST /v2/partials/prepayments/{id}/resend-pay-link — re-send the OK-TO-WIRE email for
+    an APPROVED prepayment without re-minting pay_token; non-approved is 400.
 The paid fan-out (run_prepayment_notify_bg) is suppressed under TESTING, so no notify work
 runs here.
 
@@ -19,6 +21,7 @@ Depends on: app.services.prepayment_service (mark_prepayment_paid),
 """
 
 from decimal import Decimal
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -265,3 +268,103 @@ def test_mark_paid_twice_is_rejected(db_session: Session, approved_prepay: Prepa
             db_session, pp, wire_reference="WIRE-2", paid_amount=Decimal("20002.38"), paid_via="in_app"
         )
     assert pp.wire_reference == "WIRE-1"  # the second call never overwrote it
+
+
+# ── Resend pay link (approved-only re-send of the OK-TO-WIRE email) ───────────
+
+_RUNNER = "app.services.prepayment_notifications.run_prepayment_notify_bg"
+
+
+def test_resend_pay_link_notifies_without_reminting_token(db_session: Session):
+    manager = _make_user(db_session, role="manager")
+    pp = _approved_prepay_on_plan(db_session, manager)  # pay_token="tok-approved-1"
+
+    with _client_as(db_session, manager) as c, patch(_RUNNER, new_callable=AsyncMock) as bg:
+        r = c.post(
+            f"/v2/partials/prepayments/{pp.id}/resend-pay-link",
+            data={},
+            headers={"HX-Request": "true"},
+        )
+    assert r.status_code == 200, r.text
+    assert "showToast" in r.headers.get("HX-Trigger", "")
+
+    # The OK-TO-WIRE notifier was dispatched through the background runner. (Patching
+    # the runner is the proven wiring pattern — under TESTING the real runner closes
+    # its coroutine without executing it, so patching only the notifier records
+    # nothing; see tests/test_prepayment_notify_wiring.py.)
+    assert bg.called
+    assert bg.call_args.args[0].__name__ == "notify_prepayment_approved"
+    assert bg.call_args.args[1] == pp.id
+
+    db_session.refresh(pp)
+    assert pp.pay_token == "tok-approved-1"  # NOT re-minted — the emailed link stays valid
+    assert pp.status == PrepaymentStatus.APPROVED.value
+
+
+def test_resend_pay_link_paid_is_400_and_never_notifies(db_session: Session):
+    """A paid prepayment's pay_token is spent (None) — notify_prepayment_approved would
+    email a link-less OK-TO-WIRE.
+
+    The route must 400 BEFORE dispatching.
+    """
+    manager = _make_user(db_session, role="manager")
+    pp = _approved_prepay_on_plan(db_session, manager)
+    mark_prepayment_paid(
+        db_session,
+        pp,
+        wire_reference="WIRE-1",
+        paid_amount=Decimal("20002.38"),
+        paid_via="in_app",
+        paid_by_id=manager.id,
+    )
+
+    with _client_as(db_session, manager) as c, patch(_RUNNER, new_callable=AsyncMock) as bg:
+        r = c.post(
+            f"/v2/partials/prepayments/{pp.id}/resend-pay-link",
+            data={},
+            headers={"HX-Request": "true"},
+        )
+    assert r.status_code == 400
+    assert not bg.called
+
+
+def test_resend_pay_link_requested_is_400(db_session: Session):
+    manager = _make_user(db_session, role="manager")
+    pp = _prepay(db_session, status=PrepaymentStatus.REQUESTED.value, pay_token=None)
+
+    with _client_as(db_session, manager) as c, patch(_RUNNER, new_callable=AsyncMock) as bg:
+        r = c.post(
+            f"/v2/partials/prepayments/{pp.id}/resend-pay-link",
+            data={},
+            headers={"HX-Request": "true"},
+        )
+    assert r.status_code == 400
+    assert not bg.called
+
+
+def test_resend_pay_link_restricted_non_owner_404(db_session: Session):
+    """Same access gate as mark-paid: a restricted role (sales) that doesn't own the
+    plan is 404'd by _require_mark_paid_access."""
+    owner = _make_user(db_session, role="buyer")
+    pp = _approved_prepay_on_plan(db_session, owner)
+    intruder = _make_user(db_session, role="sales")
+
+    with _client_as(db_session, intruder) as c, patch(_RUNNER, new_callable=AsyncMock) as bg:
+        r = c.post(
+            f"/v2/partials/prepayments/{pp.id}/resend-pay-link",
+            data={},
+            headers={"HX-Request": "true"},
+        )
+    assert r.status_code == 404
+    assert not bg.called
+
+
+def test_resend_pay_link_missing_404(db_session: Session):
+    manager = _make_user(db_session, role="manager")
+    with _client_as(db_session, manager) as c:
+        r = c.post(
+            "/v2/partials/prepayments/999999/resend-pay-link",
+            data={},
+            headers={"HX-Request": "true"},
+        )
+    assert r.status_code == 404

--- a/tests/test_prepayment_request_ui.py
+++ b/tests/test_prepayment_request_ui.py
@@ -4,7 +4,9 @@ Covers the buyer-facing request surface added on top of create_prepayment:
   - GET  /v2/partials/prepayments/new?line_id=... renders the modal, prefilled with the
     line's amount (unit_cost*qty) and vendor;
   - POST /v2/partials/prepayments (form-encoded) creates a Prepayment linked to the line
-    and returns 200 + an HX-Trigger success toast;
+    and returns 200 + an HX-Trigger success toast; refusals (bad amount, duplicate
+    pending, no eligible approver, COD) are REAL 400s rendered inline into the modal's
+    #pp-modal-error via hx-target-4xx, so the modal stays open with input intact;
   - can_request_prepayment gates button visibility on ownership + cut-PO state.
 
 Called by: pytest
@@ -315,7 +317,13 @@ def test_po_pane_line_with_pending_prepayment_shows_pill_and_badge(client, db_se
     assert "prepayments/new" not in body  # live button suppressed
 
 
-def test_htmx_create_duplicate_pending_returns_error_toast(client, db_session: Session, test_user: User):
+def test_htmx_create_duplicate_pending_returns_inline_400(client, db_session: Session, test_user: User):
+    """Service refusals render INLINE in the modal at a real 4xx (hx-target-4xx /
+    response-targets).
+
+    The old 200 error-toast contract closed the modal and ate the buyer's input —
+    close_modal_on_success fires on ANY 2xx.
+    """
     _seed_approver(db_session)
     _bp, line = _plan_with_line(db_session, test_user)
     db_session.commit()
@@ -331,11 +339,58 @@ def test_htmx_create_duplicate_pending_returns_error_toast(client, db_session: S
     assert first.status_code == 200, first.text
 
     second = client.post("/v2/partials/prepayments", data=payload, headers={"HX-Request": "true"})
-    # Duplicate-pending guard → honest error toast (200 + HX-Reswap none), not a silent 500.
-    assert second.status_code == 200
-    assert second.headers.get("HX-Reswap") == "none"
-    assert "error" in second.headers.get("HX-Trigger", "")
+    assert second.status_code == 400  # real 4xx → the modal stays open
+    assert "already awaiting approval" in second.text  # the inline reason partial
+    assert "error" in second.headers.get("HX-Trigger", "")  # the toast still fires too
     assert db_session.query(Prepayment).filter_by(buy_plan_line_id=line.id).count() == 1
+
+
+def test_htmx_create_bad_amount_returns_inline_400(client, db_session: Session, test_user: User):
+    _seed_approver(db_session)
+    _bp, line = _plan_with_line(db_session, test_user)
+    db_session.commit()
+
+    r = client.post(
+        "/v2/partials/prepayments",
+        data={
+            "buy_plan_id": line.buy_plan_id,
+            "buy_plan_line_id": line.id,
+            "payment_method": "wire",
+            "total_incl_fees": "not-a-number",
+        },
+        headers={"HX-Request": "true"},
+    )
+    assert r.status_code == 400
+    assert "valid prepayment amount" in r.text
+    assert db_session.query(Prepayment).filter_by(buy_plan_line_id=line.id).count() == 0
+
+
+def test_htmx_create_no_eligible_approver_returns_inline_400(client, db_session: Session, test_user: User):
+    # Deliberately NO approver seeded → routing raises NoEligibleApproverError.
+    _bp, line = _plan_with_line(db_session, test_user)
+    db_session.commit()
+
+    r = client.post(
+        "/v2/partials/prepayments",
+        data={
+            "buy_plan_id": line.buy_plan_id,
+            "buy_plan_line_id": line.id,
+            "payment_method": "wire",
+            "total_incl_fees": "50.00",
+        },
+        headers={"HX-Request": "true"},
+    )
+    assert r.status_code == 400
+    assert db_session.query(Prepayment).filter_by(buy_plan_line_id=line.id).count() == 0
+
+
+def test_request_modal_wires_inline_error_target(client, db_session: Session, test_user: User):
+    _bp, line = _plan_with_line(db_session, test_user)
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/prepayments/new?line_id={line.id}", headers={"HX-Request": "true"}).text
+    assert "hx-target-4xx" in body
+    assert "pp-modal-error" in body
 
 
 # ── Button visibility ────────────────────────────────────────────────────

--- a/tests/test_prepayment_workspace.py
+++ b/tests/test_prepayment_workspace.py
@@ -444,3 +444,41 @@ def test_resend_origin_workspace_rerenders_pane(hub_client: TestClient, db_sessi
     assert 'id="aw-pane-body"' in r.text
     assert "awListRefresh" in r.headers.get("HX-Trigger", "")
     assert bg.called
+
+
+# ── Pane lifecycle action buttons (approved / paid branches) ─────────────
+
+
+def test_pane_approved_offers_mark_paid_and_resend(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    body = hub_client.get(f"/v2/partials/approvals/prepayments/{pp.id}/pane").text
+    assert f"/v2/partials/prepayments/{pp.id}/mark-paid?origin=approvals_workspace" in body
+    assert f"/v2/partials/prepayments/{pp.id}/resend-pay-link" in body
+    assert "hx-confirm" in body  # resend asks before re-emailing accounting
+    assert f"/v2/partials/prepayments/{pp.id}/unmark-paid" not in body  # not paid yet
+
+
+def test_pane_paid_offers_undo_for_manager_only(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    pp.status = PrepaymentStatus.PAID.value
+    pp.paid_at = datetime.now(UTC)
+    pp.pay_token = None
+    db_session.commit()
+
+    body = hub_client.get(f"/v2/partials/approvals/prepayments/{pp.id}/pane").text
+    assert f"/v2/partials/prepayments/{pp.id}/unmark-paid" not in body  # buyer: no undo
+
+    test_user.role = "manager"
+    db_session.commit()
+    body = hub_client.get(f"/v2/partials/approvals/prepayments/{pp.id}/pane").text
+    assert f"/v2/partials/prepayments/{pp.id}/unmark-paid" in body
+    assert "stops working" in body  # the hx-confirm warns the old emailed link dies
+    assert f"/v2/partials/prepayments/{pp.id}/mark-paid" not in body  # paid: no re-mark
+
+
+def test_pane_requested_has_no_lifecycle_buttons(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _prepay_on_line(db_session, test_user)
+    body = hub_client.get(f"/v2/partials/approvals/prepayments/{pp.id}/pane").text
+    assert "/mark-paid" not in body
+    assert "/resend-pay-link" not in body
+    assert "/unmark-paid" not in body

--- a/tests/test_prepayment_workspace.py
+++ b/tests/test_prepayment_workspace.py
@@ -361,3 +361,86 @@ def test_prepay_without_line_still_renders_pane(hub_client: TestClient, db_sessi
     r = hub_client.get(f"/v2/partials/approvals/prepayments/{pp.id}/pane")
     assert r.status_code == 200
     assert "WireVendor" in r.text
+
+
+# ── Origin threading: mark-paid / unmark-paid / resend from the workspace pane ──
+
+
+def _approved_pp(db: Session, user: User):
+    """A decided prepayment: request APPROVED (terminal), Prepayment approved with a
+    live pay_token — the state the pane's money-loop actions operate on."""
+    bp, line, pp, ar = _prepay_on_line(db, user)
+    ar.status = ApprovalRequestStatus.APPROVED.value
+    ar.resolved_at = datetime.now(UTC)
+    pp.status = PrepaymentStatus.APPROVED.value
+    pp.approved_at = datetime.now(UTC)
+    pp.pay_token = "tok-live-1"
+    db.commit()
+    return bp, line, pp, ar
+
+
+def test_mark_paid_modal_get_threads_workspace_origin(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    body = hub_client.get(f"/v2/partials/prepayments/{pp.id}/mark-paid?origin=approvals_workspace").text
+    assert "#aw-pane" in body  # the form targets the workspace pane…
+    assert "name='origin'" in body and "approvals_workspace" in body  # …and posts the origin back
+
+
+def test_mark_paid_modal_get_defaults_to_hub_body(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    body = hub_client.get(f"/v2/partials/prepayments/{pp.id}/mark-paid").text
+    assert "#ap-hub-body" in body  # unchanged default surface
+    assert "#aw-pane" not in body
+
+
+def test_mark_paid_origin_workspace_rerenders_pane(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    r = hub_client.post(
+        f"/v2/partials/prepayments/{pp.id}/mark-paid",
+        data={"wire_reference": "FT-ORIGIN-1", "origin": "approvals_workspace"},
+    )
+    assert r.status_code == 200, r.text
+    assert 'id="aw-pane-body"' in r.text  # the prepayment PANE, not a tab body
+    trig = r.headers.get("HX-Trigger", "")
+    assert "awListRefresh" in trig and "showToast" in trig  # list nudge MERGED with the toast
+    db_session.expire_all()
+    assert pp.status == PrepaymentStatus.PAID.value
+
+
+def test_mark_paid_default_origin_rerenders_tab_body(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    r = hub_client.post(f"/v2/partials/prepayments/{pp.id}/mark-paid", data={"wire_reference": "FT-ORIGIN-2"})
+    assert r.status_code == 200, r.text
+    assert "/v2/partials/approvals/prepayments/list" in r.text  # the hub tab body (split view)
+
+
+def test_unmark_paid_origin_workspace_rerenders_pane(hub_client: TestClient, db_session: Session, test_user: User):
+    test_user.role = "manager"  # unmark is manager/admin-only
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    pp.status = PrepaymentStatus.PAID.value
+    pp.paid_at = datetime.now(UTC)
+    pp.pay_token = None
+    db_session.commit()
+
+    r = hub_client.post(
+        f"/v2/partials/prepayments/{pp.id}/unmark-paid",
+        data={"origin": "approvals_workspace"},
+    )
+    assert r.status_code == 200, r.text
+    assert 'id="aw-pane-body"' in r.text
+    assert "awListRefresh" in r.headers.get("HX-Trigger", "")
+    db_session.expire_all()
+    assert pp.status == PrepaymentStatus.APPROVED.value
+
+
+def test_resend_origin_workspace_rerenders_pane(hub_client: TestClient, db_session: Session, test_user: User):
+    _bp, _line, pp, _ar = _approved_pp(db_session, test_user)
+    with patch("app.services.prepayment_notifications.run_prepayment_notify_bg", new_callable=AsyncMock) as bg:
+        r = hub_client.post(
+            f"/v2/partials/prepayments/{pp.id}/resend-pay-link",
+            data={"origin": "approvals_workspace"},
+        )
+    assert r.status_code == 200, r.text
+    assert 'id="aw-pane-body"' in r.text
+    assert "awListRefresh" in r.headers.get("HX-Trigger", "")
+    assert bg.called


### PR DESCRIPTION
## What

Phase 1 money-loop workstream — the approved→paid gap in the Prepayments workspace, closed end to end:

- **Pane action buttons.** The approved pane now offers **Mark paid** (opens the previously-orphaned in-app modal) and **Resend pay link**; the paid pane offers a manager/admin-only **Undo paid** with a loud confirm (undo re-mints the token, so the already-emailed link dies). Button visibility mirrors each route's access gate exactly.
- **New route: `POST /v2/partials/prepayments/{id}/resend-pay-link`.** Approved-only (hard 400 before the notifier can fire — a paid row's token is spent and would email a link-less OK-TO-WIRE); the live `pay_token` is never re-minted, so the originally-emailed link keeps working; same access gate as mark-paid.
- **Origin threading.** All three lifecycle POSTs + the mark-paid modal GET accept `origin=approvals_workspace` and re-render the workspace pane (`#aw-pane` + `awListRefresh`) instead of yanking to the hub tab. Defaults byte-identical; origin whitelisted server-side.
- **Approved-but-unpaid in the Live lens.** Their approval requests are terminal, so the pending query could never carry them and they vanished into a capped Closed feed — exactly where mark-paid/resend live. A new read-side queue helper surfaces them as tracking rows (`can_act=False`, never under "Needs your approval", deduped, newest-first).
- **Request-modal input fix.** Service refusals (duplicate pending, bad amount, no eligible approver) were HTTP 200 toasts — and the modal closes on any 2xx, eating the buyer's input. They're now real 400s rendered inline (`hx-target-4xx`); the modal stays open with input intact.

Zero schema changes. APP_MAP updated.

## Evidence

- Full suite: **24481 passed, 35 skipped, 0 failed** (grep ^FAILED empty); pre-commit green. 21 new/rewritten tests pin the guards (400-before-dispatch, token untouched), the origin whitelist, role-gated buttons per pane state, Live-lens grouping/dedup, and the 4xx modal contract.
- Independent final review verdict: **ready to merge** — verified no privilege leak through origin threading (the pane re-checks access), injection-safe origin handling, and re-ran the six touched test files (124 passed).

## Post-deploy check

Verify `/v2/partials/approvals/prepayments/list` (Live lens, All + Mine) renders on real PG — the new query is portable SQLAlchemy, but SQLite masks PG-invalid SQL (house rule).

## Queued follow-ups (non-blocking, from the final review)

1. **Notifier status re-check** (~2 lines in `_notify_inner`): a pay-link confirm landing in the ms-scale window between the resend guard and the background read could still email a link-less OK-TO-WIRE — an *inherited* race (the approve flow fires the same notifier identically); fixing it in the notifier hardens both paths.
2. mark_paid_modal's own bad-amount 200-toast (same input-eating class fixed here for the request modal) + its stale header prose — one tiny commit.
3. A `logger.info`/audit row on resend (who re-emailed accounting, when).

🤖 Generated with [Claude Code](https://claude.com/claude-code)