### PR TITLE
Data-Ops: unmatched-activity review card + Decision H bulk-approve strike

### DIFF
--- a/app/routers/htmx/settings.py
+++ b/app/routers/htmx/settings.py
@@ -3,9 +3,11 @@
 Server-rendered HTML partials for the settings surface: ops verification group, users,
 scorecard, sources, system, profile + the per-user toggle endpoints, inbox scan-now,
 data-ops + connectors tabs, connector test-all, the CRM vendor/company merge + dedup
-admin actions, and the admin api-health + data-ops partials. Extracted verbatim from
-htmx_views.py (same `/v2/partials/settings`, `/api/user`, `/v2/partials/admin` paths,
-same `htmx-views` tag).
+admin actions, the admin api-health + data-ops partials, and the Data-Ops unmatched-
+activity review card (`/v2/partials/data-ops/unmatched-activities`, same require_admin
+gate as the JSON queue in app/routers/v13_features/activity.py). Extracted verbatim
+from htmx_views.py (same `/v2/partials/settings`, `/api/user`, `/v2/partials/admin`
+paths, same `htmx-views` tag).
 
 Called by: app/main.py (router mount); htmx_views.py re-imports `_run_inbox_scan_now`
     (the staying poll-inbox route). Toast feedback goes through the shared
@@ -448,6 +450,114 @@ async def settings_data_ops_tab(
         raise HTTPException(403, "Admin only")
 
     return _render_data_ops(request, user, db)
+
+
+def _render_unmatched_activities(request: Request, user: User, db: Session) -> Response:
+    """Render the unmatched-activity review card — list + count, lazy-loaded onto the
+    Data Ops tab next to the vendor/company/contact dedup sections.
+
+    Reused by the attribute/dismiss actions below so a successful (or friendly-failed)
+    action re-renders just this card and the acted-on row drops without a manual
+    refresh.
+    """
+    from ...services.activity_service import count_unmatched_activities, get_unmatched_activities
+
+    ctx = _base_ctx(request, user, "settings")
+    ctx["unmatched_activities"] = get_unmatched_activities(db, limit=30)
+    ctx["unmatched_count"] = count_unmatched_activities(db)
+    return template_response("htmx/partials/settings/_unmatched_activities.html", ctx)
+
+
+@router.get("/v2/partials/data-ops/unmatched-activities", response_class=HTMLResponse)
+async def data_ops_unmatched_activities(
+    request: Request,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Unmatched-activity review card (admin only) — same require_admin gate as the JSON
+    queue endpoints in app/routers/v13_features/activity.py."""
+    return _render_unmatched_activities(request, user, db)
+
+
+@router.post("/v2/partials/data-ops/unmatched-activities/{activity_id}/attribute", response_class=HTMLResponse)
+async def data_ops_unmatched_attribute(
+    request: Request,
+    activity_id: int,
+    entity_type: str = Form(...),
+    entity_id: int = Form(...),
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Attribute an unmatched activity to a company or vendor, then re-render the card.
+
+    Validation mirrors the JSON endpoint (attribute_activity_endpoint): the entity
+    vocabulary comes from the same ActivityAttributeRequest schema, and the target
+    company/vendor must exist. Any failure is a friendly toast + re-render, never a 500
+    or a bare error page — the row stays put so the admin can retry.
+    """
+    from pydantic import ValidationError
+
+    from ...schemas.v13_features import ActivityAttributeRequest
+    from ...services.activity_service import attribute_activity
+
+    try:
+        payload = ActivityAttributeRequest(entity_type=entity_type, entity_id=entity_id)
+    except ValidationError:
+        resp = _render_unmatched_activities(request, user, db)
+        set_toast(resp, "Choose company or vendor and a valid id.", kind="error")
+        return resp
+
+    if payload.entity_type == "company":
+        target = db.get(Company, payload.entity_id)
+        not_found_msg = "Company not found."
+    else:
+        target = db.get(VendorCard, payload.entity_id)
+        not_found_msg = "Vendor not found."
+    if not target:
+        resp = _render_unmatched_activities(request, user, db)
+        set_toast(resp, not_found_msg, kind="error")
+        return resp
+
+    result = attribute_activity(
+        activity_id=activity_id,
+        entity_type=payload.entity_type,
+        entity_id=payload.entity_id,
+        db=db,
+        user_id=user.id,
+    )
+    if not result:
+        db.rollback()
+        resp = _render_unmatched_activities(request, user, db)
+        set_toast(resp, "Activity not found.", kind="error")
+        return resp
+
+    db.commit()
+    resp = _render_unmatched_activities(request, user, db)
+    set_toast(resp, "Activity attributed.")
+    return resp
+
+
+@router.post("/v2/partials/data-ops/unmatched-activities/{activity_id}/dismiss", response_class=HTMLResponse)
+async def data_ops_unmatched_dismiss(
+    request: Request,
+    activity_id: int,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Dismiss an unmatched activity (admin only), then re-render the card."""
+    from ...services.activity_service import dismiss_activity
+
+    result = dismiss_activity(activity_id, db)
+    if not result:
+        db.rollback()
+        resp = _render_unmatched_activities(request, user, db)
+        set_toast(resp, "Activity not found.", kind="error")
+        return resp
+
+    db.commit()
+    resp = _render_unmatched_activities(request, user, db)
+    set_toast(resp, "Activity dismissed.")
+    return resp
 
 
 @router.get("/v2/partials/settings/data-export", response_class=HTMLResponse)

--- a/app/templates/htmx/partials/settings/_unmatched_activities.html
+++ b/app/templates/htmx/partials/settings/_unmatched_activities.html
@@ -1,0 +1,86 @@
+{# _unmatched_activities.html — Unmatched-activity review card (Data Ops, admin only).
+   Receives: unmatched_activities (list[ActivityLog]; company_id/vendor_card_id/
+   dismissed_at all NULL, newest first, capped at 30), unmatched_count (int, total
+   non-dismissed unmatched rows, not just the page shown).
+   Called by: app/routers/htmx/settings.py data_ops_unmatched_activities (initial
+   lazy load) and the attribute/dismiss routes below it, all of which re-render this
+   same card into #unmatched-activities-card so the acted-on row drops in place.
+   Depends on: HTMX, Tailwind CSS. Two plain id-input forms per row (no reusable
+   company/vendor typeahead exists in the Data-Ops/dedup surfaces to reuse — see
+   task-1-report.md) — the simplest faithful control per the brief.
+#}
+<div class="bg-white border border-line-base rounded-lg overflow-hidden">
+  <div class="px-4 py-3 bg-gray-50 border-b flex items-center justify-between">
+    <h2 class="text-lg font-semibold text-gray-900">
+      Unmatched Activity <span class="text-xs font-normal text-gray-500">&middot; {{ unmatched_count }}</span>
+    </h2>
+    <button hx-get="/v2/partials/data-ops/unmatched-activities"
+            hx-target="#unmatched-activities-card"
+            hx-swap="innerHTML"
+            hx-push-url="false"
+            class="px-3 py-1 text-xs font-medium text-accent-600 border border-accent-200 rounded hover:bg-accent-50">
+      Refresh
+    </button>
+  </div>
+
+  {% if unmatched_activities %}
+  <div class="divide-y divide-gray-100">
+    {% for a in unmatched_activities %}
+    <div class="px-4 py-3 flex items-start justify-between gap-4 flex-wrap" data-activity="{{ a.id }}">
+      <div class="min-w-0">
+        <div class="flex items-center gap-2 text-xs flex-wrap">
+          <span class="text-gray-500">{{ a.created_at.strftime('%b %d, %Y') if a.created_at else '—' }}</span>
+          <span class="px-1.5 py-0.5 uppercase tracking-wide rounded bg-gray-100 text-gray-600">{{ a.channel }}</span>
+          <span class="text-gray-400">&middot;</span>
+          <span class="text-gray-600">{{ a.activity_type }}</span>
+        </div>
+        <p class="text-sm font-medium text-gray-900 mt-0.5">{{ a.subject or '(no subject)' }}</p>
+        <p class="text-xs text-gray-600 mt-0.5">
+          {{ a.contact_name or 'Unknown contact' }}{% if a.contact_email %} &middot; {{ a.contact_email }}{% endif %}{% if a.contact_phone %} &middot; {{ a.contact_phone }}{% endif %}
+        </p>
+      </div>
+      <div class="flex flex-col gap-1.5 shrink-0 items-stretch">
+        <form hx-post="/v2/partials/data-ops/unmatched-activities/{{ a.id }}/attribute"
+              hx-target="#unmatched-activities-card"
+              hx-swap="innerHTML"
+              class="flex items-center gap-1">
+          <input type="hidden" name="entity_type" value="company">
+          <input type="number" name="entity_id" min="1" required placeholder="Company #"
+                 aria-label="Attribute to company id"
+                 class="w-24 rounded border border-gray-300 px-2 py-1 text-xs">
+          <button type="submit" data-loading-disable
+                  class="px-2 py-1 text-xs rounded bg-white text-accent-600 border border-accent-200 hover:bg-accent-50 whitespace-nowrap">
+            Attribute
+          </button>
+        </form>
+        <form hx-post="/v2/partials/data-ops/unmatched-activities/{{ a.id }}/attribute"
+              hx-target="#unmatched-activities-card"
+              hx-swap="innerHTML"
+              class="flex items-center gap-1">
+          <input type="hidden" name="entity_type" value="vendor">
+          <input type="number" name="entity_id" min="1" required placeholder="Vendor #"
+                 aria-label="Attribute to vendor id"
+                 class="w-24 rounded border border-gray-300 px-2 py-1 text-xs">
+          <button type="submit" data-loading-disable
+                  class="px-2 py-1 text-xs rounded bg-white text-accent-600 border border-accent-200 hover:bg-accent-50 whitespace-nowrap">
+            Attribute
+          </button>
+        </form>
+        <button type="button" data-loading-disable
+                hx-post="/v2/partials/data-ops/unmatched-activities/{{ a.id }}/dismiss"
+                hx-target="#unmatched-activities-card"
+                hx-swap="innerHTML"
+                hx-confirm="Dismiss this activity? It will be hidden from the unmatched queue."
+                class="px-2 py-1 text-xs rounded bg-white text-gray-500 border border-gray-300 hover:bg-gray-50">
+          Dismiss
+        </button>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="px-4 py-8 text-center">
+    <p class="text-sm text-gray-600">No unmatched activity.</p>
+  </div>
+  {% endif %}
+</div>

--- a/app/templates/htmx/partials/settings/data_ops.html
+++ b/app/templates/htmx/partials/settings/data_ops.html
@@ -8,7 +8,18 @@
    Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
 #}
 {% from "htmx/partials/settings/_macros.html" import merge_button, delete_both_button, dismiss_button, mass_action_bar -%}
+{% from "htmx/partials/shared/_macros.html" import lazy_body -%}
 <div class="space-y-6">
+
+  {# ── Unmatched Activity (Phase 2A review queue) — lazy-loaded, same idiom as the
+     Connector Health card (settings/system.html): explicit id so the card's own
+     attribute/dismiss forms can re-target it; hx-push-url="false" because hx-push-url
+     is inherited from the tab nav and a background loader must never rewrite the URL. #}
+  {% call lazy_body(id='unmatched-activities-card', url='/v2/partials/data-ops/unmatched-activities', class_='empty:hidden', indicator='#unmatched-activities-spinner', extra_attrs='hx-push-url="false"') %}
+    <div id="unmatched-activities-spinner" class="htmx-indicator flex items-center justify-center py-4">
+      <svg class="h-5 w-5 text-gray-400 animate-spin" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="31.4" stroke-dashoffset="10"/></svg>
+    </div>
+  {% endcall %}
 
   {# ── Pending OEM Spec-Code Mappings (admin approval queue) ── #}
   <div class="bg-white border border-line-base rounded-lg overflow-hidden">

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -3933,6 +3933,15 @@ merges different-`account_owner_id` accounts) are reused AS-IS.
   clean. **create_company no longer silently stores the AI-typo-corrected name** — it
   keeps the rep's typed name (the AI fix still strengthens the duplicate check), making
   naming suggest-only end-to-end.
+- **Unmatched Activity review card (admin):** a fourth Data Ops card, lazy-loaded via
+  `GET /v2/partials/data-ops/unmatched-activities` (`require_admin`, same gate as the
+  JSON queue in `app/routers/v13_features/activity.py`) using the `lazy_body` idiom
+  (like Connector Health), `hx-push-url="false"` since push-url is inherited from the
+  tab nav. Each row **Attribute**s (to a company or vendor, via
+  `POST .../{activity_id}/attribute`, `activity_service.attribute_activity`) or
+  **Dismiss**es (`POST .../{activity_id}/dismiss`, `dismiss_activity`); both re-render
+  just the card (`_render_unmatched_activities` → `_unmatched_activities.html`) with a
+  toast, never a 500.
 
 ### 10a. Global contact lists + vendor stock-list upload UI
 

--- a/docs/superpowers/2026-07-04-common-sense-audit-findings.md
+++ b/docs/superpowers/2026-07-04-common-sense-audit-findings.md
@@ -11,7 +11,7 @@ Status key: ⬜ todo · 🔵 building · ✅ done+deployed
 - ✅ **All 9 HIGH** (4 dead controls + 5 slow-sync hangs) done + live.
 - ✅ **All 7 slow-sync** → background+poll/SSE; **all 7 CSV exports** (shared helper + CSV-injection security fix); **6 empty states**; the dead-control mediums; **bulk actions** (resell per-line, sightings assign+refresh); **density D/E/F + toolbars L/M/N + prospecting/CRM bars**.
 - 🔵 **In flight (final cleanup):** dossier Live-market sort (wire the orphaned `/v2/partials/search/filter`) + buy-plans hub `<title>` disambiguation.
-- ⏸ **Deferred (decision-adjacent, NOT autonomous):** prospecting bulk claim/dismiss (build with idea **O**); approvals bulk-approve (approval-adjacent — respects "leave Approvals unchanged"); resell demote-triage-cards-to-KPI (would undo the recent triage-card filter fix — skip); parts dead undo-archive toast (LOW nit, parts/list.html allowlist-sensitive — low value).
+- ⏸ **Deferred (decision-adjacent, NOT autonomous):** prospecting bulk claim/dismiss (build with idea **O**); ~~approvals bulk-approve (approval-adjacent — respects "leave Approvals unchanged")~~ **CLOSED 2026-08-28 (dropped, Decision H — Deal Sheet j/k + auto-advance covers it)**; resell demote-triage-cards-to-KPI (would undo the recent triage-card filter fix — skip); parts dead undo-archive toast (LOW nit, parts/list.html allowlist-sensitive — low value).
 
 ## 🔴 HIGH (9)
 
@@ -64,7 +64,7 @@ Status key: ⬜ todo · 🔵 building · ✅ done+deployed
 - ⬜ Approvals Halted lane always rendered (min-h-120) even empty → dead 4th column. `approvals/_surface_pipeline.html:55,75-88`
 - ⬜ Sightings: no bulk "Assign to buyer" though `POST /…/batch-assign` exists (orphaned). `table.html:358`, `sightings.py:1157`
 - ⬜ Resell: no CSV export of collected offers / outreach tracker. `resell/_offers.html:67-199`
-- ⬜ Approvals: no multi-select bulk-approve on pending queues. `approvals/_tab_buy_plan.html:24-61`
+- ~~⬜ Approvals: no multi-select bulk-approve on pending queues. `approvals/_tab_buy_plan.html:24-61`~~ **CLOSED 2026-08-28 (dropped, Decision H — Deal Sheet j/k + auto-advance covers it)**
 - ⬜ Requisitions list: no CSV export. `requisitions/list.html:24`
 - ⬜ Vendors list / contacts: no CSV export or bulk actions. `vendors/list.html:18`
 - ⬜ Two pages both titled "Approvals" (/v2/approvals vs /v2/buy-plans) — give buy-plans hub its own `<title>`. `buy_plans/hub.html:12`

--- a/docs/superpowers/2026-07-05-unfinished-work-inventory.md
+++ b/docs/superpowers/2026-07-05-unfinished-work-inventory.md
@@ -36,7 +36,7 @@ Tracking docs understate completion; APP_MAP missing migration 185 (`requirement
 - **Idea I** (buy-plan line editing) — folds into the buy-plan epic (next).
 - **Idea C** (score/price hover) — decided (deterministic factor breakdown); build after buy-plan.
 - **SP4 manual "Park in prospecting" UI** — never built (auto-sweep backbone exists).
-- **Approvals bulk-approve** — parked under "leave Approvals unchanged".
+- ~~**Approvals bulk-approve** — parked under "leave Approvals unchanged".~~ **CLOSED 2026-08-28 (dropped, Decision H — Deal Sheet j/k + auto-advance covers it)**
 
 ## 🛣 ROADMAP (multi-day / post-go-live)
 API-search Phases 1-4 (product core; Phase 1 is the highest-confidence next batch); HIGH-BE-11 (`db.query()`→2.0, ~1,561 callsites — land a lint guard first, migrate in waves); HIGH-SEC-4 (Graph-webhook IP allowlist); CRM redesign Phases 1-6; vendor-API parametric enrichment (MOSFET extractor, blocked on inventory); calendar delta sync; KB insight refresh (disabled for AI cost).

--- a/specs/approvals-workspace.md
+++ b/specs/approvals-workspace.md
@@ -126,4 +126,4 @@ All four tabs usable first (display + approve/reject/verify/prepay, incl. the li
 5. QP-sales fields optional at submit; manager completes at approval.
 6. Notes reuse ActivityLog manual notes if the pattern fits; sales keeps notes while pending.
 7. Payment method is picked by the buyer at confirm-PO (wire / PayPal / credit card / ACH / COD); COD lines are excluded from prepayment and the risk lane.
-8. **Deferred, in writing:** repair-service TPOs (handled outside for now); bulk approve/verify actions; buyer sibling-line context beyond a "line N of M · partial-ship yes/no" flag on the card; Myrna/Katy in-app approve rights.
+8. **Deferred, in writing:** repair-service TPOs (handled outside for now); buyer sibling-line context beyond a "line N of M · partial-ship yes/no" flag on the card; Myrna/Katy in-app approve rights. *(Bulk approve/verify actions dropped 2026-08-28, Decision H: Deal Sheet j/k + auto-advance covers it.)*

--- a/tests/test_unmatched_activities_ui.py
+++ b/tests/test_unmatched_activities_ui.py
@@ -202,12 +202,18 @@ class TestAttribute:
         assert resp.status_code == 200
         assert f'data-activity="{a.id}"' in resp.text
 
-    def test_attribute_nonexistent_activity_is_friendly(self, admin_client, db_session):
+    def test_attribute_nonexistent_activity_is_friendly(self, admin_client, db_session, test_company):
         resp = admin_client.post(
             f"{CARD_URL}/999999/attribute",
-            data={"entity_type": "company", "entity_id": "1"},
+            data={"entity_type": "company", "entity_id": str(test_company.id)},
         )
         assert resp.status_code == 200
+        # Friendly toast naming the activity, not a 500 or bare error page.
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "Activity not found." in trigger
+        assert '"type": "error"' in trigger
+        # The card itself still renders (heading is always present, with rows or not).
+        assert "Unmatched Activity" in resp.text
 
 
 # ── (e) POST dismiss sets dismissed_at and removes the row ─────────────
@@ -228,3 +234,9 @@ class TestDismiss:
     def test_dismiss_nonexistent_is_friendly(self, admin_client, db_session):
         resp = admin_client.post(f"{CARD_URL}/999999/dismiss")
         assert resp.status_code == 200
+        # Friendly toast naming the activity, not a 500 or bare error page.
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "Activity not found." in trigger
+        assert '"type": "error"' in trigger
+        # The card itself still renders (heading is always present, with rows or not).
+        assert "Unmatched Activity" in resp.text

--- a/tests/test_unmatched_activities_ui.py
+++ b/tests/test_unmatched_activities_ui.py
@@ -1,0 +1,230 @@
+"""tests/test_unmatched_activities_ui.py — Data-Ops unmatched-activity review card
+(HTMX).
+
+Covers the thin HTMX UI over the existing Phase 2A unmatched-activity queue service
+(app/services/activity_service.py get_unmatched_activities / count_unmatched_activities /
+attribute_activity / dismiss_activity): the lazy-loaded card partial, the attribute-to-
+company/vendor forms, and the dismiss action — mounted on the Settings Data-Ops tab
+alongside the vendor/company/contact dedup sections.
+
+Called by: pytest
+Depends on: conftest.py fixtures (admin_user, test_user, test_company, test_vendor_card,
+    db_session), app.routers.htmx.settings, app.models.ActivityLog
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models import ActivityLog
+
+CARD_URL = "/v2/partials/data-ops/unmatched-activities"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_client(db_session, user):
+    """Return a TestClient authenticated as *user* (mirrors
+    test_unmatched_activities.py)."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    def _override_user():
+        return user
+
+    def _override_buyer():
+        return user
+
+    def _override_admin():
+        if user.role != "admin":
+            from fastapi import HTTPException
+
+            raise HTTPException(403, "Admin access required")
+        return user
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = _override_user
+    app.dependency_overrides[require_buyer] = _override_buyer
+    app.dependency_overrides[require_admin] = _override_admin
+
+    try:
+        client = TestClient(app)
+        yield client
+    finally:
+        for dep in [get_db, require_user, require_buyer, require_admin]:
+            app.dependency_overrides.pop(dep, None)
+
+
+@pytest.fixture()
+def admin_client(db_session, admin_user):
+    yield from _make_client(db_session, admin_user)
+
+
+@pytest.fixture()
+def buyer_client(db_session, test_user):
+    yield from _make_client(db_session, test_user)
+
+
+def _make_unmatched(db_session, user_id, email="unknown@x.com", ext_id="ui-1", subject="Stock offer"):
+    a = ActivityLog(
+        user_id=user_id,
+        activity_type="email_received",
+        channel="email",
+        company_id=None,
+        vendor_card_id=None,
+        contact_email=email,
+        contact_name="Random Person",
+        subject=subject,
+        external_id=ext_id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(a)
+    db_session.commit()
+    return a
+
+
+# ── (a) admin GET renders a seeded unmatched activity + count ──────────
+
+
+class TestCardRender:
+    def test_admin_get_renders_activity_and_count(self, admin_client, db_session, admin_user):
+        a = _make_unmatched(db_session, admin_user.id)
+
+        resp = admin_client.get(CARD_URL)
+        assert resp.status_code == 200
+        html = resp.text
+        assert "Stock offer" in html
+        assert "unknown@x.com" in html
+        assert f'data-activity="{a.id}"' in html
+        # count badge reflects the single seeded row
+        assert "1" in html
+
+    # ── (f) empty queue → "No unmatched activity" state ─────────────
+
+    def test_empty_queue_renders_empty_state(self, admin_client, db_session):
+        resp = admin_client.get(CARD_URL)
+        assert resp.status_code == 200
+        assert "No unmatched activity" in resp.text
+
+
+# ── (b) non-admin GET → 403 ─────────────────────────────────────────────
+
+
+class TestAdminGate:
+    def test_non_admin_get_forbidden(self, buyer_client, db_session, test_user):
+        _make_unmatched(db_session, test_user.id)
+
+        resp = buyer_client.get(CARD_URL)
+        assert resp.status_code == 403
+
+    def test_non_admin_attribute_forbidden(self, buyer_client, db_session, test_user):
+        a = _make_unmatched(db_session, test_user.id)
+
+        resp = buyer_client.post(
+            f"{CARD_URL}/{a.id}/attribute",
+            data={"entity_type": "company", "entity_id": "1"},
+        )
+        assert resp.status_code == 403
+
+    def test_non_admin_dismiss_forbidden(self, buyer_client, db_session, test_user):
+        a = _make_unmatched(db_session, test_user.id)
+
+        resp = buyer_client.post(f"{CARD_URL}/{a.id}/dismiss")
+        assert resp.status_code == 403
+
+
+# ── (c) POST attribute with a valid company id ──────────────────────────
+
+
+class TestAttribute:
+    def test_attribute_to_valid_company_removes_row(self, admin_client, db_session, admin_user, test_company):
+        a = _make_unmatched(db_session, admin_user.id)
+
+        resp = admin_client.post(
+            f"{CARD_URL}/{a.id}/attribute",
+            data={"entity_type": "company", "entity_id": str(test_company.id)},
+        )
+        assert resp.status_code == 200
+        assert f'data-activity="{a.id}"' not in resp.text
+        assert "No unmatched activity" in resp.text
+
+        db_session.refresh(a)
+        assert a.company_id == test_company.id
+        assert a.vendor_card_id is None
+
+    def test_attribute_to_valid_vendor_removes_row(self, admin_client, db_session, admin_user, test_vendor_card):
+        a = _make_unmatched(db_session, admin_user.id, ext_id="ui-2")
+
+        resp = admin_client.post(
+            f"{CARD_URL}/{a.id}/attribute",
+            data={"entity_type": "vendor", "entity_id": str(test_vendor_card.id)},
+        )
+        assert resp.status_code == 200
+        assert f'data-activity="{a.id}"' not in resp.text
+
+        db_session.refresh(a)
+        assert a.vendor_card_id == test_vendor_card.id
+        assert a.company_id is None
+
+    # ── (d) POST attribute with a nonexistent entity id → friendly error, no 500 ──
+
+    def test_attribute_nonexistent_company_is_friendly(self, admin_client, db_session, admin_user):
+        a = _make_unmatched(db_session, admin_user.id, ext_id="ui-3")
+
+        resp = admin_client.post(
+            f"{CARD_URL}/{a.id}/attribute",
+            data={"entity_type": "company", "entity_id": "999999"},
+        )
+        assert resp.status_code == 200
+        # The row is still present — attribution did not silently succeed.
+        assert f'data-activity="{a.id}"' in resp.text
+
+        db_session.refresh(a)
+        assert a.company_id is None
+
+    def test_attribute_invalid_entity_type_is_friendly(self, admin_client, db_session, admin_user):
+        a = _make_unmatched(db_session, admin_user.id, ext_id="ui-4")
+
+        resp = admin_client.post(
+            f"{CARD_URL}/{a.id}/attribute",
+            data={"entity_type": "bogus", "entity_id": "1"},
+        )
+        assert resp.status_code == 200
+        assert f'data-activity="{a.id}"' in resp.text
+
+    def test_attribute_nonexistent_activity_is_friendly(self, admin_client, db_session):
+        resp = admin_client.post(
+            f"{CARD_URL}/999999/attribute",
+            data={"entity_type": "company", "entity_id": "1"},
+        )
+        assert resp.status_code == 200
+
+
+# ── (e) POST dismiss sets dismissed_at and removes the row ─────────────
+
+
+class TestDismiss:
+    def test_dismiss_removes_row_and_sets_timestamp(self, admin_client, db_session, admin_user):
+        a = _make_unmatched(db_session, admin_user.id, ext_id="ui-5")
+
+        resp = admin_client.post(f"{CARD_URL}/{a.id}/dismiss")
+        assert resp.status_code == 200
+        assert f'data-activity="{a.id}"' not in resp.text
+        assert "No unmatched activity" in resp.text
+
+        db_session.refresh(a)
+        assert a.dismissed_at is not None
+
+    def test_dismiss_nonexistent_is_friendly(self, admin_client, db_session):
+        resp = admin_client.post(f"{CARD_URL}/999999/dismiss")
+        assert resp.status_code == 200


### PR DESCRIPTION
Phase 3 (do-all plan) data-ops stream. **Merge is owner-gated — do not merge without the owner's word.**

## What

1. **Unmatched-activity review card** (admin-only, Settings → Data Ops): the shipped-but-invisible backend (`/api/activities/unmatched` + attribute/dismiss) finally gets a surface — lazy-loaded card listing unattributed activities (30 shown, true-total badge) with per-row attribute-to-company/vendor and dismiss, friendly-toast errors, same `require_admin` gate as the JSON endpoints (which are untouched, tests intact).
2. **Decision H executed (docs-only):** bulk approve/verify was never built — struck the deferral entries in `specs/approvals-workspace.md` + two docs/superpowers inventories (history preserved as CLOSED). Zero code changes in that commit; the Deal Sheet bulk LINE editor is untouched. j/k + auto-advance is the sanctioned substitute.

## Evidence

- Full suite in worktree: `24604 passed, 35 skipped, 0 FAILED in 558s`
- 12 new UI tests (TDD, RED-first) + 21 untouched JSON tests green; task review + final whole-branch review clean (admin gate / autoescape-XSS / CSRF posture all verified on inspection); deferred minors listed in the review are test-quality nits only.

## Post-deploy check

Settings → Data Ops as admin: unmatched card renders with count; attribute a row to a company → row leaves the list, ActivityLog gains company_id; dismiss a row → gone; non-admin sees no card data (403 partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkHRARudqRbahKpsFDmUQa