### PR TITLE
Customer-360 sibling pooling: AI account summary pools same-customer accounts (#22)

### DIFF
--- a/app/company_utils.py
+++ b/app/company_utils.py
@@ -268,6 +268,36 @@ def find_company_dup_match(db, company_id: int, normalized_name: str | None, thr
     return {"id": best_row.id, "name": best_row.name, "score": round(best_score)}
 
 
+def find_sibling_companies(db, company, cap: int = 5) -> list:
+    """Active companies sharing this company's exact normalized_name.
+
+    These are the policy-allowed duplicates auto-dedup deliberately skips
+    (different owners keep separate accounts). Read-only; callers must never
+    merge based on this. Returns at most ``cap`` rows, ordered by id.
+
+    Called by: services.account_summary_service.generate_account_summary
+    (customer-360 sibling pooling).
+    """
+    if not company.normalized_name:
+        return []
+
+    from sqlalchemy import select
+
+    from .models import Company
+
+    stmt = (
+        select(Company)
+        .where(
+            Company.normalized_name == company.normalized_name,
+            Company.id != company.id,
+            Company.is_active.is_(True),
+        )
+        .order_by(Company.id.asc())
+        .limit(cap)
+    )
+    return list(db.scalars(stmt).all())
+
+
 def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> list[dict]:
     """Find potential duplicate companies using fuzzy name matching.
 

--- a/app/routers/htmx/insights_views.py
+++ b/app/routers/htmx/insights_views.py
@@ -22,6 +22,7 @@ from ...constants import RequisitionStatus
 from ...database import get_db
 from ...dependencies import require_user
 from ...models import Company, Requisition, User, VendorCard
+from ...rate_limit import check_rate_limit
 from ...template_env import template_response
 from ...utils.search_builder import SearchBuilder
 from .._lookup_helpers import get_requisition_or_404
@@ -75,6 +76,67 @@ async def customer_activity_digest(
     ctx["digest"] = digest
     ctx["refresh_url"] = f"/v2/partials/customers/{company_id}/activity-digest"
     return template_response("htmx/partials/shared/activity_digest_card.html", ctx)
+
+
+def _account_summary_ctx(request, user, company, mode, summary=None):
+    ctx = _base_ctx(request, user, "customers")
+    ctx["company"] = company
+    ctx["mode"] = mode
+    ctx["summary"] = summary or {}
+    ctx["sibling_accounts"] = (summary or {}).get("sibling_accounts", [])
+    return ctx
+
+
+@router.get("/v2/partials/customers/{company_id}/account-summary", response_class=HTMLResponse)
+async def account_summary_panel(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Idle account-summary card: one-tap Generate, no AI call on page load."""
+    from ...dependencies import can_manage_account
+
+    company = db.get(Company, company_id)
+    if not company:
+        raise HTTPException(404, "Company not found")
+    mode = "idle" if can_manage_account(user, company, db) else "forbidden"
+    return template_response(
+        "htmx/partials/customers/_account_summary_card.html",
+        _account_summary_ctx(request, user, company, mode),
+    )
+
+
+@router.post("/v2/partials/customers/{company_id}/account-summary", response_class=HTMLResponse)
+async def account_summary_generate(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Generate the AI account summary (sibling-pooled) and render the card."""
+    from ...dependencies import can_manage_account
+    from ...services.account_summary_service import generate_account_summary
+
+    company = db.get(Company, company_id)
+    if not company:
+        raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        return template_response(
+            "htmx/partials/customers/_account_summary_card.html",
+            _account_summary_ctx(request, user, company, "forbidden"),
+        )
+    if not check_rate_limit(user.id, "account_summary", limit=5, window_seconds=60):
+        return template_response(
+            "htmx/partials/customers/_account_summary_card.html",
+            _account_summary_ctx(request, user, company, "throttled"),
+        )
+    summary = await generate_account_summary(company_id, db)
+    mode = "ready" if summary.get("situation") or summary.get("development") else "unavailable"
+    return template_response(
+        "htmx/partials/customers/_account_summary_card.html",
+        _account_summary_ctx(request, user, company, mode, summary),
+    )
 
 
 # ── Dashboard partial ───────────────────────────────────────────────────

--- a/app/services/account_summary_service.py
+++ b/app/services/account_summary_service.py
@@ -1,8 +1,9 @@
 """services/account_summary_service.py -- AI-generated account summary.
 
 Gathers context from company data, requisitions, activities, and contacts
-to produce a strategic account summary via Claude. Called from the companies
-router and rendered on the account overview tab.
+to produce a strategic account summary via Claude. Rendered by the
+account-summary panel on the customer detail page
+(routers/htmx/insights_views.py) and the JSON API (routers/crm/companies.py).
 """
 
 from collections import Counter
@@ -25,7 +26,11 @@ from ..models import (
 async def generate_account_summary(company_id: int, db: Session) -> dict:
     """Build context and ask Claude for a strategic account summary.
 
-    Returns dict with keys: situation, development, next_steps.
+    Returns dict with keys: situation, development, next_steps, sibling_accounts
+    (empty list when the company has no siblings). Context (sites, contacts,
+    requisitions, activities, commercial stats) is pooled across sibling companies
+    (see company_utils.find_sibling_companies) sharing the same normalized_name —
+    read-only; sibling rows are never merged.
     """
     from ..utils.claude_client import claude_json
 
@@ -33,10 +38,26 @@ async def generate_account_summary(company_id: int, db: Session) -> dict:
     if not company:
         return {}
 
+    from ..company_utils import find_sibling_companies
+
+    siblings = find_sibling_companies(db, company)
+    company_ids = [company_id] + [s.id for s in siblings]
+
+    sibling_accounts = [
+        {
+            "id": s.id,
+            "name": s.name,
+            "owner": (s.account_owner.name or s.account_owner.email) if s.account_owner else "Unassigned",
+        }
+        for s in siblings
+    ]
+
     # ── Gather context ───────────────────────────────────────────────
 
-    # Sites
-    sites = db.query(CustomerSite).filter(CustomerSite.company_id == company_id, CustomerSite.is_active.is_(True)).all()
+    # Sites (pooled across siblings)
+    sites = (
+        db.query(CustomerSite).filter(CustomerSite.company_id.in_(company_ids), CustomerSite.is_active.is_(True)).all()
+    )
     site_ids = [s.id for s in sites]
 
     # Contacts across all sites
@@ -71,10 +92,10 @@ async def generate_account_summary(company_id: int, db: Session) -> dict:
         )
         req_counts = {row[0]: row[1] for row in count_rows}
 
-    # Recent activities
+    # Recent activities (pooled across siblings)
     activities = (
         db.query(ActivityLog)
-        .filter(ActivityLog.company_id == company_id)
+        .filter(ActivityLog.company_id.in_(company_ids))
         .order_by(ActivityLog.created_at.desc())
         .limit(20)
         .all()
@@ -104,6 +125,18 @@ async def generate_account_summary(company_id: int, db: Session) -> dict:
 
     owner_name = company.account_owner.name if company.account_owner else "Unassigned"
     ctx_parts.append(f"Account owner: {owner_name}")
+
+    if siblings:
+        sib_bits = []
+        for s in siblings:
+            owner = (s.account_owner.name or s.account_owner.email) if s.account_owner else "Unassigned"
+            sib_bits.append(f"{s.name} (owner: {owner})")
+        ctx_parts.append(
+            f"Sibling accounts pooled ({len(siblings)}): "
+            + "; ".join(sib_bits)
+            + " — same customer under multiple account rows; data below is pooled across all of them."
+        )
+
     ctx_parts.append(f"Sites: {len(sites)}")
     ctx_parts.append(f"Contacts: {len(contacts)}")
 
@@ -144,6 +177,19 @@ async def generate_account_summary(company_id: int, db: Session) -> dict:
             age_days = (now - r.created_at).days if r.created_at else "?"
             recent_lines.append(f"  - REQ-{r.id} '{r.name}' ({r.status}, {mpn_count} MPNs, {age_days}d ago)")
         ctx_parts.append("Recent requisitions:\n" + "\n".join(recent_lines))
+
+    # Commercial stats (pooled across siblings)
+    from .crm_service import company_commercial_stats
+
+    stats = company_commercial_stats(db, company_ids)
+    won_rev = sum((s.get("revenue_90d") or 0) for s in stats.values())
+    rates = [s["win_rate"] for s in stats.values() if s.get("win_rate") is not None]
+    if rates or won_rev:
+        bits = [f"won revenue last 90d: ${won_rev:,.0f}"]
+        if rates:
+            # win_rate is already a 0-100 percentage (company_commercial_stats), not a fraction.
+            bits.append(f"win rate: {sum(rates) / len(rates):.0f}%")
+        ctx_parts.append("Commercial (pooled): " + ", ".join(bits))
 
     # Activity summary
     if activities:
@@ -196,4 +242,5 @@ async def generate_account_summary(company_id: int, db: Session) -> dict:
         "situation": str(result.get("situation", "")),
         "development": str(result.get("development", "")),
         "next_steps": result.get("next_steps", []),
+        "sibling_accounts": sibling_accounts,
     }

--- a/app/templates/htmx/partials/customers/_account_summary_card.html
+++ b/app/templates/htmx/partials/customers/_account_summary_card.html
@@ -1,0 +1,50 @@
+{# _account_summary_card.html — one-tap AI account summary (sibling-pooled).
+   Receives: company, mode (idle|ready|unavailable|throttled|forbidden),
+   summary (situation/development/next_steps), sibling_accounts [{id,name,owner}].
+   Called by: account-summary routes in routers/htmx/insights_views.py. #}
+<div class="account-summary-card rounded-lg border border-brand-200 bg-white p-4">
+  <div class="flex items-center justify-between gap-3">
+    <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">Account summary
+      <span class="ml-1 text-[11px] uppercase tracking-wide text-amber-600"
+            title="AI-generated from CRM data — verify before acting.">AI</span>
+    </p>
+    {% if mode != 'forbidden' %}
+    <button type="button"
+            hx-post="/v2/partials/customers/{{ company.id }}/account-summary"
+            hx-target="closest .account-summary-card"
+            hx-swap="outerHTML"
+            hx-push-url="false"
+            class="text-xs text-brand-600 hover:text-brand-700 cursor-pointer">
+      {% if mode == 'ready' %}Regenerate{% else %}Generate{% endif %}
+    </button>
+    {% endif %}
+  </div>
+
+  {% if sibling_accounts %}
+  <div class="mt-2 rounded border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs text-amber-800">
+    Includes {{ sibling_accounts | length }} sibling account{{ 's' if sibling_accounts | length != 1 }}:
+    {% for s in sibling_accounts %}{{ s.name }} (owner: {{ s.owner }}){% if not loop.last %}, {% endif %}{% endfor %}
+    — same customer under separate rows; accounts stay unmerged.
+  </div>
+  {% endif %}
+
+  {% if mode == 'ready' %}
+    <p class="text-sm text-gray-900 mt-2">{{ summary.situation }}</p>
+    {% if summary.development %}<p class="text-xs text-gray-600 mt-1 leading-relaxed">{{ summary.development }}</p>{% endif %}
+    {% if summary.next_steps %}
+    <ul class="mt-2 space-y-0.5">
+      {% for step in summary.next_steps %}
+      <li class="text-xs text-gray-700">→ {{ step }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  {% elif mode == 'idle' %}
+    <p class="text-xs text-gray-500 mt-2">One-tap AI briefing on this account — pipeline, engagement, and suggested next moves.</p>
+  {% elif mode == 'throttled' %}
+    <p class="text-xs text-amber-700 mt-2">Generating too fast — please wait a minute and try again.</p>
+  {% elif mode == 'unavailable' %}
+    <p class="text-xs text-gray-500 mt-2">Summary unavailable right now — try again shortly.</p>
+  {% elif mode == 'forbidden' %}
+    <p class="text-xs text-gray-500 mt-2">Restricted — account summaries are available to the account team.</p>
+  {% endif %}
+</div>

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -61,6 +61,14 @@
        hx-swap="innerHTML"
        class="empty:hidden"></div>
 
+  {# One-tap AI account summary (sibling-pooled) — lazy; button card only, no AI on load #}
+  <div hx-get="/v2/partials/customers/{{ company.id }}/account-summary"
+       hx-target="this"
+       hx-trigger="load"
+       hx-swap="innerHTML"
+       hx-push-url="false"
+       class="empty:hidden"></div>
+
   {# ── Slim account header ─────────────────────────────────────────────────
      One compact card: identity (left) · commercial/cadence chip strip (middle) ·
      actions (right). Account cadence/disposition/clocks collapse below. #}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -7710,9 +7710,10 @@ company, db)` (else a `forbidden` card) and a per-user `check_rate_limit(user.id
 "account_summary", limit=5, window_seconds=60)` (else `throttled`), then calls
 `account_summary_service.generate_account_summary`. That service pools context
 across **sibling accounts** — `company_utils.find_sibling_companies(db, company,
-cap=5)` returns other active `Company` rows sharing the exact same
-`normalized_name` — the policy-allowed duplicates that auto-dedup deliberately
-skips because their `account_owner_id` differs. Pooling is **read-only**: sites,
+cap=5)` applies no owner filter, returning every other active `Company` row
+sharing the exact same `normalized_name`; such rows persist unmerged because
+auto-dedup's merge step skips pairs whose `account_owner_id` differs, not
+because of any filter in this function. Pooling is **read-only**: sites,
 contacts, requisitions, activity, and commercial stats are gathered across
 `[company_id] + sibling_ids` to brief Claude, but sibling rows are never merged or
 written. `_account_summary_card.html` surfaces an amber banner listing each pooled

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -7698,3 +7698,24 @@ Route: `POST /v2/partials/buy-plans/{plan}/lines/{line}/receive` (`require_user`
 PermissionError→403, ValueError→400); `origin=approvals_workspace` re-renders the
 SO/BP pane when a `lens` rides along (the kanban card's button — the board repaints
 in place) else the PO-line pane, both with `awListRefresh`.
+
+## Customer-360 Sibling Pooling — one-tap AI account summary (2026-08-27)
+
+A one-tap AI account summary sits on the customer detail page, lazy-mounted
+(`hx-trigger=load`) in `detail.html` right below the existing dup-suggestion banner:
+`GET /v2/partials/customers/{company_id}/account-summary`
+(`insights_views.account_summary_panel`) renders an idle button card with no AI call
+on page load; `POST` (`account_summary_generate`) gates on `can_manage_account(user,
+company, db)` (else a `forbidden` card) and a per-user `check_rate_limit(user.id,
+"account_summary", limit=5, window_seconds=60)` (else `throttled`), then calls
+`account_summary_service.generate_account_summary`. That service pools context
+across **sibling accounts** — `company_utils.find_sibling_companies(db, company,
+cap=5)` returns other active `Company` rows sharing the exact same
+`normalized_name` — the policy-allowed duplicates that auto-dedup deliberately
+skips because their `account_owner_id` differs. Pooling is **read-only**: sites,
+contacts, requisitions, activity, and commercial stats are gathered across
+`[company_id] + sibling_ids` to brief Claude, but sibling rows are never merged or
+written. `_account_summary_card.html` surfaces an amber banner listing each pooled
+sibling by name + owner ("accounts stay unmerged") whenever `sibling_accounts` is
+non-empty, so the AI-generated situation/development/next-steps read as one
+customer even though the underlying accounts stay separate.

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -4757,6 +4757,13 @@ class TestCustomerTabDeepLink:
         assert tab_content_block, "company-tab-content div not found"
         assert "hx-trigger" not in tab_content_block.group(0)
 
+    def test_detail_mounts_account_summary_panel(self, client: TestClient, db_session: Session, test_user: User):
+        """The customer detail page lazily mounts the account-summary panel (c360)."""
+        co = self._make_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+        assert f"/v2/partials/customers/{co.id}/account-summary" in resp.text
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TestDispositionFilter — P0-C disposition and has_open_reqs filters

--- a/tests/test_customer360_siblings.py
+++ b/tests/test_customer360_siblings.py
@@ -90,3 +90,65 @@ class TestSiblingPooling:
         with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
             out = _run(generate_account_summary(test_company.id, db_session))
         assert out == {}
+
+
+class TestAccountSummaryPanel:
+    def test_get_renders_generate_button(self, client, db_session, test_company, test_user):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{test_company.id}/account-summary", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Generate" in resp.text
+        assert f"/v2/partials/customers/{test_company.id}/account-summary" in resp.text
+
+    def test_post_renders_summary_with_sibling_banner(self, client, db_session, test_company, test_user):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        fake = {
+            "situation": "Solid account.",
+            "development": "Growing.",
+            "next_steps": ["Call the buyer"],
+            "sibling_accounts": [{"id": 9, "name": "Sib Co", "owner": "Pat"}],
+        }
+        with patch(
+            "app.services.account_summary_service.generate_account_summary", new_callable=AsyncMock, return_value=fake
+        ):
+            resp = client.post(
+                f"/v2/partials/customers/{test_company.id}/account-summary", headers={"HX-Request": "true"}
+            )
+        assert resp.status_code == 200
+        assert "Solid account." in resp.text
+        assert "Includes 1 sibling account" in resp.text
+        assert "Sib Co" in resp.text and "Pat" in resp.text
+
+    def test_post_ai_unavailable_friendly(self, client, db_session, test_company, test_user):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        with patch(
+            "app.services.account_summary_service.generate_account_summary", new_callable=AsyncMock, return_value={}
+        ):
+            resp = client.post(
+                f"/v2/partials/customers/{test_company.id}/account-summary", headers={"HX-Request": "true"}
+            )
+        assert resp.status_code == 200
+        assert "unavailable" in resp.text.lower()
+
+    def test_post_rate_limited_friendly(self, client, db_session, test_company, test_user):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        with patch("app.routers.htmx.insights_views.check_rate_limit", return_value=False):
+            resp = client.post(
+                f"/v2/partials/customers/{test_company.id}/account-summary", headers={"HX-Request": "true"}
+            )
+        assert resp.status_code == 200
+        assert "wait" in resp.text.lower()
+
+    def test_non_manager_gets_forbidden_card(self, client, db_session, test_company):
+        # client's test_user (buyer) neither owns nor manages test_company
+        resp = client.get(f"/v2/partials/customers/{test_company.id}/account-summary", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "restricted" in resp.text.lower() or "not available" in resp.text.lower()
+
+    def test_missing_company_404(self, client, db_session):
+        resp = client.get("/v2/partials/customers/999999/account-summary", headers={"HX-Request": "true"})
+        assert resp.status_code == 404

--- a/tests/test_customer360_siblings.py
+++ b/tests/test_customer360_siblings.py
@@ -110,8 +110,13 @@ class TestAccountSummaryPanel:
             "next_steps": ["Call the buyer"],
             "sibling_accounts": [{"id": 9, "name": "Sib Co", "owner": "Pat"}],
         }
-        with patch(
-            "app.services.account_summary_service.generate_account_summary", new_callable=AsyncMock, return_value=fake
+        with (
+            patch(
+                "app.services.account_summary_service.generate_account_summary",
+                new_callable=AsyncMock,
+                return_value=fake,
+            ),
+            patch("app.routers.htmx.insights_views.check_rate_limit", return_value=True),
         ):
             resp = client.post(
                 f"/v2/partials/customers/{test_company.id}/account-summary", headers={"HX-Request": "true"}
@@ -124,8 +129,13 @@ class TestAccountSummaryPanel:
     def test_post_ai_unavailable_friendly(self, client, db_session, test_company, test_user):
         test_company.account_owner_id = test_user.id
         db_session.commit()
-        with patch(
-            "app.services.account_summary_service.generate_account_summary", new_callable=AsyncMock, return_value={}
+        with (
+            patch(
+                "app.services.account_summary_service.generate_account_summary",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch("app.routers.htmx.insights_views.check_rate_limit", return_value=True),
         ):
             resp = client.post(
                 f"/v2/partials/customers/{test_company.id}/account-summary", headers={"HX-Request": "true"}

--- a/tests/test_customer360_siblings.py
+++ b/tests/test_customer360_siblings.py
@@ -5,8 +5,11 @@ account_summary_service.generate_account_summary, and the account-summary
 HTMX partials.
 """
 
+from unittest.mock import AsyncMock, patch
+
 from app.company_utils import find_sibling_companies
-from app.models.crm import Company
+from app.models.crm import Company, CustomerSite
+from app.services.account_summary_service import generate_account_summary
 
 
 def _mk_company(db, name, *, owner_id=None, is_active=True):
@@ -14,6 +17,15 @@ def _mk_company(db, name, *, owner_id=None, is_active=True):
     db.add(c)
     db.commit()
     return c
+
+
+_AI = {"situation": "s", "development": "d", "next_steps": ["n1"]}
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 class TestFindSiblings:
@@ -44,3 +56,37 @@ class TestFindSiblings:
         db_session.commit()
         got = find_sibling_companies(db_session, test_company, cap=5)
         assert len(got) == 5
+
+
+class TestSiblingPooling:
+    def test_no_siblings_prompt_unchanged_and_empty_list(self, db_session, test_company):
+        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=_AI) as mock_ai:
+            out = _run(generate_account_summary(test_company.id, db_session))
+        assert out["sibling_accounts"] == []
+        assert "Sibling accounts pooled" not in mock_ai.call_args.args[0]
+
+    def test_sibling_sites_and_activities_pooled(self, db_session, test_company, test_user):
+        sib = _mk_company(db_session, "Sibling Co", owner_id=test_user.id)
+        sib.normalized_name = test_company.normalized_name
+        db_session.add(CustomerSite(company_id=sib.id, site_name="Sib Plant"))
+        db_session.commit()
+        from app.models.intelligence import ActivityLog
+
+        db_session.add(
+            ActivityLog(activity_type="sales_note", channel="manual", company_id=sib.id, subject="sib touchpoint")
+        )
+        db_session.commit()
+        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=_AI) as mock_ai:
+            out = _run(generate_account_summary(test_company.id, db_session))
+        prompt = mock_ai.call_args.args[0]
+        assert "Sibling accounts pooled (1): Sibling Co" in prompt
+        assert out["sibling_accounts"] == [
+            {"id": sib.id, "name": "Sibling Co", "owner": test_user.name or test_user.email}
+        ]
+        # pooled: the sibling's activity is inside the 20-row activity window
+        assert "Recent activity" in prompt
+
+    def test_failure_still_returns_empty_dict(self, db_session, test_company):
+        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+            out = _run(generate_account_summary(test_company.id, db_session))
+        assert out == {}

--- a/tests/test_customer360_siblings.py
+++ b/tests/test_customer360_siblings.py
@@ -1,0 +1,46 @@
+"""tests/test_customer360_siblings.py — Customer-360 sibling pooling (AI queue P3-7).
+
+Covers: company_utils.find_sibling_companies, sibling pooling in
+account_summary_service.generate_account_summary, and the account-summary
+HTMX partials.
+"""
+
+from app.company_utils import find_sibling_companies
+from app.models.crm import Company
+
+
+def _mk_company(db, name, *, owner_id=None, is_active=True):
+    c = Company(name=name, account_owner_id=owner_id, is_active=is_active)
+    db.add(c)
+    db.commit()
+    return c
+
+
+class TestFindSiblings:
+    def test_same_normalized_name_found(self, db_session, test_company):
+        sib = _mk_company(db_session, f"{test_company.name}, Inc.")
+        assert sib.normalized_name == test_company.normalized_name  # validator sync
+        got = find_sibling_companies(db_session, test_company)
+        assert [c.id for c in got] == [sib.id]
+
+    def test_self_and_inactive_and_unrelated_excluded(self, db_session, test_company):
+        _mk_company(db_session, f"{test_company.name} LLC", is_active=False)
+        _mk_company(db_session, "Totally Different Corp")
+        got = find_sibling_companies(db_session, test_company)
+        assert got == []
+
+    def test_null_normalized_name_no_siblings(self, db_session, test_company):
+        test_company.normalized_name = None
+        db_session.commit()
+        assert find_sibling_companies(db_session, test_company) == []
+
+    def test_cap(self, db_session, test_company):
+        # Guaranteed-identical normalized names (assigned directly):
+        sibs = []
+        for i in range(7):
+            c = _mk_company(db_session, f"{test_company.name} whatever {i}")
+            c.normalized_name = test_company.normalized_name
+            sibs.append(c)
+        db_session.commit()
+        got = find_sibling_companies(db_session, test_company, cap=5)
+        assert len(got) == 5


### PR DESCRIPTION
AI queue Phase 3 item 7 (idea #22) — built under the standing AI-queue authorization (specs/ai-queue-phase-plan-2026-08-23.md).

## What

The AI account summary now pools context across **sibling accounts** — active `Company` rows sharing the exact `normalized_name` (the policy-allowed duplicates auto-dedup deliberately leaves unmerged). Rows stay unmerged; strictly read-only; no migration.

- `company_utils.find_sibling_companies(db, company, cap=5)` — exact-match, active-only, self-excluded.
- `generate_account_summary` pools sites (→ contacts/reqs/requirement counts), ActivityLog, and a pooled commercial line (`crm_service.company_commercial_stats`, only when real signal exists); prompt gains a "Sibling accounts pooled (N)" line; success return gains `sibling_accounts` (failure paths still `{}`).
- **Net-new render surface** (spec correction: the service had NO UI consumer — the docstring's "overview tab" never existed): one-tap panel on customer detail. GET = idle card, zero AI on page load; POST = generate. Gated by `can_manage_account` + per-user rate limit (`account_summary`, 5/min); friendly 200 cards for forbidden/throttled/unavailable. Banner: "Includes N sibling accounts (owned by …)" listing names + owners.
- JSON API `POST /api/companies/{id}/summarize` untouched (gains the `sibling_accounts` key on success).

## Guardrails held

Identity-hiding: no excess/resell data in context (resell ActivityLog rows carry no `company_id` — structurally excluded). No-siblings prompt byte-identical except the commercial-signal line. `claude_json` fast-tier call unchanged.

## Residual (deliberate)

Part-history pooling (`analyze_customer_materials`) not included — single-company-shaped and prompt-heavy; additive follow-up if wanted.

## Evidence

- Full suite in worktree: `24475 passed, 35 skipped, 0 FAILED in 659s`
- Feature tests: 13 (helper 4, pooling 3, panel 6) + detail-mount render test; existing 21 account-summary tests green with zero assertion changes.
- 5 task reviews + whole-branch final review (clean; minors triaged, 2 fixed, rest deferred) + scoped re-review of the fix wave.

## Post-deploy check

Open a customer detail page → account-summary card renders idle (no AI call in logs) → tap Generate → summary renders; for a customer with a same-name sibling account, banner lists the sibling + owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkHRARudqRbahKpsFDmUQa