### PR TITLE
Buy-plan handoff brief: one-tap AI deal summary on the Approvals pane (#17)

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1085,6 +1085,7 @@ class DigestEntityType(StrEnum):
 
     REQUISITION = "requisition"
     COMPANY = "company"
+    BUY_PLAN = "buy_plan"
 
 
 class DigestStatusSignal(StrEnum):

--- a/app/routers/htmx/insights_views.py
+++ b/app/routers/htmx/insights_views.py
@@ -77,6 +77,27 @@ async def customer_activity_digest(
     return template_response("htmx/partials/shared/activity_digest_card.html", ctx)
 
 
+@router.get("/v2/partials/buy-plans/{plan_id}/handoff-brief", response_class=HTMLResponse)
+async def buyplan_handoff_brief(
+    request: Request,
+    plan_id: int,
+    force: int = 0,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """AI handoff brief card for a buy plan (one-tap load from the deal pane)."""
+    from ...constants import DigestEntityType
+    from ...dependencies import get_buyplan_for_user
+    from ...services.activity_digest_service import get_or_build_digest
+
+    get_buyplan_for_user(db, user, plan_id)  # 404s missing plans and restricted non-owners
+    digest = await get_or_build_digest(DigestEntityType.BUY_PLAN, plan_id, db, force=bool(force))
+    ctx = _base_ctx(request, user, "buy-plans")
+    ctx["digest"] = digest
+    ctx["refresh_url"] = f"/v2/partials/buy-plans/{plan_id}/handoff-brief"
+    return template_response("htmx/partials/shared/activity_digest_card.html", ctx)
+
+
 # ── Dashboard partial ───────────────────────────────────────────────────
 
 

--- a/app/services/activity_digest_service.py
+++ b/app/services/activity_digest_service.py
@@ -83,12 +83,22 @@ responsiveness, sentiment trend, open RFQs, and the single most useful follow-up
 'on_track' for healthy engagement, 'stalled' when contact has gone quiet, 'needs_attention'
 when something awaits a reply."""
 
+_BUYPLAN_SYSTEM = """You write a handoff brief for an electronic-component buy plan (deal), so a
+backup teammate can take over cold. Given deterministic deal facts (plan header, per-line
+standing, quality-plan review stamps, prepayments, approval history) and recent activity,
+produce a tight digest: what the customer asked for, where each line stands, what is blocked
+(issues, unpaid prepayments, unreviewed QP sections, missing POs), and the single most useful
+next action. status_signal: 'on_track' when moving, 'stalled' when nothing recent, 'needs_attention'
+when something is blocked or awaiting a decision."""
+
 
 def _system_prompt(entity_type: DigestEntityType) -> str:
     if entity_type == DigestEntityType.REQUISITION:
         return _REQ_SYSTEM
     if entity_type == DigestEntityType.COMPANY:
         return _ACCOUNT_SYSTEM
+    if entity_type == DigestEntityType.BUY_PLAN:
+        return _BUYPLAN_SYSTEM
     raise ValueError(entity_type)
 
 
@@ -120,10 +130,12 @@ def _get_redis():
 
 
 def _load_activities(entity_type: DigestEntityType, entity_id: int, db: Session):
-    from .activity_service import get_company_activities, get_requisition_activities
+    from .activity_service import get_buy_plan_activities, get_company_activities, get_requisition_activities
 
     if entity_type == DigestEntityType.REQUISITION:
         return get_requisition_activities(entity_id, db, limit=ACTIVITY_CAP, meaningful_only=True)
+    if entity_type == DigestEntityType.BUY_PLAN:
+        return get_buy_plan_activities(entity_id, db, limit=200, meaningful_only=False)
     return get_company_activities(entity_id, db, limit=ACTIVITY_CAP, meaningful_only=True)
 
 
@@ -156,8 +168,20 @@ async def get_or_build_digest(
     if existing and not force and existing.cooldown_until and existing.cooldown_until > now:
         return _digest_to_dict(existing)
 
+    plan = None
+    if entity_type == DigestEntityType.BUY_PLAN:
+        from ..models.buy_plan import BuyPlan
+
+        plan = db.get(BuyPlan, entity_id)
+        if plan is None:
+            return {"state": DigestState.INSUFFICIENT}
+
     activities = _load_activities(entity_type, entity_id, db)
-    if len(activities) < 2:
+    if entity_type == DigestEntityType.BUY_PLAN:
+        meaningful = [a for a in activities if a.is_meaningful is not False][:ACTIVITY_CAP]
+        if not plan.lines and len(meaningful) < 2:
+            return {"state": DigestState.INSUFFICIENT}
+    elif len(activities) < 2:
         return {"state": DigestState.INSUFFICIENT}
 
     basis_last = max((a.created_at for a in activities if a.created_at), default=None)
@@ -191,7 +215,15 @@ async def get_or_build_digest(
     try:
         from ..utils.claude_client import claude_structured
 
-        prompt = "Recent activity (newest first):\n" + _build_activity_lines(activities)
+        if entity_type == DigestEntityType.BUY_PLAN:
+            from .buyplan_handoff import build_handoff_facts
+
+            act_block = _build_activity_lines(meaningful) if meaningful else "none logged"
+            prompt = (
+                "Deal facts:\n" + build_handoff_facts(db, plan) + "\n\nRecent activity (newest first):\n" + act_block
+            )
+        else:
+            prompt = "Recent activity (newest first):\n" + _build_activity_lines(activities)
         try:
             result = await claude_structured(
                 prompt=prompt,

--- a/app/services/activity_digest_service.py
+++ b/app/services/activity_digest_service.py
@@ -219,9 +219,12 @@ async def get_or_build_digest(
             from .buyplan_handoff import build_handoff_facts
 
             act_block = _build_activity_lines(meaningful) if meaningful else "none logged"
-            prompt = (
-                "Deal facts:\n" + build_handoff_facts(db, plan) + "\n\nRecent activity (newest first):\n" + act_block
-            )
+            try:
+                facts = build_handoff_facts(db, plan)
+            except Exception as e:
+                logger.warning("Handoff facts build failed for plan {}: {}", entity_id, e)
+                return {"state": DigestState.ERROR}
+            prompt = "Deal facts:\n" + facts + "\n\nRecent activity (newest first):\n" + act_block
         else:
             prompt = "Recent activity (newest first):\n" + _build_activity_lines(activities)
         try:

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -10,7 +10,7 @@ Usage:
 from datetime import UTC, datetime, timedelta
 
 from loguru import logger
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session, selectinload
 
@@ -947,6 +947,22 @@ def get_requisition_activities(
     if meaningful_only:
         q = q.filter(_is_meaningful_or_unscored())
     return q.order_by(ActivityLog.created_at.desc()).limit(limit).all()
+
+
+def get_buy_plan_activities(
+    buy_plan_id: int, db: Session, limit: int = 200, meaningful_only: bool = True
+) -> list[ActivityLog]:
+    """Get the activity timeline for a buy plan, newest first.
+
+    Includes plan-level, line-tagged, and prepayment-tagged rows (everything logged
+    against the plan) — backs the AI handoff brief. Same meaningful_only semantics as
+    get_requisition_activities.
+    """
+    stmt = select(ActivityLog).where(ActivityLog.buy_plan_id == buy_plan_id)
+    if meaningful_only:
+        stmt = stmt.where(_is_meaningful_or_unscored())
+    stmt = stmt.order_by(ActivityLog.created_at.desc()).limit(limit)
+    return list(db.scalars(stmt).all())
 
 
 def _paginate_timeline(db: Session, *conditions, limit: int, offset: int) -> tuple[list[ActivityLog], int]:

--- a/app/services/buyplan_handoff.py
+++ b/app/services/buyplan_handoff.py
@@ -27,6 +27,10 @@ def _money(v) -> str:
     return f"${v:,.0f}" if v is not None else "—"
 
 
+def _unit_money(v) -> str:
+    return f"${v:,.2f}" if v is not None else "—"
+
+
 def _d(dt) -> str:
     return dt.strftime("%Y-%m-%d") if dt else "not yet"
 
@@ -52,10 +56,11 @@ def build_handoff_facts(db: Session, plan: BuyPlan) -> str:
         for line in lines[:LINE_CAP]:
             mpn = line.requirement.primary_mpn if line.requirement else "?"
             vendor = line.offer.vendor_name if line.offer else "?"
+            eta = _d(line.estimated_ship_date) if line.estimated_ship_date else "—"
             seg = (
                 f"  - {mpn} ×{line.quantity or 0} | vendor: {vendor} | "
-                f"{_money(line.unit_cost)} → {_money(line.unit_sell)} | {line.status} | "
-                f"PO {line.po_number or '—'} | ETA {line.estimated_ship_date or '—'}"
+                f"{_unit_money(line.unit_cost)} → {_unit_money(line.unit_sell)} | {line.status} | "
+                f"PO {line.po_number or '—'} | ETA {eta}"
             )
             if line.issue_type:
                 note = f": {line.issue_note}" if line.issue_note else ""

--- a/app/services/buyplan_handoff.py
+++ b/app/services/buyplan_handoff.py
@@ -1,0 +1,118 @@
+"""services/buyplan_handoff.py — deterministic facts block for the AI handoff brief.
+
+Purpose: assemble everything a backup needs to pick up a deal — plan header,
+per-line standing (vendor, qty, cost→sell, status, PO, ETA, issues), QP section
+review stamps, prepayment states, and the ApprovalEvent timeline — as plain text
+for the BUY_PLAN entity of activity_digest_service. Read-only; no AI here.
+
+Called by: app/services/activity_digest_service.py (BUY_PLAN branch)
+Depends on: app/models/buy_plan.py, app/models/quality_plan.py, app/models/approvals.py
+"""
+
+from collections import Counter
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..constants import ApprovalGateType, ApprovalSubjectType
+from ..models.approvals import ApprovalEvent, ApprovalRequest
+from ..models.buy_plan import BuyPlan
+from ..models.quality_plan import Prepayment, QualityPlan
+
+LINE_CAP = 15
+EVENT_CAP = 10
+
+
+def _money(v) -> str:
+    return f"${v:,.0f}" if v is not None else "—"
+
+
+def _d(dt) -> str:
+    return dt.strftime("%Y-%m-%d") if dt else "not yet"
+
+
+def build_handoff_facts(db: Session, plan: BuyPlan) -> str:
+    """Deterministic facts block, one section per aspect of the deal."""
+    req = plan.requisition
+    parts = [
+        f"Buy plan #{plan.id} | status: {plan.status} | SO verify: {plan.so_status} | order type: {plan.order_type}",
+        f"Customer: {req.customer_name or '?'} | requisition: REQ-{req.id} '{req.name}'",
+        f"ERP refs: SO# {plan.sales_order_number or 'not set'} | customer PO# {plan.customer_po_number or 'not set'}",
+        f"Totals: cost {_money(plan.total_cost)} | revenue {_money(plan.total_revenue)} | "
+        f"margin {plan.total_margin_pct if plan.total_margin_pct is not None else '—'}%",
+        f"Quote: {plan.quote.status if plan.quote else 'none linked'}",
+    ]
+
+    lines = list(plan.lines)
+    if not lines:
+        parts.append("Lines: none yet")
+    else:
+        counts = Counter(line.status for line in lines)
+        parts.append(f"Lines ({len(lines)}): " + ", ".join(f"{s}: {n}" for s, n in counts.items()))
+        for line in lines[:LINE_CAP]:
+            mpn = line.requirement.primary_mpn if line.requirement else "?"
+            vendor = line.offer.vendor_name if line.offer else "?"
+            seg = (
+                f"  - {mpn} ×{line.quantity or 0} | vendor: {vendor} | "
+                f"{_money(line.unit_cost)} → {_money(line.unit_sell)} | {line.status} | "
+                f"PO {line.po_number or '—'} | ETA {line.estimated_ship_date or '—'}"
+            )
+            if line.issue_type:
+                note = f": {line.issue_note}" if line.issue_note else ""
+                seg += f" | ISSUE {line.issue_type}{note}"
+            parts.append(seg)
+        if len(lines) > LINE_CAP:
+            parts.append(f"  (+{len(lines) - LINE_CAP} more lines)")
+
+    qp = db.scalars(
+        select(QualityPlan).where(QualityPlan.buy_plan_id == plan.id).order_by(QualityPlan.id.asc())
+    ).first()
+    if qp is None:
+        parts.append("Quality plan: not created")
+    else:
+        sales = f"reviewed {_d(qp.sales_section_reviewed_at)}" if qp.sales_section_reviewed_at else "not reviewed"
+        purch = (
+            f"reviewed {_d(qp.purchasing_section_reviewed_at)}" if qp.purchasing_section_reviewed_at else "not reviewed"
+        )
+        parts.append(f"Quality plan #{qp.id}: Sales section {sales}; Purchasing section {purch}")
+
+    prepays = list(db.scalars(select(Prepayment).where(Prepayment.buy_plan_id == plan.id)))
+    if not prepays:
+        parts.append("Prepayments: none")
+    else:
+        pc = Counter(p.status for p in prepays)
+        parts.append(f"Prepayments ({len(prepays)}): " + ", ".join(f"{s}: {n}" for s, n in pc.items()))
+        for p in prepays:
+            parts.append(f"  - {_money(p.total_incl_fees)} to {p.vendor_name or '?'} ({p.status})")
+
+    req_ids = list(
+        db.scalars(
+            select(ApprovalRequest.id).where(
+                ApprovalRequest.gate_type == ApprovalGateType.BUY_PLAN,
+                ApprovalRequest.subject_type == ApprovalSubjectType.BUY_PLAN,
+                ApprovalRequest.subject_id == plan.id,
+            )
+        )
+    )
+    events = []
+    if req_ids:
+        events = list(
+            db.scalars(
+                select(ApprovalEvent)
+                .where(ApprovalEvent.request_id.in_(req_ids))
+                .order_by(ApprovalEvent.created_at.desc())
+                .limit(EVENT_CAP)
+            )
+        )
+    if not events:
+        parts.append("Approval history: none")
+    else:
+        parts.append("Approval history (newest first):")
+        for e in events:
+            actor = (e.actor.name or e.actor.email) if e.actor else "system"
+            note = ""
+            if isinstance(e.payload, dict):
+                note = e.payload.get("comment") or e.payload.get("note") or ""
+            parts.append(f"  - {_d(e.created_at)} | {e.event_type} | {actor}" + (f" | {note}" if note else ""))
+
+    return "\n".join(parts)

--- a/app/templates/htmx/partials/approvals/_pane_sales_order.html
+++ b/app/templates/htmx/partials/approvals/_pane_sales_order.html
@@ -209,6 +209,22 @@
   {% endif %}
   {% endif %}
 
+  {# ── Handoff brief (AI, one-tap): loads the cached digest card on demand #}
+  <div class="rounded-lg border border-brand-200 bg-white p-3">
+    <div class="flex items-center justify-between gap-3">
+      <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">Handoff brief</p>
+      <button type="button"
+              hx-get="/v2/partials/buy-plans/{{ bp.id }}/handoff-brief"
+              hx-target="#handoff-brief-{{ bp.id }}"
+              hx-swap="innerHTML"
+              hx-push-url="false"
+              class="text-xs text-brand-600 hover:text-brand-700 cursor-pointer">
+        Generate
+      </button>
+    </div>
+    <div id="handoff-brief-{{ bp.id }}" class="mt-2 empty:hidden"></div>
+  </div>
+
   {# ── Notes & attachments (2.4) — never status-locked ─────────────── #}
   {% include "htmx/partials/approvals/_notes_thread.html" %}
 </div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -3108,6 +3108,27 @@ budget, but none exist today — the dormant KB-insight refresh job
 (`knowledge_jobs._job_refresh_insights`) was deleted 2026-07-06 (no UI consumer, burned
 Anthropic API cost when enabled; recoverable from git history).
 
+### 8c. Buy-plan handoff brief (one-tap deal handoff, 2026-08)
+
+The Approvals deal pane (`_pane_sales_order.html`) carries a "Handoff brief" panel below the
+QP-sales section: a `Generate` button lazy-loads `GET
+/v2/partials/buy-plans/{plan_id}/handoff-brief` (`insights_views.buyplan_handoff_brief`) into
+an empty `#handoff-brief-{{ bp.id }}` div, rendering the same shared `activity_digest_card.html`
+states (ready/insufficient/generating/error) as the requisition/company digests above. The
+route is ownership-gated first (`get_buyplan_for_user` — 404s a missing plan or a restricted
+non-owner) before calling `get_or_build_digest(DigestEntityType.BUY_PLAN, plan_id, db, force)`
+— same cache row, cooldown, and Redis nx-lock machinery, new entity type. Unlike the other two
+entities, the BUY_PLAN branch's Claude prompt leads with deterministic facts, not raw activity:
+`services/buyplan_handoff.build_handoff_facts` assembles plan header/totals, up to 15 per-line
+rows (vendor, qty, cost→sell, status, PO#, ETA, issue), QP sales/purchasing review stamps,
+prepayment states, and the last 10 `ApprovalEvent` rows into plain text, appended with up to 30
+meaningful rows from `get_buy_plan_activities` (200-row load, `meaningful_only=False`, filtered
+in Python to `is_meaningful is not False`). The insufficient-guard is looser than the other
+entities': a plan with any lines is never "insufficient" even with zero logged activity — only
+a lineless plan with fewer than 2 meaningful activities returns `{state: "insufficient"}`.
+`_BUYPLAN_SYSTEM` targets a status_signal of on_track/stalled/needs_attention and one next
+action for a backup teammate picking the deal up cold.
+
 ---
 
 ## 9. Inbox Observability

--- a/tests/test_approvals_workspace_pane.py
+++ b/tests/test_approvals_workspace_pane.py
@@ -165,6 +165,16 @@ def test_pane_missing_plan_404s(hub_client: TestClient):
     assert hub_client.get("/v2/partials/approvals/plan/999999/pane").status_code == 404
 
 
+def test_pane_offers_handoff_brief(hub_client: TestClient, db_session: Session, test_user: User):
+    req, q, _ = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    db_session.commit()
+
+    body = hub_client.get(f"/v2/partials/approvals/plan/{bp.id}/pane").text
+    assert f"/v2/partials/buy-plans/{bp.id}/handoff-brief" in body
+    assert "Handoff brief" in body
+
+
 # ── Decide from the pane (origin=approvals_workspace) ────────────────────
 
 

--- a/tests/test_buyplan_handoff.py
+++ b/tests/test_buyplan_handoff.py
@@ -1,8 +1,9 @@
 """tests/test_buyplan_handoff.py — Buy-plan handoff brief (AI queue P3-6).
 
 Covers: DigestEntityType.BUY_PLAN, activity_service.get_buy_plan_activities,
-services/buyplan_handoff.build_handoff_facts, and the BUY_PLAN branch of
-activity_digest_service.get_or_build_digest.
+services/buyplan_handoff.build_handoff_facts, the BUY_PLAN branch of
+activity_digest_service.get_or_build_digest, and the
+/v2/partials/buy-plans/{plan_id}/handoff-brief endpoint.
 """
 
 from datetime import UTC, datetime
@@ -201,6 +202,16 @@ class TestBuyPlanDigest:
             second = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, test_buy_plan.id, db_session)
         assert second["state"] == digest_svc.DigestState.READY
         assert mock_ai2.called  # non-meaningful row still regenerated the brief
+
+    async def test_facts_build_error_returns_error_state(self, db_session, test_buy_plan, test_offer, monkeypatch):
+        monkeypatch.setattr(digest_svc, "_get_redis", lambda: None)
+        db_session.add(
+            BuyPlanLine(buy_plan_id=test_buy_plan.id, offer_id=test_offer.id, quantity=10, status="awaiting_po")
+        )
+        db_session.commit()
+        with patch("app.services.buyplan_handoff.build_handoff_facts", side_effect=RuntimeError("boom")):
+            res = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, test_buy_plan.id, db_session)
+        assert res["state"] == digest_svc.DigestState.ERROR
 
 
 class TestHandoffEndpoint:

--- a/tests/test_buyplan_handoff.py
+++ b/tests/test_buyplan_handoff.py
@@ -201,3 +201,44 @@ class TestBuyPlanDigest:
             second = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, test_buy_plan.id, db_session)
         assert second["state"] == digest_svc.DigestState.READY
         assert mock_ai2.called  # non-meaningful row still regenerated the brief
+
+
+class TestHandoffEndpoint:
+    """GET /v2/partials/buy-plans/{plan_id}/handoff-brief.
+
+    No ready-made restricted-role TestClient fixture exists in tests/conftest.py (only
+    `client` bound to the buyer `test_user`, plus `manager_client`; `sales_user` and
+    `trader_user` have no matching client override) — so the restricted-non-owner 404
+    path of get_buyplan_for_user is not separately exercised here. test_missing_plan_404
+    covers get_buyplan_for_user's 404 behavior (same HTTPException(404) raised for both
+    a missing plan and a restricted non-owner).
+    """
+
+    def test_renders_card(self, client, db_session, test_buy_plan):
+        with patch(
+            "app.services.activity_digest_service.get_or_build_digest",
+            new_callable=AsyncMock,
+            return_value={
+                "state": digest_svc.DigestState.READY,
+                "headline": "Deal ready",
+                "narrative": None,
+                "highlights": [],
+                "next_step": None,
+                "status_signal": "on_track",
+                "generated_at": None,
+            },
+        ):
+            resp = client.get(
+                f"/v2/partials/buy-plans/{test_buy_plan.id}/handoff-brief",
+                headers={"HX-Request": "true"},
+            )
+        assert resp.status_code == 200
+        assert "Deal ready" in resp.text
+        assert f"/v2/partials/buy-plans/{test_buy_plan.id}/handoff-brief" in resp.text
+
+    def test_missing_plan_404(self, client, db_session):
+        resp = client.get(
+            "/v2/partials/buy-plans/999999/handoff-brief",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 404

--- a/tests/test_buyplan_handoff.py
+++ b/tests/test_buyplan_handoff.py
@@ -1,0 +1,54 @@
+"""tests/test_buyplan_handoff.py — Buy-plan handoff brief (AI queue P3-6).
+
+Covers: DigestEntityType.BUY_PLAN, activity_service.get_buy_plan_activities,
+services/buyplan_handoff.build_handoff_facts, and the BUY_PLAN branch of
+activity_digest_service.get_or_build_digest.
+"""
+
+from datetime import UTC, datetime
+
+from app.constants import DigestEntityType
+from app.models.intelligence import ActivityLog
+from app.services.activity_service import get_buy_plan_activities
+
+
+def _mk_plan_activity(
+    db, buy_plan_id, *, activity_type="sales_note", is_meaningful=True, buy_plan_line_id=None, subject=None, notes=None
+):
+    a = ActivityLog(
+        activity_type=activity_type,
+        channel="manual",
+        buy_plan_id=buy_plan_id,
+        buy_plan_line_id=buy_plan_line_id,
+        subject=subject,
+        notes=notes,
+        is_meaningful=is_meaningful,
+        occurred_at=datetime.now(UTC),
+    )
+    db.add(a)
+    db.commit()
+    return a
+
+
+class TestBuyPlanActivities:
+    def test_entity_type_value(self):
+        assert DigestEntityType.BUY_PLAN.value == "buy_plan"
+
+    def test_returns_plan_rows_newest_first(self, db_session, test_buy_plan):
+        a1 = _mk_plan_activity(db_session, test_buy_plan.id, subject="first")
+        a2 = _mk_plan_activity(db_session, test_buy_plan.id, subject="second")
+        rows = get_buy_plan_activities(test_buy_plan.id, db_session)
+        assert [r.id for r in rows][:2] == [a2.id, a1.id]
+
+    def test_meaningful_only_hides_scored_false(self, db_session, test_buy_plan):
+        _mk_plan_activity(db_session, test_buy_plan.id, subject="keep", is_meaningful=True)
+        noisy = _mk_plan_activity(db_session, test_buy_plan.id, subject="noise", is_meaningful=False)
+        rows = get_buy_plan_activities(test_buy_plan.id, db_session, meaningful_only=True)
+        assert noisy.id not in [r.id for r in rows]
+        rows_all = get_buy_plan_activities(test_buy_plan.id, db_session, meaningful_only=False)
+        assert noisy.id in [r.id for r in rows_all]
+
+    def test_other_plan_rows_excluded(self, db_session, test_buy_plan):
+        _mk_plan_activity(db_session, test_buy_plan.id, subject="mine")
+        rows = get_buy_plan_activities(test_buy_plan.id + 999, db_session)
+        assert rows == []

--- a/tests/test_buyplan_handoff.py
+++ b/tests/test_buyplan_handoff.py
@@ -6,7 +6,11 @@ activity_digest_service.get_or_build_digest.
 """
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
+import pytest
+
+import app.services.activity_digest_service as digest_svc
 from app.constants import ApprovalGateType, ApprovalSubjectType, DigestEntityType
 from app.models.approvals import ApprovalEvent, ApprovalRequest
 from app.models.buy_plan import BuyPlanLine
@@ -133,3 +137,67 @@ class TestHandoffFacts:
         assert "approved" in facts
         assert "Prepayments (1): approved: 1" in facts
         assert "$1,200" in facts
+
+
+_FAKE = {
+    "headline": "Deal ready",
+    "narrative": "All lines placed.",
+    "highlights": [{"label": "Lines", "value": "1"}],
+    "status_signal": "on_track",
+    "next_step": "Verify PO",
+}
+
+
+@pytest.mark.asyncio
+class TestBuyPlanDigest:
+    async def test_missing_plan_insufficient(self, db_session, monkeypatch):
+        monkeypatch.setattr(digest_svc, "_get_redis", lambda: None)
+        res = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, 999999, db_session)
+        assert res["state"] == digest_svc.DigestState.INSUFFICIENT
+
+    async def test_empty_plan_insufficient(self, db_session, test_buy_plan, monkeypatch):
+        monkeypatch.setattr(digest_svc, "_get_redis", lambda: None)
+        res = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, test_buy_plan.id, db_session)
+        assert res["state"] == digest_svc.DigestState.INSUFFICIENT
+
+    async def test_plan_with_line_generates_with_facts_in_prompt(
+        self, db_session, test_buy_plan, test_offer, monkeypatch
+    ):
+        monkeypatch.setattr(digest_svc, "_get_redis", lambda: None)
+        db_session.add(
+            BuyPlanLine(buy_plan_id=test_buy_plan.id, offer_id=test_offer.id, quantity=10, status="awaiting_po")
+        )
+        db_session.commit()
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_FAKE) as mock_ai:
+            res = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, test_buy_plan.id, db_session)
+        assert res["state"] == digest_svc.DigestState.READY
+        prompt = mock_ai.call_args.kwargs["prompt"]
+        assert f"Buy plan #{test_buy_plan.id}" in prompt
+        assert "Recent activity" in prompt
+        sys_prompt = mock_ai.call_args.kwargs["system"]
+        assert "handoff" in sys_prompt.lower() or "backup" in sys_prompt.lower()
+
+    async def test_nonmeaningful_activity_busts_basis(self, db_session, test_buy_plan, test_offer, monkeypatch):
+        monkeypatch.setattr(digest_svc, "_get_redis", lambda: None)
+        db_session.add(
+            BuyPlanLine(buy_plan_id=test_buy_plan.id, offer_id=test_offer.id, quantity=1, status="awaiting_po")
+        )
+        db_session.commit()
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_FAKE):
+            first = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, test_buy_plan.id, db_session)
+        assert first["state"] == digest_svc.DigestState.READY
+        # expire the cooldown so the basis guard is what decides
+        row = (
+            db_session.query(digest_svc.ActivityDigest)
+            .filter_by(entity_type="buy_plan", entity_id=test_buy_plan.id)
+            .one()
+        )
+        row.cooldown_until = datetime(2020, 1, 1, tzinfo=UTC)
+        db_session.commit()
+        _mk_plan_activity(
+            db_session, test_buy_plan.id, activity_type="field_edit", is_meaningful=False, subject="line edited"
+        )
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_FAKE) as mock_ai2:
+            second = await digest_svc.get_or_build_digest(DigestEntityType.BUY_PLAN, test_buy_plan.id, db_session)
+        assert second["state"] == digest_svc.DigestState.READY
+        assert mock_ai2.called  # non-meaningful row still regenerated the brief

--- a/tests/test_buyplan_handoff.py
+++ b/tests/test_buyplan_handoff.py
@@ -7,9 +7,13 @@ activity_digest_service.get_or_build_digest.
 
 from datetime import UTC, datetime
 
-from app.constants import DigestEntityType
+from app.constants import ApprovalGateType, ApprovalSubjectType, DigestEntityType
+from app.models.approvals import ApprovalEvent, ApprovalRequest
+from app.models.buy_plan import BuyPlanLine
 from app.models.intelligence import ActivityLog
+from app.models.quality_plan import Prepayment, QualityPlan
 from app.services.activity_service import get_buy_plan_activities
+from app.services.buyplan_handoff import build_handoff_facts
 
 
 def _mk_plan_activity(
@@ -52,3 +56,80 @@ class TestBuyPlanActivities:
         _mk_plan_activity(db_session, test_buy_plan.id, subject="mine")
         rows = get_buy_plan_activities(test_buy_plan.id + 999, db_session)
         assert rows == []
+
+
+class TestHandoffFacts:
+    def test_header_and_empty_sections(self, db_session, test_buy_plan):
+        facts = build_handoff_facts(db_session, test_buy_plan)
+        assert f"Buy plan #{test_buy_plan.id}" in facts
+        assert "status: draft" in facts
+        assert "Lines: none yet" in facts
+        assert "Quality plan: not created" in facts
+        assert "Prepayments: none" in facts
+        assert "Approval history: none" in facts
+
+    def test_line_facts_and_status_counts(self, db_session, test_buy_plan, test_offer):
+        line = BuyPlanLine(
+            buy_plan_id=test_buy_plan.id,
+            requirement_id=test_offer.requirement_id,
+            offer_id=test_offer.id,
+            quantity=25,
+            unit_cost=4.10,
+            unit_sell=6.00,
+            status="awaiting_po",
+            issue_type=None,
+        )
+        db_session.add(line)
+        db_session.commit()
+        facts = build_handoff_facts(db_session, test_buy_plan)
+        assert "Lines (1): awaiting_po: 1" in facts
+        assert "×25" in facts
+        assert test_offer.vendor_name in facts
+
+    def test_line_issue_surfaces_as_blocker(self, db_session, test_buy_plan, test_offer):
+        # NOTE: brief's sample used issue_type="price_up", which is not a member of
+        # LineIssueType (sold_out | price_changed | lead_time_changed | other — see
+        # app/constants.py) and BuyPlanLine._validate_issue_type raises ValueError on
+        # assignment. Adapted to "price_changed", the real vocabulary's closest match.
+        line = BuyPlanLine(
+            buy_plan_id=test_buy_plan.id,
+            offer_id=test_offer.id,
+            quantity=5,
+            status="issue",
+            issue_type="price_changed",
+            issue_note="vendor repriced +12%",
+        )
+        db_session.add(line)
+        db_session.commit()
+        facts = build_handoff_facts(db_session, test_buy_plan)
+        assert "ISSUE price_changed: vendor repriced +12%" in facts
+
+    def test_qp_section_stamps(self, db_session, test_buy_plan, test_user):
+        qp = QualityPlan(buy_plan_id=test_buy_plan.id)
+        qp.sales_section_reviewed_at = datetime(2026, 8, 20, tzinfo=UTC)
+        qp.sales_section_reviewed_by_id = test_user.id
+        db_session.add(qp)
+        db_session.commit()
+        facts = build_handoff_facts(db_session, test_buy_plan)
+        assert "Sales section reviewed 2026-08-20" in facts
+        assert "Purchasing section not reviewed" in facts
+
+    def test_prepayment_and_approval_timeline(self, db_session, test_buy_plan, test_user):
+        db_session.add(
+            Prepayment(buy_plan_id=test_buy_plan.id, total_incl_fees=1200, vendor_name="Arrow", status="approved")
+        )
+        req = ApprovalRequest(
+            gate_type=ApprovalGateType.BUY_PLAN.value,
+            subject_type=ApprovalSubjectType.BUY_PLAN.value,
+            subject_id=test_buy_plan.id,
+            status="approved",
+            requested_by_id=test_user.id,
+        )
+        db_session.add(req)
+        db_session.flush()
+        db_session.add(ApprovalEvent(request_id=req.id, actor_id=test_user.id, event_type="approved"))
+        db_session.commit()
+        facts = build_handoff_facts(db_session, test_buy_plan)
+        assert "approved" in facts
+        assert "Prepayments (1): approved: 1" in facts
+        assert "$1,200" in facts


### PR DESCRIPTION
AI queue Phase 3 item 6 (idea #17) — built under the standing AI-queue authorization (specs/ai-queue-phase-plan-2026-08-23.md).

## What

A one-tap **Handoff brief** panel on the Approvals-workspace deal pane: "what the customer asked for, where each line stands, blockers, next actions" — for handing a deal to a backup.

- `DigestEntityType.BUY_PLAN` extends the existing cached activity-digest machinery (ActivityDigest row per entity, Redis anti-stampede lock, cooldown, basis-change regeneration). **No migration** — entity_type is String(50) + enum validator.
- Prompt is deterministic facts first (`app/services/buyplan_handoff.py`): plan header, per-line standing (vendor, qty, cost→sell at 2 decimals, status, PO, ETA, issues), QP section review stamps, prepayments, ApprovalEvent timeline — then recent plan-scoped ActivityLog lines (`get_buy_plan_activities`, new helper).
- Cache-bust basis covers ALL plan activity rows (incl. non-meaningful FIELD_EDITs) so line edits and approval events regenerate the brief; the prompt itself uses meaningful-only lines.
- GET `/v2/partials/buy-plans/{plan_id}/handoff-brief`, ownership-gated via `get_buyplan_for_user` (restricted roles 404 off-ownership); renders the shared digest card with Refresh. Panel button in `_pane_sales_order.html` — zero AI on pane render, AI only on tap, cached after.
- Facts-build failures return the card's ERROR state, never a 500 (spec guardrail).

## Spec corrections applied (verified in code)

- No `ApprovalAction` model exists — timeline reads `ApprovalEvent` via `ApprovalRequest(gate_type=BUY_PLAN, subject=plan)`.
- QP "gate state" in live code = per-section Mark-Reviewed stamps (no QP ApprovalRequests are ever created).

## Evidence

- Full suite in worktree: `24475 passed, 35 skipped, 0 FAILED in 670s`
- Feature tests: 16 (activities helper 4, facts builder 5, digest branch 5 incl. error-guard, endpoint 2) + pane render test; existing digest suites (20 tests) green untouched.
- 5 task reviews + whole-branch final review (merge-ready; minors triaged, 4 fixed, rest deferred) + scoped re-review of the fix wave.

## Post-deploy check

Open a deal pane in the Approvals workspace → "Handoff brief" panel with Generate button (no AI call in logs on pane open) → tap Generate → brief card renders with headline/highlights/next step; tap Refresh → regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkHRARudqRbahKpsFDmUQa