### PR TITLE
Quotes Tranche B: send dialog, honest preview, preflight everywhere, sane seeding, customer-safe copy

### DIFF
--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -382,7 +382,8 @@ async def quote_preflight_check(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Advisory pre-send checks (DNC recipient / non-US country-of-origin / MPN drift).
+    """Advisory pre-send checks (DNC recipient / non-US country-of-origin / MPN drift /
+    zero-margin pricing).
 
     Read-only; returns the warnings the send UI surfaces. Advisory only — it never
     blocks the send (the salesperson decides). See app/services/quote_preflight.py.

--- a/app/routers/htmx/offers/crud.py
+++ b/app/routers/htmx/offers/crud.py
@@ -33,7 +33,8 @@ from ....models.intelligence import ChangeLog
 from ....services.activity_service import log_activity as _log_activity
 from ....services.ai_offer_service import parse_offer_form_rows, save_form_parsed_offers
 from ....services.offer_qualification import apply_qualification, normalize_offer_condition
-from ....services.quote_builder_service import recalc_quote_totals
+from ....services.pricing_history import preload_last_quoted_prices
+from ....services.quote_builder_service import recalc_quote_totals, seed_sell_price
 from ....services.status_machine import require_valid_transition
 from ....utils.normalization import normalize_mpn_key
 from ....vendor_utils import normalize_vendor_name
@@ -257,8 +258,18 @@ async def create_quote_from_offers(
     db.add(quote)
     db.flush()
 
+    # Preload pricing history once for the batch (avoids an N+1 preload per offer) — the
+    # same seed_sell_price rule the Build-Quote tab and the other two quote-line creation
+    # routes use: last-quoted price wins, else cost × DEFAULT_MARKUP_PCT.
+    try:
+        quoted_prices = preload_last_quoted_prices(db)
+    except Exception as e:
+        logger.warning("Pricing history unavailable seeding quote {}: {} — sells fall back to markup", quote_number, e)
+        quoted_prices = {}
+
     for o in offers:
-        sell_price = float(o.unit_price or 0)
+        cost = float(o.unit_price or 0)
+        sell, margin_pct = seed_sell_price(db, o.mpn, cost, last_quoted=quoted_prices)
 
         line = QuoteLine(
             quote_id=quote.id,
@@ -266,9 +277,9 @@ async def create_quote_from_offers(
             mpn=o.mpn or "",
             manufacturer=o.manufacturer or "",
             qty=o.qty_available or 1,
-            cost_price=sell_price,  # Default cost = sell, buyer adjusts
-            sell_price=sell_price,
-            margin_pct=0.0,
+            cost_price=cost,
+            sell_price=sell,
+            margin_pct=margin_pct,
         )
         db.add(line)
 

--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -36,6 +36,7 @@ from ...models import (
 )
 from ...services.crm_service import quote_base_number, revision_quote_number
 from ...services.quote_builder_service import recalc_quote_totals
+from ...services.quote_preflight import quote_preflight
 from ...services.quote_requisitions import (
     link_quote_to_requisitions,
     requisition_ids_for_quote,
@@ -304,6 +305,9 @@ async def quote_detail_partial(
             "lines": lines,
             "offers": offers,
             "contributing_reqs": requisitions_for_quote(db, quote.id),
+            # Advisory pre-send checks (DNC / non-US COO / MPN drift). Only meaningful
+            # pre-send, so scoped to drafts — never blocks (see services/quote_preflight.py).
+            "preflight_warnings": [w.to_dict() for w in quote_preflight(db, quote)] if quote.status == "draft" else [],
         }
     )
     return template_response("htmx/partials/quotes/detail.html", ctx)

--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -17,6 +17,7 @@ from datetime import UTC, date, datetime, timedelta
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from loguru import logger
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload
 
 from ...constants import (
@@ -35,7 +36,8 @@ from ...models import (
     User,
 )
 from ...services.crm_service import quote_base_number, revision_quote_number
-from ...services.quote_builder_service import recalc_quote_totals
+from ...services.pricing_history import preload_last_quoted_prices
+from ...services.quote_builder_service import recalc_quote_totals, seed_sell_price
 from ...services.quote_preflight import quote_preflight
 from ...services.quote_requisitions import (
     link_quote_to_requisitions,
@@ -430,15 +432,17 @@ async def add_offer_to_quote(
             status_code=403,
             detail={"error": "offer does not belong to this quote's requisition"},
         )
+    cost = float(offer.unit_price) if offer.unit_price else 0
+    sell, margin_pct = seed_sell_price(db, offer.mpn, cost)
     line = QuoteLine(
         quote_id=quote_id,
         offer_id=offer_id,
         mpn=offer.mpn,
         manufacturer=offer.manufacturer,
         qty=offer.qty_available or 0,
-        cost_price=float(offer.unit_price) if offer.unit_price else 0,
-        sell_price=0,
-        margin_pct=0,
+        cost_price=cost,
+        sell_price=sell,
+        margin_pct=margin_pct,
     )
     db.add(line)
     recalc_quote_totals(db, quote)
@@ -633,11 +637,24 @@ async def add_offers_to_draft_quote(
         raise HTTPException(400, "Can only add to draft quotes")
 
     offers = db.query(Offer).filter(Offer.id.in_(offer_ids), Offer.requisition_id == req_id).all()
+
+    # Preload pricing history once for the batch (avoids an N+1 preload per offer) — the
+    # same seed_sell_price rule the Build-Quote tab and the other two quote-line creation
+    # routes use: last-quoted price wins, else cost × DEFAULT_MARKUP_PCT.
+    try:
+        quoted_prices = preload_last_quoted_prices(db)
+    except SQLAlchemyError as e:
+        logger.warning(
+            "Pricing history unavailable seeding quote {}: {} — sells fall back to markup", quote.quote_number, e
+        )
+        quoted_prices = {}
+
     for o in offers:
         existing = db.query(QuoteLine).filter(QuoteLine.quote_id == quote_id, QuoteLine.offer_id == o.id).first()
         if existing:
             continue
-        sell_price = float(o.unit_price or 0)
+        cost = float(o.unit_price or 0)
+        sell, margin_pct = seed_sell_price(db, o.mpn, cost, last_quoted=quoted_prices)
         qty = o.qty_available or 1
         line = QuoteLine(
             quote_id=quote.id,
@@ -645,9 +662,9 @@ async def add_offers_to_draft_quote(
             mpn=o.mpn or "",
             manufacturer=o.manufacturer or "",
             qty=qty,
-            cost_price=sell_price,
-            sell_price=sell_price,
-            margin_pct=0.0,
+            cost_price=cost,
+            sell_price=sell,
+            margin_pct=margin_pct,
         )
         db.add(line)
 

--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -55,7 +55,7 @@ from ...services.quote_send import (
 )
 from ...services.status_machine import require_valid_transition
 from ...template_env import template_response
-from ._shared import _base_ctx, _parse_date_safe, toast_error_response
+from ._shared import _base_ctx, _parse_date_safe, set_toast, toast_error_response
 
 router = APIRouter(tags=["htmx-views"])
 
@@ -479,10 +479,47 @@ async def add_offer_to_quote(
     return template_response("htmx/partials/quotes/line_row.html", ctx)
 
 
+@router.get("/v2/partials/quotes/{quote_id}/send-dialog", response_class=HTMLResponse)
+async def send_quote_dialog(
+    request: Request,
+    quote_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Render the Send Quote dialog (Task 4/B1): editable recipient + CC + preflight.
+
+    Loaded into #modal-content by $dispatch('open-modal', {url: ...}) from the quote
+    detail / Build-Quote action bars — replaces the old hx-confirm. Recipient resolution
+    mirrors send_quote_email's default (site.contact_email/contact_name), prefilled as
+    editable override_email/override_name inputs so the sender can redirect the quote or
+    add a CC without leaving the dialog. The subject reuses build_quote_subject (Task 3)
+    and preflight_warnings reuses quote_preflight (Task 1) so neither can drift from what
+    the detail page and the real send show.
+    """
+    quote = get_quote_for_user(db, user, quote_id)
+    site = db.get(CustomerSite, quote.customer_site_id) if quote.customer_site_id else None
+    to_email = (site.contact_email or "").strip() if site else ""
+    to_name = ((site.contact_name if site else "") or "").strip()
+    return template_response(
+        "htmx/partials/quotes/_send_dialog.html",
+        {
+            "request": request,
+            "quote": quote,
+            "to_email": to_email,
+            "to_name": to_name,
+            "subject": build_quote_subject(quote),
+            "preflight_warnings": [w.to_dict() for w in quote_preflight(db, quote)],
+        },
+    )
+
+
 @router.post("/v2/partials/quotes/{quote_id}/send", response_class=HTMLResponse)
 async def send_quote_htmx(
     request: Request,
     quote_id: int,
+    override_email: str | None = Form(None),
+    override_name: str | None = Form(None),
+    cc: str | None = Form(None),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -491,6 +528,10 @@ async def send_quote_htmx(
     Delegates to the canonical quote-send service so this button actually emails the
     customer (captures Graph ids, writes an outbound ActivityLog, hard-blocks DNC). In
     TESTING the service skips the real Graph call but still marks the quote sent.
+
+    override_email/override_name/cc (Task 4/B1) come from the send dialog and are all
+    optional — a request with none of them (the legacy hx-confirm button, or any other
+    caller) resolves the recipient exactly as before.
     """
     quote = get_quote_for_user(db, user, quote_id)
     testing = os.environ.get("TESTING") == "1"
@@ -502,7 +543,16 @@ async def send_quote_htmx(
 
         token = await require_fresh_token(request, db)
     try:
-        await send_quote_email(db, quote, user, token=token, testing=testing)
+        result = await send_quote_email(
+            db,
+            quote,
+            user,
+            token=token,
+            override_email=override_email,
+            override_name=override_name,
+            cc=cc,
+            testing=testing,
+        )
     except QuoteSendDNCBlocked:
         # Surface the failure as a toast WITHOUT swapping — the Send buttons
         # (quotes/detail.html, requisitions/tabs/build_quote.html) target #main-content,
@@ -512,7 +562,8 @@ async def send_quote_htmx(
         return toast_error_response("This recipient is do-not-contact — quote not sent.")
     except QuoteSendError as exc:
         return toast_error_response(exc.detail)
-    return await quote_detail_partial(request, quote_id, user, db)
+    resp = await quote_detail_partial(request, quote_id, user, db)
+    return set_toast(resp, f"Quote {quote.quote_number} sent to {result.sent_to}", "success")
 
 
 @router.post("/v2/partials/quotes/{quote_id}/result", response_class=HTMLResponse)

--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -47,6 +47,8 @@ from ...services.quote_requisitions import (
 from ...services.quote_send import (
     QuoteSendDNCBlocked,
     QuoteSendError,
+    _build_quote_email_html,
+    build_quote_subject,
     quote_valid_until,
     send_quote_email,
     validity_days_from_valid_until,
@@ -68,12 +70,36 @@ async def preview_quote(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Render quote email preview before sending."""
+    """Render the quote email preview — the EXACT html the Send button would email.
+
+    Renders _build_quote_email_html (quote_send.py), the single home of the email
+    builder, so preview and send can never drift (Task B2). Recipient resolution mirrors
+    send_quote_email's (site.contact_email/contact_name) — no override here since this
+    button posts no body. A site with no resolvable contact email still renders (200):
+    the shell shows a "no recipient resolved" note instead of a To: line, same as the
+    JSON preview endpoint's no-recipient handling (routers/crm/quotes.py:358).
+    """
     quote = get_quote_for_user(db, user, quote_id, options=[joinedload(Quote.quote_lines)])
+
+    site = db.get(CustomerSite, quote.customer_site_id) if quote.customer_site_id else None
+    to_email = (site.contact_email or "").strip() if site else ""
+    to_name = ((site.contact_name if site else "") or "").strip()
+    company_name = site.company.name if site and site.company else ""
+
+    email_html = _build_quote_email_html(quote, to_name, company_name, user)
+    subject = build_quote_subject(quote)
+    to_display = f"{to_name} <{to_email}>" if to_name else to_email
 
     return template_response(
         "htmx/partials/quotes/preview.html",
-        {"request": request, "quote": quote, "valid_until_date": quote_valid_until(quote)},
+        {
+            "request": request,
+            "quote": quote,
+            "email_html": email_html,
+            "to_email": to_email,
+            "to_display": to_display,
+            "subject": subject,
+        },
     )
 
 

--- a/app/services/pricing_history.py
+++ b/app/services/pricing_history.py
@@ -125,6 +125,10 @@ def preload_last_quoted_prices(db: Session) -> dict[str, dict]:
     for q in quotes:
         date_str = quote_date_iso(q)
         for item in q.line_items or []:
+            # Malformed legacy line_items can carry a non-dict entry — skip it rather
+            # than raise (mirrors the same guard in quote_preflight._quote_line_pricing).
+            if not isinstance(item, dict):
+                continue
             entry = {
                 "sell_price": item.get("sell_price"),
                 "margin_pct": item.get("margin_pct"),

--- a/app/services/quote_builder_service.py
+++ b/app/services/quote_builder_service.py
@@ -242,6 +242,56 @@ def get_builder_data(
     return lines
 
 
+def seed_sell_price(
+    db: Session,
+    mpn: str | None,
+    cost: float | None,
+    *,
+    markup_pct: float = DEFAULT_MARKUP_PCT,
+    last_quoted: dict[str, dict] | None = None,
+) -> tuple[float | None, float | None]:
+    """Seed a sell price + margin_pct for ONE new quote line — THE ONE seeding rule.
+
+    Last-quoted price for *mpn* wins when pricing history exists
+    (``preload_last_quoted_prices``); otherwise falls back to ``cost * (1 + markup_pct /
+    100)``. Returns ``(sell, margin_pct)`` — margin_pct computed the SAME way
+    ``margin_guardrail`` / ``quote_export_context`` already do (``(sell - cost) / sell *
+    100``), never a new formula. Returns ``(None, None)`` when there is neither history nor
+    a cost to seed from.
+
+    *last_quoted* lets a caller looping over many lines preload once
+    (``preload_last_quoted_prices``) and pass the SAME dict to every call, avoiding an N+1
+    query per line; omit it for a one-off call and this loads it itself (best-effort — a
+    lookup failure falls through to the markup branch, same as ``build_quote_tab_data``).
+
+    Extracted from ``build_quote_tab_data``'s inline seeding math (the ONE place this rule
+    used to live) so the Build-Quote tab AND the three quote-line creation routes (offer-
+    select create-quote, add-offer-to-quote, add-offers-to-draft-quote) compute it once.
+    """
+    if last_quoted is None:
+        try:
+            last_quoted = preload_last_quoted_prices(db)
+        except Exception as e:  # pragma: no cover - best-effort, mirrors existing callers
+            from loguru import logger
+
+            logger.warning("Pricing history unavailable seeding sell price for {}: {} — falling back to markup", mpn, e)
+            last_quoted = {}
+
+    mpn_key = (mpn or "").upper().strip()
+    lq = last_quoted.get(mpn_key)
+    sell = lq.get("sell_price") if lq else None
+
+    if sell is not None:
+        sell = float(sell)
+    elif cost is not None:
+        sell = round(float(cost) * (1 + markup_pct / 100.0), 4)
+    else:
+        return None, None
+
+    margin_pct = round((sell - float(cost)) / sell * 100, 2) if (cost is not None and sell) else None
+    return sell, margin_pct
+
+
 def build_quote_tab_data(
     db: Session,
     req_id: int,
@@ -280,8 +330,6 @@ def build_quote_tab_data(
         logger.warning("Pricing history unavailable for req {}: {} — seeds fall back to markup", req_id, e)
         last_quoted = {}
 
-    markup_factor = 1 + (markup_pct / 100.0)
-
     lines: list[dict] = []
     for r in requirements:
         best = best_costs.get(r.id)
@@ -307,13 +355,18 @@ def build_quote_tab_data(
         ]
         offers.sort(key=lambda o: o["unit_price"])
 
-        # Seed the sell price: last-quoted wins, else best-cost × markup.
+        # Seed the sell price: last-quoted wins, else best-cost × markup — the shared rule
+        # (seed_sell_price), so this tab and the three quote-line creation routes agree.
         lq = last_quoted.get((r.primary_mpn or "").upper().strip())
-        seed = lq.get("sell_price") if lq else None
-        seed_source = "last_quoted" if seed is not None else None
-        if seed is None and best_cost is not None:
-            seed = round(best_cost * markup_factor, 4)
+        if lq and lq.get("sell_price") is not None:
+            seed_source = "last_quoted"
+        elif best_cost is not None:
             seed_source = "markup"
+        else:
+            seed_source = None
+        seed, _seed_margin_pct = seed_sell_price(
+            db, r.primary_mpn, best_cost, markup_pct=markup_pct, last_quoted=last_quoted
+        )
 
         lines.append(
             {

--- a/app/services/quote_preflight.py
+++ b/app/services/quote_preflight.py
@@ -2,10 +2,11 @@
 
 What: ``quote_preflight(db, quote)`` runs deterministic, READ-ONLY checks just before a quote
       email is sent and returns a list of advisory ``PreflightWarning``s. It NEVER blocks the
-      send — the send UI surfaces the warnings and the salesperson decides. Three checks:
+      send — the send UI surfaces the warnings and the salesperson decides. Four checks:
         1. dnc                — recipient site or matching contact is marked Do-Not-Contact
         2. country_of_origin  — a quoted line's sourced offer has a non-US country of origin
         3. mpn_drift          — a quoted MPN is not one the requisition actually asked for
+        4. pricing            — a quoted line is at $0/unset sell or at-or-under cost (B4)
 Called by: app/routers/crm/quotes.py (GET /api/quotes/{id}/preflight; the send/preview UI).
 Depends on: models (Quote, CustomerSite, Offer, Requirement),
             app.services.vendor_reachability.dnc_contact_for_email,
@@ -44,7 +45,7 @@ class PreflightWarning:
     ``level`` is always 'warning' — preflight never errors/blocks.
     """
 
-    code: str  # "dnc" | "country_of_origin" | "mpn_drift"
+    code: str  # "dnc" | "country_of_origin" | "mpn_drift" | "pricing"
     message: str
 
     def to_dict(self) -> dict[str, str]:
@@ -71,6 +72,36 @@ def _quote_line_refs(quote: Quote) -> list[tuple[str | None, int | None]]:
     for item in items:
         if isinstance(item, dict):
             refs.append((item.get("mpn"), item.get("offer_id")))
+    return refs
+
+
+def _quote_line_pricing(quote: Quote) -> list[tuple[str | None, float | None, float | None]]:
+    """Return [(mpn, cost_price, sell_price), ...] for a quote, preferring the
+    structured quote_lines relationship and falling back to the legacy line_items JSON
+    (same dual-path ``_quote_line_refs`` uses, plus the cost/sell each line carries)."""
+    if quote.quote_lines:
+        return [
+            (
+                ql.mpn,
+                float(ql.cost_price) if ql.cost_price is not None else None,
+                float(ql.sell_price) if ql.sell_price is not None else None,
+            )
+            for ql in quote.quote_lines
+        ]
+    refs: list[tuple[str | None, float | None, float | None]] = []
+    raw_items = quote.line_items
+    items = raw_items if isinstance(raw_items, list) else []
+    for item in items:
+        if isinstance(item, dict):
+            cost = item.get("cost_price")
+            sell = item.get("sell_price")
+            refs.append(
+                (
+                    item.get("mpn"),
+                    float(cost) if cost is not None else None,
+                    float(sell) if sell is not None else None,
+                )
+            )
     return refs
 
 
@@ -131,5 +162,20 @@ def quote_preflight(db: Session, quote: Quote) -> list[PreflightWarning]:
     if drift:
         listing = ", ".join(drift[:_MAX_LISTED])
         warnings.append(PreflightWarning("mpn_drift", f"{len(drift)} quoted MPN(s) not on the requisition: {listing}."))
+
+    # 4. Zero-margin pricing — a line quoted at $0/unset sell, or at-or-under its cost (B4).
+    bad_pricing = 0
+    for _mpn, cost, sell in _quote_line_pricing(quote):
+        if sell is None or sell == 0:
+            bad_pricing += 1
+        elif cost is not None and sell <= cost:
+            bad_pricing += 1
+    if bad_pricing:
+        warnings.append(
+            PreflightWarning(
+                "pricing",
+                f"{bad_pricing} line(s) at $0 or ≤ cost — check pricing before sending",
+            )
+        )
 
     return warnings

--- a/app/services/quote_send.py
+++ b/app/services/quote_send.py
@@ -101,6 +101,16 @@ def validity_days_from_valid_until(quote: Quote, target: date) -> int:
     return (target - quote_expiry_anchor(quote)).days
 
 
+def build_quote_subject(quote: Quote) -> str:
+    """The canonical quote email subject line — the SINGLE place it is built.
+
+    Used by send_quote_email (the real send) AND the HTMX preview
+    (routers/htmx/quotes.py) so the two can never drift. Task 4's send dialog reuses
+    this too.
+    """
+    return f"Quote {quote.quote_number} — Trio Supply Chain Solutions"
+
+
 async def send_quote_email(
     db: Session,
     quote: Quote,
@@ -138,7 +148,7 @@ async def send_quote_email(
 
     # 3. Build the branded HTML body.
     html = _build_quote_email_html(quote, to_name, company_name, user)
-    subject = f"Quote {quote.quote_number} — Trio Supply Chain Solutions"
+    subject = build_quote_subject(quote)
 
     # 4. Send via Graph + capture the sent-message ids (skipped in TESTING).
     graph_message_id = None

--- a/app/services/quote_send.py
+++ b/app/services/quote_send.py
@@ -119,6 +119,7 @@ async def send_quote_email(
     token: str,
     override_email: str | None = None,
     override_name: str | None = None,
+    cc: str | None = None,
     testing: bool = False,
 ) -> SendQuoteResult:
     """Email ``quote`` to the customer and record the send.
@@ -126,6 +127,11 @@ async def send_quote_email(
     Resolves the recipient (override else the site contact), hard-blocks DNC recipients,
     sends via Graph (skipped under ``testing``), captures the Graph message ids, advances
     the quote→SENT and requisition→QUOTED, writes an outbound ActivityLog, and commits.
+
+    ``cc`` (Task 4/B1) is an optional comma-separated address string from the send dialog;
+    trimmed minimally (blank/whitespace → no CC) and threaded into the Graph payload as
+    ``ccRecipients`` — never validated against DNC (CC is an internal-side addition, not
+    the customer recipient the DNC hard-block below protects).
 
     Raises QuoteSendDNCBlocked (recipient on DNC) or QuoteSendError (no/invalid recipient,
     Graph error) — neither mutates the quote status.
@@ -157,11 +163,21 @@ async def send_quote_email(
         from ..utils.graph_client import GraphClient, build_sendmail_payload
 
         gc = GraphClient(token)
+        # Minimal trim/validate, matching the brief: blank → no CC. Multiple addresses
+        # (comma-separated, the natural shape for a CC field) are split and passed
+        # through as-is — same idiom as email_service.py's extra_message_fields use
+        # (ccRecipients isn't a build_sendmail_payload param, so it rides in as an extra
+        # top-level message field rather than growing that helper's signature).
+        cc_addresses = [addr.strip() for addr in (cc or "").split(",") if addr.strip()]
+        extra_fields = (
+            {"ccRecipients": [{"emailAddress": {"address": addr}} for addr in cc_addresses]} if cc_addresses else None
+        )
         payload = build_sendmail_payload(
             subject,
             html,
             [{"address": to_email, "name": to_name}],
             save_to_sent="true",
+            extra_message_fields=extra_fields,
         )
         result = await gc.post_json("/me/sendMail", payload, raise_on_error=False)
         if "error" in result:

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -87,6 +87,9 @@ function showToast(message, type = 'info') {
     toast.type = type;
     toast.show = true;
 }
+// Exposed so inline Alpine handlers in Jinja templates (evaluated outside this
+// module's scope) can call it directly — same convention as postJSON/postForm below.
+window.showToast = showToast;
 
 // Append to a capped (last-10) Alpine store log used by trouble tickets.
 function pushCappedLog(storeName, entry) {

--- a/app/templates/htmx/partials/quotes/_send_dialog.html
+++ b/app/templates/htmx/partials/quotes/_send_dialog.html
@@ -1,0 +1,77 @@
+{# _send_dialog.html — Send Quote dialog (Task 4/B1), loaded into #modal-content via
+   $dispatch('open-modal', {url: '/v2/partials/quotes/{id}/send-dialog'}). The base modal
+   renders ✕ / backdrop / Escape.
+   Receives: quote (Quote), to_email/to_name (str — resolved site contact, may be blank),
+             subject (str — build_quote_subject, quote_send.py), preflight_warnings
+             (list[dict] — quote_preflight.py, same shape/idiom as detail.html).
+   POSTs override_email/override_name/cc to the SAME send route the legacy hx-confirm
+   button used (/v2/partials/quotes/{id}/send) — absent/blank fields resolve exactly as
+   before (site contact, no CC). On success the route swaps #main-content with the
+   refreshed quote detail and fires a showToast HX-Trigger naming the recipient; this
+   form only needs to close itself on success (close_modal_on_success), never its own toast.
+   Called by: GET /v2/partials/quotes/{quote_id}/send-dialog
+#}
+{% from "htmx/partials/shared/_macros.html" import close_modal_on_success -%}
+<div class='p-5'>
+  <h3 id="modal-title" class='text-sm font-semibold text-gray-900 mb-1'>Send Quote</h3>
+  <p class='text-secondary mb-4'>{{ quote.quote_number }} &nbsp;&middot;&nbsp; {{ subject }}</p>
+
+  {% if preflight_warnings %}
+  <div class="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2" role="status"
+       aria-label="Quote pre-send advisories">
+    <p class="text-xs font-semibold text-amber-700 flex items-center gap-1">
+      <svg class="h-3.5 w-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+      </svg>
+      Before you send — {{ preflight_warnings|length }} advisory check{{ 's' if preflight_warnings|length != 1 }}
+    </p>
+    <ul class="mt-1 space-y-0.5 pl-5 list-disc">
+      {% for w in preflight_warnings %}
+      <li class="text-xs text-amber-700">{{ w.message }}</li>
+      {% endfor %}
+    </ul>
+    <p class="text-[11px] text-amber-600 mt-1">Advisory only — review, then send if it's correct.</p>
+  </div>
+  {% endif %}
+
+  {% if not to_email %}
+  <p class="mb-3 text-xs text-amber-700 font-medium">
+    No recipient resolved — add a customer contact email below before sending.
+  </p>
+  {% endif %}
+
+  <form hx-post='/v2/partials/quotes/{{ quote.id }}/send'
+        hx-target='#main-content'
+        {{ close_modal_on_success() }}
+        data-loading-disable
+        class='space-y-3'>
+
+    <div class='grid grid-cols-2 gap-2'>
+      <div>
+        <label class='form-label'>Recipient Email</label>
+        <input type='email' name='override_email' value='{{ to_email }}'
+               placeholder='customer@example.com'
+               class='w-full px-3 py-2 border border-gray-300 rounded-lg text-sm input-focus'>
+      </div>
+      <div>
+        <label class='form-label'>Recipient Name</label>
+        <input type='text' name='override_name' value='{{ to_name }}'
+               placeholder='Contact name'
+               class='w-full px-3 py-2 border border-gray-300 rounded-lg text-sm input-focus'>
+      </div>
+    </div>
+
+    <div>
+      <label class='form-label'>CC <span class='text-xs font-normal text-secondary'>— optional, comma-separated</span></label>
+      <input type='text' name='cc' value=''
+             placeholder='sales@trioscs.com, manager@trioscs.com'
+             class='w-full px-3 py-2 border border-gray-300 rounded-lg text-sm input-focus'>
+    </div>
+
+    <div class='flex justify-end gap-2 pt-1'>
+      <button type='button' @click='$dispatch("close-modal")' class='btn btn-ghost btn-md'>Cancel</button>
+      <button type='submit' class='btn btn-primary btn-md'>Send Quote</button>
+    </div>
+  </form>
+</div>

--- a/app/templates/htmx/partials/quotes/_send_dialog.html
+++ b/app/templates/htmx/partials/quotes/_send_dialog.html
@@ -8,10 +8,22 @@
    button used (/v2/partials/quotes/{id}/send) — absent/blank fields resolve exactly as
    before (site contact, no CC). On success the route swaps #main-content with the
    refreshed quote detail and fires a showToast HX-Trigger naming the recipient; this
-   form only needs to close itself on success (close_modal_on_success), never its own toast.
+   form only needs to close itself on success, never its own toast.
+
+   Fix round 1 (B1 follow-up): the route's error paths (DNC block, QuoteSendError) are
+   also 200 OK — toast_error_response sets HX-Reswap: none so the failure toast fires
+   without wiping #main-content — so the shared close_modal_on_success() macro (which
+   closes on ANY htmx "successful" 2xx) would close this dialog on a REJECTED send too,
+   silently discarding the typed override_email/override_name/cc with no retry. This
+   form instead closes only when BOTH htmx's own `successful` flag is true (still a
+   floor against a genuinely-failed request — a network error, an unhandled 500) AND
+   that same HX-Reswap: none header is ABSENT (rules out the documented 200-but-
+   rejected error contract). Any failure — network, 5xx, or the documented DNC/
+   QuoteSendError 200 — leaves the dialog open with the error toast already visible.
+   Route's 200-based error contract is unchanged — other callers of
+   /v2/partials/quotes/{id}/send still get exactly the same response.
    Called by: GET /v2/partials/quotes/{quote_id}/send-dialog
 #}
-{% from "htmx/partials/shared/_macros.html" import close_modal_on_success -%}
 <div class='p-5'>
   <h3 id="modal-title" class='text-sm font-semibold text-gray-900 mb-1'>Send Quote</h3>
   <p class='text-secondary mb-4'>{{ quote.quote_number }} &nbsp;&middot;&nbsp; {{ subject }}</p>
@@ -43,7 +55,7 @@
 
   <form hx-post='/v2/partials/quotes/{{ quote.id }}/send'
         hx-target='#main-content'
-        {{ close_modal_on_success() }}
+        hx-on::after-request="if(event.detail.successful && event.detail.xhr.getResponseHeader('HX-Reswap') !== 'none') this.dispatchEvent(new CustomEvent('close-modal', {bubbles: true}))"
         data-loading-disable
         class='space-y-3'>
 

--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -112,6 +112,28 @@
   </div>
   {% endif %}
 
+  {# Advisory pre-send checks — DNC / non-US country-of-origin / MPN drift. Informational
+     only; the Send button below is never disabled (see services/quote_preflight.py).
+     Copied from build_quote.html's assembled-quote summary card so both surfaces match. #}
+  {% if preflight_warnings and quote.status == 'draft' %}
+  <div class="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2" role="status"
+       aria-label="Quote pre-send advisories">
+    <p class="text-xs font-semibold text-amber-700 flex items-center gap-1">
+      <svg class="h-3.5 w-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+      </svg>
+      Before you send — {{ preflight_warnings|length }} advisory check{{ 's' if preflight_warnings|length != 1 }}
+    </p>
+    <ul class="mt-1 space-y-0.5 pl-5 list-disc">
+      {% for w in preflight_warnings %}
+      <li class="text-xs text-amber-700">{{ w.message }}</li>
+      {% endfor %}
+    </ul>
+    <p class="text-[11px] text-amber-600 mt-1">Advisory only — review, then send if it's correct.</p>
+  </div>
+  {% endif %}
+
   {# Quote actions bar #}
   <div class="mb-6 flex flex-wrap gap-2">
     {% if quote.status == 'draft' %}

--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -241,12 +241,35 @@
         }
       });
       navigator.clipboard.writeText(text).then(() => {
-        window.dispatchEvent(new CustomEvent('toast', {detail: {message: 'Table copied to clipboard', type: 'success'}}));
+        showToast('Table copied to clipboard', 'success');
       });
     "
             class="btn btn-secondary btn-lg inline-flex items-center gap-1.5">
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/></svg>
       Copy Table
+    </button>
+
+    {# Customer-safe copy (B5, Decision E): copies ONLY cells 0,1,2,3,5 — MPN,
+       Description, Manufacturer, Qty, and Sell (relabeled "Price" here so nothing
+       in the header hints at cost/margin). Cell 4 (Cost) and cell 6 (Margin %) are
+       never touched. Guarded by tests/test_quote_copy_table_header.py. #}
+    <button @click="
+      const rows = document.querySelectorAll('#quote-lines-body tr:not(#empty-lines-row)');
+      let text = 'MPN\tDescription\tManufacturer\tQty\tPrice\n';
+      rows.forEach(r => {
+        const cells = r.querySelectorAll('td');
+        if (cells.length >= 6) {
+          const cols = Array.from(cells);
+          text += [cols[0], cols[1], cols[2], cols[3], cols[5]].map(cell => cell.textContent.trim()).join('\t') + '\n';
+        }
+      });
+      navigator.clipboard.writeText(text).then(() => {
+        showToast('Customer table copied to clipboard', 'success');
+      });
+    "
+            class="btn btn-secondary btn-lg inline-flex items-center gap-1.5">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/></svg>
+      Copy for customer
     </button>
 
     <a href="/api/quotes/{{ quote.id }}/pdf" target="_blank" rel="noopener noreferrer"

--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -137,12 +137,9 @@
   {# Quote actions bar #}
   <div class="mb-6 flex flex-wrap gap-2">
     {% if quote.status == 'draft' %}
-    <button hx-post="/v2/partials/quotes/{{ quote.id }}/send"
-            hx-target="#main-content"
-            hx-confirm="Send this quote to the customer?"
-            data-loading-disable
+    <button type="button"
+            @click="$dispatch('open-modal', {url: '/v2/partials/quotes/{{ quote.id }}/send-dialog'})"
             class="btn-primary btn-md">
-      {{ loading_spinner("h-4 w-4 spinner") }}
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
       Send Quote
     </button>

--- a/app/templates/htmx/partials/quotes/preview.html
+++ b/app/templates/htmx/partials/quotes/preview.html
@@ -1,7 +1,10 @@
-{# preview.html — Quote email preview before sending.
-   Receives: quote (Quote with quote_lines loaded).
-   Called by: htmx_views.py preview_quote route.
-   Depends on: Tailwind CSS with brand palette.
+{# preview.html — Quote email preview shell (Phase-3 B2).
+   Renders the EXACT html the Send button emails (_build_quote_email_html,
+   quote_send.py) inside a sandboxed iframe — no second email template, no
+   hand-rolled table/notes/status markup. This IS the send-path output.
+   Receives: quote, email_html (str — the built email body), to_email (str, may be
+             ""), to_display (str — "Name <email>" or just the email/"" ), subject.
+   Called by: routers/htmx/quotes.py preview_quote route.
 #}
 <div class="max-w-3xl mx-auto">
   <div class="bg-white rounded-lg shadow border border-gray-200 p-6">
@@ -10,80 +13,22 @@
       <span class="text-sm text-gray-600">{{ quote.quote_number }}</span>
     </div>
 
-    {# Quote header info #}
-    <div class="bg-gray-50 rounded-lg p-4 mb-4 text-sm">
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <p class="text-xs text-gray-600">Status</p>
-          <p class="font-medium text-gray-900">{{ quote.status|title }}</p>
-        </div>
-        {% if quote.payment_terms %}
-        <div>
-          <p class="text-xs text-gray-600">Payment Terms</p>
-          <p class="text-gray-900">{{ quote.payment_terms }}</p>
-        </div>
-        {% endif %}
-        {% if quote.shipping_terms %}
-        <div>
-          <p class="text-xs text-gray-600">Shipping Terms</p>
-          <p class="text-gray-900">{{ quote.shipping_terms }}</p>
-        </div>
-        {% endif %}
-        {% if valid_until_date %}
-        <div>
-          <p class="text-xs text-gray-600">Valid Until</p>
-          <p class="text-gray-900">{{ valid_until_date.strftime('%B %d, %Y') }}</p>
-        </div>
-        {% endif %}
-        {% if quote.subtotal %}
-        <div>
-          <p class="text-xs text-gray-600">Subtotal</p>
-          <p class="font-medium text-gray-900">${{ "%.2f"|format(quote.subtotal) }}</p>
-        </div>
-        {% endif %}
-      </div>
+    {# Header strip: To / Subject, mirroring what the Send button actually emails. #}
+    <div class="bg-gray-50 rounded-lg p-4 mb-4 text-sm space-y-1">
+      {% if to_email %}
+      <p><span class="text-gray-600">To:</span> <span class="font-medium text-gray-900">{{ to_display }}</span></p>
+      {% else %}
+      <p class="text-amber-700 font-medium">No recipient resolved — add a customer contact email before sending.</p>
+      {% endif %}
+      <p><span class="text-gray-600">Subject:</span> <span class="font-medium text-gray-900">{{ subject }}</span></p>
     </div>
 
-    {# Line items table #}
-    {% if quote.quote_lines %}
-    <table class="min-w-full divide-y divide-gray-200 mb-4">
-      <thead class="bg-gray-50">
-        <tr>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">MPN</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Description</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Mfr</th>
-          <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Qty</th>
-          <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Sell Price</th>
-          <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Line Total</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-200">
-        {% for line in quote.quote_lines %}
-        <tr>
-          <td class="px-3 py-2 text-sm font-mono text-gray-900">{{ line.mpn or '—' }}</td>
-          <td class="px-3 py-2 text-sm text-gray-600">{{ line|part_description or '—' }}</td>
-          <td class="px-3 py-2 text-sm text-gray-600">{{ line.manufacturer or '—' }}</td>
-          <td class="px-3 py-2 text-sm text-right text-gray-900">{{ "{:,}".format(line.qty) if line.qty else '—' }}</td>
-          <td class="px-3 py-2 text-sm text-right text-gray-900">{{ "$%.4f"|format(line.sell_price) if line.sell_price else '—' }}</td>
-          <td class="px-3 py-2 text-sm text-right font-medium text-gray-900">
-            {% if line.qty and line.sell_price %}${{ "%.2f"|format(line.qty * line.sell_price) }}{% else %}—{% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    {% else %}
-    <p class="text-sm text-gray-400 text-center py-4">No line items on this quote.</p>
-    {% endif %}
+    <iframe srcdoc="{{ email_html | e }}"
+            sandbox
+            class="w-full border border-gray-200 rounded-lg"
+            style="min-height:70vh"></iframe>
 
-    {% if quote.notes %}
-    <div class="bg-amber-50 rounded border border-amber-200 p-3 mb-4">
-      <p class="text-xs text-amber-700 font-medium mb-1">Notes</p>
-      <p class="text-sm text-amber-800">{{ quote.notes }}</p>
-    </div>
-    {% endif %}
-
-    <div class="flex items-center gap-3 pt-2 border-t border-gray-200">
+    <div class="flex items-center gap-3 pt-4 mt-4 border-t border-gray-200">
       <button hx-get="/v2/partials/quotes/{{ quote.id }}"
               hx-target="#main-content"
               class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200">

--- a/app/templates/htmx/partials/requisitions/tabs/build_quote.html
+++ b/app/templates/htmx/partials/requisitions/tabs/build_quote.html
@@ -194,10 +194,8 @@
           Download PDF
         </a>
         {% if quote.status == 'draft' %}
-        <button hx-post="/v2/partials/quotes/{{ quote.id }}/send"
-                hx-target="#main-content"
-                hx-confirm="Send this quote to the customer?"
-                data-loading-disable
+        <button type="button"
+                @click="$dispatch('open-modal', {url: '/v2/partials/quotes/{{ quote.id }}/send-dialog'})"
                 class="btn-primary btn-sm">
           <svg class="h-3.5 w-3.5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
           Send

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1850,7 +1850,35 @@ the emailed expiry — so the editor default, the preview cell, and the real out
 agree. `< 1` day → 400 (must be in the future); unparseable → 400 (invalid date). Blank/omitted
 fields are left unchanged (edit-in-place). Ownership is scoped through `get_quote_for_user`
 (SALES sees only own reqs → 404 otherwise). Errors surface via the global `htmx:responseError`
-toast with no swap, so the modal stays open to fix and retry.
+toast with no swap, so the modal stays open to fix and retry. (The Preview route above was
+superseded by Phase-3 Tranche B — see below; it now renders the real email body, not a
+standalone summary table.)
+
+**Phase-3 Tranche B (send dialog, honest preview, detail preflight, seeding, customer-safe
+copy).** The old one-click `hx-confirm` Send button (`quotes/detail.html`,
+`requisitions/tabs/build_quote.html`) now opens a **send dialog**
+(`GET /v2/partials/quotes/{id}/send-dialog` → `quotes/_send_dialog.html`) with editable
+recipient email/name, an optional comma-separated CC (threaded into the Graph payload as
+`ccRecipients` via `build_sendmail_payload`'s `extra_message_fields`), and the same
+`quote_preflight` advisories; on success it swaps `#main-content` and toasts "Quote {number}
+sent to {recipient}" (`set_toast`), and on any failure — DNC block, `QuoteSendError`, or a
+genuine 5xx — it stays open with the error toast visible (`hx-on::after-request` gates the
+close on both `successful` AND the absence of the error path's `HX-Reswap: none` header).
+**Preview** (`POST /v2/partials/quotes/{id}/preview`) now renders `_build_quote_email_html`
+— the SAME builder `send_quote_email` calls — inside a sandboxed iframe, so preview and send
+can never drift; the subject line is `quote_send.build_quote_subject(quote)`, the one place
+it's built. `quote_preflight` also gained a 4th check, **pricing** (a quoted line at
+$0/unset sell, or at-or-under its cost), and now renders as an amber banner directly on the
+quote detail page for drafts (not just the Build-Quote tab). Sell-price seeding — last-quoted
+price wins, else cost × `DEFAULT_MARKUP_PCT` — is now ONE rule, `quote_builder_service.
+seed_sell_price()`, called by the Build-Quote tab AND all three quote-line-creation routes
+(offer-select create-quote, add-offer-to-quote, add-offers-to-draft-quote) so a line's seeded
+price can't differ by which path created it. Quote detail also gained a **"Copy for
+customer"** button beside the existing "Copy Table" — it copies only MPN/Description/
+Manufacturer/Qty/Sell (relabeled "Price"), never the Cost or Margin % cells, guarded by
+`tests/test_quote_copy_table_header.py`. Both copy buttons now call `showToast()` directly
+(exported as `window.showToast` in `htmx_app.js` for inline Alpine handlers) instead of
+dispatching a `toast` CustomEvent.
 
 ## 6. Buy Plan Workflow
 

--- a/tests/test_integration_quote_workflow.py
+++ b/tests/test_integration_quote_workflow.py
@@ -15,6 +15,7 @@ def test_create_quote_from_offers_populates_line_items_json(client, db_session, 
     Otherwise the customer receives an empty line-item table.
     """
     from app.models import Quote
+    from app.services.quote_builder_service import DEFAULT_MARKUP_PCT
 
     resp = client.post(
         f"/v2/partials/requisitions/{test_requisition.id}/create-quote",
@@ -30,7 +31,10 @@ def test_create_quote_from_offers_populates_line_items_json(client, db_session, 
     assert len(quote.line_items) == 1
     li = quote.line_items[0]
     assert li["mpn"] == "LM317T"
-    assert li["sell_price"] == 0.50
+    # B4: sell is seeded (no pricing history for this MPN yet) = cost x DEFAULT_MARKUP_PCT,
+    # not sell == cost (0.50) like before seed_sell_price existed.
+    expected_sell = round(0.50 * (1 + DEFAULT_MARKUP_PCT / 100.0), 4)
+    assert li["sell_price"] == expected_sell
     assert li["qty"] == 1000
     assert li["offer_id"] == test_offer.id
     assert "manufacturer" in li

--- a/tests/test_oq_offers_quotes_workflow.py
+++ b/tests/test_oq_offers_quotes_workflow.py
@@ -179,5 +179,6 @@ class TestLineMutationsRecalcTotals:
         )
         assert resp.status_code == 200
         db_session.refresh(draft_quote)
-        # add-offer seeds sell_price=0 (buyer prices later); cost = 0.50 * 1000 = 500.
+        # add-offer seeds sell via seed_sell_price (B4: last-quoted/markup, buyer adjusts);
+        # cost = 0.50 * 1000 = 500 either way.
         assert draft_quote.total_cost == pytest.approx(500.0)

--- a/tests/test_quote_copy_table_header.py
+++ b/tests/test_quote_copy_table_header.py
@@ -5,6 +5,11 @@ The Copy Table button copies the first 6 <td>s of each quote line row; its heade
 must label them in the SAME order (MPN, Description, Manufacturer, Qty, Cost, Sell). The
 pre-fix header omitted Description, shifting every label one column left — Cost values
 pasted under "Sell" (a customer-facing cost leak when the paste left the building).
+
+Also guards the "Copy for customer" sibling button (B5, Decision E): it must copy ONLY
+cells 0,1,2,3,5 (MPN/Description/Manufacturer/Qty/Sell, labeled "Price") — no Cost, no
+Margin — and both buttons must use the real global showToast() (htmx_app.js:84-89)
+instead of the dead `CustomEvent('toast')` nothing ever listened for.
 """
 
 from pathlib import Path
@@ -25,3 +30,29 @@ def test_copy_header_matches_line_row_cells():
     sell_pos = line_row.find("line.sell_price|float")
     mfr_pos = line_row.find("line.manufacturer")
     assert -1 < mfr_pos < cost_pos < sell_pos
+
+
+def test_customer_copy_button_omits_cost_and_margin():
+    detail = DETAIL.read_text()
+    # Isolate the customer-copy button's own @click block via its header-line
+    # marker so we're not accidentally matching the internal Copy Table button's
+    # "Cost" column (or the "Cost Price" / "Margin %" <th> labels elsewhere on
+    # the page).
+    header_marker = "let text = 'MPN\\tDescription\\tManufacturer\\tQty\\tPrice\\n';"
+    assert header_marker in detail
+    start = detail.index(header_marker)
+    end = detail.index("Copy for customer", start)
+    customer_block = detail[start:end]
+    assert "Cost" not in customer_block
+    assert "Margin" not in customer_block
+
+
+def test_neither_copy_button_uses_dead_custom_event_toast():
+    detail = DETAIL.read_text()
+    assert "CustomEvent('toast'" not in detail
+    assert 'CustomEvent("toast"' not in detail
+
+
+def test_both_copy_buttons_call_the_real_show_toast():
+    detail = DETAIL.read_text()
+    assert detail.count("showToast(") >= 2

--- a/tests/test_quote_detail_preflight.py
+++ b/tests/test_quote_detail_preflight.py
@@ -1,0 +1,119 @@
+"""test_quote_detail_preflight.py — B3: preflight advisories on the quote detail page.
+
+Covers:
+- draft quote with a DNC-flagged customer site -> detail GET renders the amber
+  advisory card with the DNC message.
+- non-draft (status='sent') quote, even with a DNC-flagged site -> no card
+  (preflight_warnings is only populated for drafts; see quote_detail_partial).
+- draft quote with no warnings -> no card.
+
+Called by: pytest
+Depends on: conftest.py fixtures, app.routers.htmx.quotes.quote_detail_partial,
+            app.services.quote_preflight.quote_preflight
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import CustomerSite, Quote, Requisition, User
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def draft_quote_dnc_site(
+    db_session: Session,
+    test_requisition: Requisition,
+    test_customer_site: CustomerSite,
+    test_user: User,
+) -> Quote:
+    """A draft quote whose customer site is marked Do-Not-Contact (cheapest preflight
+    trigger — quote_preflight's first check)."""
+    test_customer_site.do_not_contact = True
+    db_session.add(test_customer_site)
+    q = Quote(
+        requisition_id=test_requisition.id,
+        customer_site_id=test_customer_site.id,
+        quote_number="TEST-Q-PREFLIGHT-DRAFT-DNC",
+        status="draft",
+        line_items=[],
+        created_by_id=test_user.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(q)
+    db_session.commit()
+    db_session.refresh(q)
+    return q
+
+
+@pytest.fixture()
+def sent_quote_dnc_site(
+    db_session: Session,
+    test_requisition: Requisition,
+    test_customer_site: CustomerSite,
+    test_user: User,
+) -> Quote:
+    """A SENT quote whose customer site is DNC-flagged — the trigger fires but the quote
+    is not a draft, so preflight_warnings must stay empty."""
+    test_customer_site.do_not_contact = True
+    db_session.add(test_customer_site)
+    q = Quote(
+        requisition_id=test_requisition.id,
+        customer_site_id=test_customer_site.id,
+        quote_number="TEST-Q-PREFLIGHT-SENT-DNC",
+        status="sent",
+        line_items=[],
+        created_by_id=test_user.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(q)
+    db_session.commit()
+    db_session.refresh(q)
+    return q
+
+
+@pytest.fixture()
+def draft_quote_clean(
+    db_session: Session,
+    test_requisition: Requisition,
+    test_customer_site: CustomerSite,
+    test_user: User,
+) -> Quote:
+    """A draft quote with no preflight triggers at all (site not DNC, no lines)."""
+    q = Quote(
+        requisition_id=test_requisition.id,
+        customer_site_id=test_customer_site.id,
+        quote_number="TEST-Q-PREFLIGHT-DRAFT-CLEAN",
+        status="draft",
+        line_items=[],
+        created_by_id=test_user.id,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(q)
+    db_session.commit()
+    db_session.refresh(q)
+    return q
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestQuoteDetailPreflightAdvisories:
+    def test_draft_with_dnc_site_shows_amber_card(self, client: TestClient, draft_quote_dnc_site: Quote):
+        resp = client.get(f"/v2/partials/quotes/{draft_quote_dnc_site.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Before you send" in resp.text
+        assert "Do-Not-Contact" in resp.text
+
+    def test_sent_quote_never_shows_card_even_with_trigger(self, client: TestClient, sent_quote_dnc_site: Quote):
+        resp = client.get(f"/v2/partials/quotes/{sent_quote_dnc_site.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Before you send" not in resp.text
+
+    def test_draft_with_no_warnings_shows_no_card(self, client: TestClient, draft_quote_clean: Quote):
+        resp = client.get(f"/v2/partials/quotes/{draft_quote_clean.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Before you send" not in resp.text

--- a/tests/test_quote_preflight.py
+++ b/tests/test_quote_preflight.py
@@ -18,7 +18,10 @@ def _add_requirement(db: Session, requisition_id: int, **kw) -> Requirement:
 
 
 def _add_line(db: Session, quote: Quote, mpn: str, offer_id: int | None = None) -> QuoteLine:
-    ql = QuoteLine(quote_id=quote.id, mpn=mpn, offer_id=offer_id, qty=1)
+    # Healthy default cost/sell (comfortable margin) so these dnc/coo/mpn_drift-focused
+    # tests stay isolated from quote_preflight's B4 "pricing" check (test_quote_seeding.py
+    # covers that check directly).
+    ql = QuoteLine(quote_id=quote.id, mpn=mpn, offer_id=offer_id, qty=1, cost_price=1.0, sell_price=2.0)
     db.add(ql)
     db.commit()
     db.refresh(quote)

--- a/tests/test_quote_preview_email.py
+++ b/tests/test_quote_preview_email.py
@@ -1,0 +1,77 @@
+"""test_quote_preview_email.py — Preview renders the exact send-path email (Phase-3 B2).
+
+Verifies: /v2/partials/quotes/{id}/preview no longer hand-rolls its own markup — it
+renders _build_quote_email_html (the SAME builder send_quote_email uses) inside an
+iframe-srcdoc shell with a To/Subject header strip, so what the salesperson previews is
+byte-for-byte what goes out. Also covers the no-resolvable-recipient case (200 + a note,
+never a 500).
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, db_session, test_quote, test_requisition,
+test_user), app.routers.htmx.quotes.preview_quote, app.services.quote_send.
+"""
+
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Quote, Requisition, User
+from app.services.quote_send import build_quote_subject
+
+
+class TestPreviewRendersSendPathEmail:
+    def test_preview_contains_email_builder_markup_not_old_fields(self, client: TestClient, test_quote: Quote):
+        """The preview body IS _build_quote_email_html's output (a marker only it
+        emits), and the old hand-rolled preview's "Status" field label is gone."""
+        resp = client.post(
+            f"/v2/partials/quotes/{test_quote.id}/preview",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # Unique to _build_quote_email_html's greeting body — never emitted by anything else.
+        assert "Thank you for your interest. Please find our quotation detailed below." in resp.text
+        # The old preview.html rendered a labeled "Status" field — that markup is deleted.
+        assert ">Status<" not in resp.text
+
+    def test_preview_shows_resolved_recipient(self, client: TestClient, test_quote: Quote):
+        """The header strip shows the recipient the send path would actually use
+        (site.contact_name / contact_email — same resolution as send_quote_email)."""
+        resp = client.post(
+            f"/v2/partials/quotes/{test_quote.id}/preview",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "jane@acme-electronics.com" in resp.text
+        assert "Jane Doe" in resp.text
+        assert build_quote_subject(test_quote) in resp.text
+
+    def test_preview_no_recipient_resolved_is_200_not_500(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        test_user: User,
+    ):
+        """A quote with no customer site (so no contact email to resolve) must still
+        preview at 200 with a note — mirrors crm/quotes.py:358's no-recipient handling,
+        never a 500."""
+        quote = Quote(
+            requisition_id=test_requisition.id,
+            customer_site_id=None,
+            quote_number="TEST-Q-NOSITE-001",
+            status="draft",
+            line_items=[],
+            created_by_id=test_user.id,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(quote)
+        db_session.commit()
+        db_session.refresh(quote)
+
+        resp = client.post(
+            f"/v2/partials/quotes/{quote.id}/preview",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "no recipient resolved" in resp.text.lower()

--- a/tests/test_quote_seeding.py
+++ b/tests/test_quote_seeding.py
@@ -1,0 +1,260 @@
+"""tests/test_quote_seeding.py — B4: shared sell-price seeding + zero-margin preflight.
+
+Covers:
+  - ``seed_sell_price`` (app.services.quote_builder_service): last-quoted price wins when
+    pricing history exists for the MPN; else cost x DEFAULT_MARKUP_PCT, with margin_pct
+    computed the same way ``margin_guardrail``/``quote_export_context`` already do.
+  - The three quote-line creation call sites now seed through that SAME helper (no more
+    sell=cost or hardcoded sell=0): offer-select create-quote (offers/crud.py), add-offer-
+    to-quote and add-offers-to-draft-quote (htmx/quotes.py).
+  - ``quote_preflight``'s new zero/negative-margin "pricing" warning.
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, db_session, test_user, test_requisition,
+    test_customer_site, test_offer, test_quote), app.services.quote_builder_service,
+    app.services.quote_preflight.
+"""
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Quote, QuoteLine, Requisition, User
+from app.services.quote_builder_service import DEFAULT_MARKUP_PCT, seed_sell_price
+from app.services.quote_preflight import quote_preflight
+
+
+def _prior_sent_quote(db: Session, req: Requisition, user: User, mpn: str, sell_price: float) -> Quote:
+    """A previously-sent quote for *mpn* — the pricing history seed_sell_price's last-
+    quoted branch reads.
+
+    Mirrors ``preload_last_quoted_prices``'s own tests (test_quote_builder_service.py::
+    TestBuildQuoteTabData::test_sell_seed_prefers_last_quoted_price) — history is read from
+    ``Quote.line_items`` JSON, not the QuoteLine ORM rows.
+    """
+    q = Quote(
+        requisition_id=req.id,
+        quote_number=f"Q-PRIOR-{mpn}",
+        status="sent",
+        line_items=[{"mpn": mpn, "sell_price": sell_price, "margin_pct": 50.0}],
+        subtotal=sell_price,
+        created_by_id=user.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.commit()
+    return q
+
+
+def _draft_quote(db: Session, req: Requisition, site, user: User, quote_number: str) -> Quote:
+    q = Quote(
+        requisition_id=req.id,
+        customer_site_id=site.id,
+        quote_number=quote_number,
+        status="draft",
+        line_items=[],
+        created_by_id=user.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.commit()
+    db.refresh(q)
+    return q
+
+
+# ── seed_sell_price — the shared helper ─────────────────────────────────────
+
+
+class TestSeedSellPrice:
+    def test_last_quoted_price_wins_when_history_exists(
+        self, db_session: Session, test_requisition: Requisition, test_user: User
+    ):
+        _prior_sent_quote(db_session, test_requisition, test_user, "LM317T", 0.99)
+        sell, margin_pct = seed_sell_price(db_session, "LM317T", 0.50)
+        assert sell == pytest.approx(0.99)
+        assert margin_pct == pytest.approx((0.99 - 0.50) / 0.99 * 100, rel=1e-3)
+
+    def test_no_history_falls_back_to_cost_times_markup(self, db_session: Session):
+        sell, margin_pct = seed_sell_price(db_session, "NOPART-XYZ", 0.50)
+        expected_sell = round(0.50 * (1 + DEFAULT_MARKUP_PCT / 100.0), 4)
+        assert sell == pytest.approx(expected_sell)
+        assert margin_pct == pytest.approx((expected_sell - 0.50) / expected_sell * 100, rel=1e-3)
+
+    def test_no_history_and_no_cost_returns_none_none(self, db_session: Session):
+        assert seed_sell_price(db_session, "NOPART-XYZ", None) == (None, None)
+
+    def test_preloaded_last_quoted_dict_is_honored_and_case_insensitive(self, db_session: Session):
+        preloaded = {"LM317T": {"sell_price": 1.50}}
+        sell, margin_pct = seed_sell_price(db_session, "lm317t", 1.00, last_quoted=preloaded)
+        assert sell == pytest.approx(1.50)
+        assert margin_pct == pytest.approx((1.50 - 1.00) / 1.50 * 100, rel=1e-3)
+
+
+# ── The three quote-line creation sites ──────────────────────────────────────
+
+
+class TestCreateQuoteFromOffersSeedsPrice:
+    """offers/crud.py::create_quote_from_offers (offer-select "Create Quote from Selected")."""
+
+    def test_seeds_last_quoted_price_when_history_exists(
+        self, client: TestClient, db_session: Session, test_requisition: Requisition, test_user: User, test_offer
+    ):
+        _prior_sent_quote(db_session, test_requisition, test_user, test_offer.mpn, 0.99)
+        resp = client.post(
+            f"/v2/partials/requisitions/{test_requisition.id}/create-quote",
+            data={"offer_ids": str(test_offer.id)},
+        )
+        assert resp.status_code == 200
+        line = db_session.query(QuoteLine).filter(QuoteLine.offer_id == test_offer.id).first()
+        assert line is not None
+        assert float(line.sell_price) == pytest.approx(0.99)
+        assert float(line.cost_price) == pytest.approx(0.50)
+
+    def test_no_history_seeds_cost_times_markup(
+        self, client: TestClient, db_session: Session, test_requisition: Requisition, test_offer
+    ):
+        resp = client.post(
+            f"/v2/partials/requisitions/{test_requisition.id}/create-quote",
+            data={"offer_ids": str(test_offer.id)},
+        )
+        assert resp.status_code == 200
+        line = db_session.query(QuoteLine).filter(QuoteLine.offer_id == test_offer.id).first()
+        expected_sell = round(0.50 * (1 + DEFAULT_MARKUP_PCT / 100.0), 4)
+        assert float(line.sell_price) == pytest.approx(expected_sell)
+        assert line.margin_pct is not None
+
+
+class TestAddOfferToQuoteSeedsPrice:
+    """htmx/quotes.py::add_offer_to_quote — previously hardcoded sell_price=0."""
+
+    def test_no_history_seeds_cost_times_markup(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        test_customer_site,
+        test_user: User,
+        test_offer,
+    ):
+        quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, "TEST-Q-SEED-ADD-OFFER")
+        resp = client.post(
+            f"/v2/partials/quotes/{quote.id}/add-offer/{test_offer.id}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        line = db_session.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).first()
+        expected_sell = round(0.50 * (1 + DEFAULT_MARKUP_PCT / 100.0), 4)
+        assert float(line.sell_price) == pytest.approx(expected_sell)
+        assert float(line.sell_price) != 0  # was hardcoded 0 before B4
+
+    def test_seeds_last_quoted_price_when_history_exists(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        test_customer_site,
+        test_user: User,
+        test_offer,
+    ):
+        _prior_sent_quote(db_session, test_requisition, test_user, test_offer.mpn, 0.99)
+        quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, "TEST-Q-SEED-ADD-OFFER-HIST")
+        resp = client.post(
+            f"/v2/partials/quotes/{quote.id}/add-offer/{test_offer.id}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        line = db_session.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).first()
+        assert float(line.sell_price) == pytest.approx(0.99)
+
+
+class TestAddOffersToDraftQuoteSeedsPrice:
+    """htmx/quotes.py::add_offers_to_draft_quote — previously sell_price = cost_price."""
+
+    def test_no_history_seeds_cost_times_markup(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        test_customer_site,
+        test_user: User,
+        test_offer,
+    ):
+        quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, "TEST-Q-SEED-ADD-DRAFT")
+        resp = client.post(
+            f"/v2/partials/requisitions/{test_requisition.id}/add-offers-to-quote",
+            content=json.dumps({"offer_ids": [test_offer.id], "quote_id": quote.id}),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        line = db_session.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).first()
+        expected_sell = round(0.50 * (1 + DEFAULT_MARKUP_PCT / 100.0), 4)
+        assert float(line.sell_price) == pytest.approx(expected_sell)
+        assert float(line.sell_price) != float(line.cost_price)  # was sell == cost before B4
+
+    def test_seeds_last_quoted_price_when_history_exists(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        test_customer_site,
+        test_user: User,
+        test_offer,
+    ):
+        _prior_sent_quote(db_session, test_requisition, test_user, test_offer.mpn, 0.99)
+        quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, "TEST-Q-SEED-ADD-DRAFT-HIST")
+        resp = client.post(
+            f"/v2/partials/requisitions/{test_requisition.id}/add-offers-to-quote",
+            content=json.dumps({"offer_ids": [test_offer.id], "quote_id": quote.id}),
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        line = db_session.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).first()
+        assert float(line.sell_price) == pytest.approx(0.99)
+
+
+# ── quote_preflight: zero/negative-margin pricing check ──────────────────────
+
+
+class TestPricingPreflightCheck:
+    def test_zero_sell_line_flagged(self, db_session: Session, test_quote: Quote):
+        db_session.add(QuoteLine(quote_id=test_quote.id, mpn="LM317T", qty=1, cost_price=1.0, sell_price=0))
+        db_session.commit()
+        warnings = quote_preflight(db_session, test_quote)
+        assert any(w.code == "pricing" for w in warnings)
+
+    def test_unset_sell_line_flagged(self, db_session: Session, test_quote: Quote):
+        db_session.add(QuoteLine(quote_id=test_quote.id, mpn="LM317T", qty=1, cost_price=1.0))
+        db_session.commit()
+        warnings = quote_preflight(db_session, test_quote)
+        assert any(w.code == "pricing" for w in warnings)
+
+    def test_sell_at_or_below_cost_flagged(self, db_session: Session, test_quote: Quote):
+        db_session.add(QuoteLine(quote_id=test_quote.id, mpn="LM317T", qty=1, cost_price=2.0, sell_price=1.5))
+        db_session.commit()
+        warnings = quote_preflight(db_session, test_quote)
+        pricing = [w for w in warnings if w.code == "pricing"]
+        assert len(pricing) == 1
+        assert "1 line" in pricing[0].message
+
+    def test_healthy_line_not_flagged(self, db_session: Session, test_quote: Quote):
+        db_session.add(QuoteLine(quote_id=test_quote.id, mpn="LM317T", qty=1, cost_price=1.0, sell_price=2.0))
+        db_session.commit()
+        warnings = quote_preflight(db_session, test_quote)
+        assert not any(w.code == "pricing" for w in warnings)
+
+    def test_no_lines_not_flagged(self, db_session: Session, test_quote: Quote):
+        warnings = quote_preflight(db_session, test_quote)
+        assert not any(w.code == "pricing" for w in warnings)
+
+    def test_multiple_bad_lines_counted(self, db_session: Session, test_quote: Quote):
+        db_session.add(QuoteLine(quote_id=test_quote.id, mpn="LM317T", qty=1, cost_price=1.0, sell_price=0))
+        db_session.add(QuoteLine(quote_id=test_quote.id, mpn="NE555P", qty=1, cost_price=2.0, sell_price=1.0))
+        db_session.add(QuoteLine(quote_id=test_quote.id, mpn="TL072CP", qty=1, cost_price=1.0, sell_price=2.0))
+        db_session.commit()
+        warnings = quote_preflight(db_session, test_quote)
+        pricing = [w for w in warnings if w.code == "pricing"]
+        assert len(pricing) == 1
+        assert "2 line" in pricing[0].message

--- a/tests/test_quote_send_dialog.py
+++ b/tests/test_quote_send_dialog.py
@@ -218,3 +218,65 @@ async def test_service_empty_cc_is_none_no_cc_recipients_key(
     assert mock_post.called
     payload = mock_post.call_args.args[1]
     assert "ccRecipients" not in payload["message"]
+
+
+# ── Fix round 1 (B1 follow-up): dialog must NOT close on a rejected send ────
+#
+# close_modal_on_success() closes on ANY htmx "successful" 2xx — but the send route's
+# error paths (DNC block, QuoteSendError) are ALSO 200 (HX-Reswap: none + a showToast
+# error, so the failure toast fires without wiping #main-content). The dialog form no
+# longer uses that shared macro; it keys its own close on the same HX-Reswap: none
+# signal so a rejected send leaves it open (with the typed override_email/
+# override_name/cc intact) instead of silently discarding the user's input.
+
+
+def test_send_success_response_has_no_hx_reswap_none_header(
+    client, db_session, test_requisition, test_customer_site, test_user
+):
+    """The signal the dialog's close guard keys on: a genuine send carries NO
+    HX-Reswap: none header (so the guard's `getResponseHeader(...) !== 'none'` closes
+    the dialog)."""
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-CLOSEOK")
+
+    resp = client.post(f"/v2/partials/quotes/{quote.id}/send")
+
+    assert resp.status_code == 200
+    assert resp.headers.get("HX-Reswap") != "none"
+    db_session.refresh(quote)
+    assert quote.status == QuoteStatus.SENT
+
+
+def test_send_dnc_blocked_response_has_hx_reswap_none_header(
+    client, db_session, test_requisition, test_customer_site, test_user
+):
+    """A DNC-blocked send (still HTTP 200) carries HX-Reswap: none — the exact signal
+    the dialog's close guard checks to stay OPEN instead of discarding the user's typed
+    overrides."""
+    test_customer_site.do_not_contact = True
+    db_session.commit()
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-CLOSEDNC")
+
+    resp = client.post(f"/v2/partials/quotes/{quote.id}/send")
+
+    assert resp.status_code == 200
+    assert resp.headers.get("HX-Reswap") == "none"
+    trigger = json.loads(resp.headers["HX-Trigger"])
+    assert trigger["showToast"]["type"] == "error"
+    db_session.refresh(quote)
+    assert quote.status == "draft"
+
+
+def test_send_dialog_form_guards_close_on_hx_reswap_and_successful(
+    client, db_session, test_requisition, test_customer_site, test_user
+):
+    """The dialog's <form> must NOT use the bare close_modal_on_success() idiom (which
+    closes on ANY 2xx) — it needs its own guard checking both htmx's `successful` flag
+    AND the absence of the HX-Reswap: none error signal before closing."""
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-CLOSEGUARD")
+
+    resp = client.get(f"/v2/partials/quotes/{quote.id}/send-dialog")
+
+    assert resp.status_code == 200
+    assert "event.detail.successful" in resp.text
+    assert "getResponseHeader('HX-Reswap')" in resp.text
+    assert "!== 'none'" in resp.text

--- a/tests/test_quote_send_dialog.py
+++ b/tests/test_quote_send_dialog.py
@@ -1,0 +1,220 @@
+"""test_quote_send_dialog.py — Tests for Task 4 (B1): the quote send dialog.
+
+Covers:
+  - GET /v2/partials/quotes/{id}/send-dialog — renders the resolved recipient
+    (site contact) prefilled + a CC input + preflight warnings.
+  - POST /v2/partials/quotes/{id}/send reads override_email/override_name/cc form
+    fields (all optional — absent form = legacy behavior unchanged) and forwards
+    them to the canonical send_quote_email service.
+  - send_quote_email's optional override_email/cc reach the Graph sendMail
+    payload (toRecipients / ccRecipients) — same Graph mock seam as
+    tests/test_quote_send.py (GraphClient.post_json, email_service._find_sent_message).
+  - A successful send fires a showToast HX-Trigger naming quote number + recipient.
+
+Depends on: tests/conftest.py fixtures (client, db_session, test_user,
+test_requisition, test_customer_site), SQLite test engine.
+"""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.constants import QuoteStatus
+from app.models import Quote
+
+
+def _draft_quote(db: Session, req, site, user, number="Q-2026-DLG") -> Quote:
+    """Build and persist a DRAFT quote tied to req/site/user."""
+    q = Quote(
+        requisition_id=req.id,
+        customer_site_id=site.id,
+        quote_number=number,
+        status="draft",
+        line_items=[{"mpn": "LM317T", "qty": 100, "sell_price": 5.00}],
+        subtotal=500.0,
+        total_cost=300.0,
+        total_margin_pct=40.0,
+        created_by_id=user.id,
+        created_at=datetime.now(UTC),
+    )
+    db.add(q)
+    db.commit()
+    db.refresh(q)
+    return q
+
+
+# ── (a) GET dialog ───────────────────────────────────────────────────────────
+
+
+def test_get_send_dialog_shows_prefilled_contact_and_cc_input(
+    client, db_session, test_requisition, test_customer_site, test_user
+):
+    """The dialog prefills the site contact's email and offers an editable CC input."""
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user)
+
+    resp = client.get(f"/v2/partials/quotes/{quote.id}/send-dialog")
+
+    assert resp.status_code == 200
+    assert "jane@acme-electronics.com" in resp.text
+    assert "name='override_email'" in resp.text
+    assert "name='override_name'" in resp.text
+    assert "name='cc'" in resp.text
+    # The subject is built via the canonical build_quote_subject (Task 3) so the
+    # dialog can never drift from what actually sends.
+    assert quote.quote_number in resp.text
+    assert "Trio Supply Chain Solutions" in resp.text
+
+
+# ── (b) POST send with override_email → the route forwards it to the service,
+#        which the mocked Graph send receives ────────────────────────────────
+
+
+def test_post_send_forwards_override_and_cc_form_fields_to_service(
+    client, db_session, test_requisition, test_customer_site, test_user
+):
+    """The route reads override_email/override_name/cc Form fields (all optional) and
+    forwards them to send_quote_email — same wiring style as
+    test_quote_send.py::test_htmx_send_triggers_real_send_email."""
+    from app.routers.htmx import quotes
+    from app.services.quote_send import SendQuoteResult
+
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-OVR")
+
+    async def _fake(db, q, user, **kwargs):
+        q.status = QuoteStatus.SENT
+        q.sent_at = datetime.now(UTC)
+        db.commit()
+        return SendQuoteResult(
+            sent_to=kwargs.get("override_email") or "jane@acme-electronics.com",
+            status="sent",
+            req_status=None,
+            status_changed=False,
+            graph_message_id=None,
+        )
+
+    with patch.object(quotes, "send_quote_email", new=AsyncMock(side_effect=_fake)) as mock_send:
+        resp = client.post(
+            f"/v2/partials/quotes/{quote.id}/send",
+            data={"override_email": "override@example.com", "override_name": "Override Name", "cc": "cc@example.com"},
+        )
+
+    assert resp.status_code == 200
+    assert mock_send.called
+    kwargs = mock_send.call_args.kwargs
+    assert kwargs["override_email"] == "override@example.com"
+    assert kwargs["override_name"] == "Override Name"
+    assert kwargs["cc"] == "cc@example.com"
+
+
+async def test_service_override_email_reaches_graph_to_payload(
+    db_session, test_requisition, test_customer_site, test_user
+):
+    """send_quote_email's override_email reaches the Graph sendMail toRecipients —
+    same mock seam as test_quote_send.py::test_service_captures_graph_ids_when_message_found."""
+    from app.services.quote_send import send_quote_email
+
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-OVRSVC")
+
+    with (
+        patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock) as mock_post,
+        patch("app.email_service._find_sent_message", new_callable=AsyncMock) as mock_find,
+    ):
+        mock_post.return_value = {}
+        mock_find.return_value = {"id": "MSG1", "conversationId": "CONV1"}
+        result = await send_quote_email(
+            db_session,
+            quote,
+            test_user,
+            token="t",
+            testing=False,
+            override_email="override@example.com",
+            override_name="Override Name",
+        )
+
+    assert mock_post.called
+    payload = mock_post.call_args.args[1]
+    assert payload["message"]["toRecipients"] == [
+        {"emailAddress": {"address": "override@example.com", "name": "Override Name"}}
+    ]
+    assert result.sent_to == "override@example.com"
+
+
+# ── (c) success response carries the HX-Trigger showToast naming sent_to ────
+
+
+def test_post_send_success_toast_names_recipient(client, db_session, test_requisition, test_customer_site, test_user):
+    """A successful send fires a showToast HX-Trigger naming the quote number +
+    recipient."""
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-TOAST")
+
+    resp = client.post(f"/v2/partials/quotes/{quote.id}/send")
+
+    assert resp.status_code == 200
+    trigger = json.loads(resp.headers["HX-Trigger"])
+    assert quote.quote_number in trigger["showToast"]["message"]
+    assert "jane@acme-electronics.com" in trigger["showToast"]["message"]
+    assert trigger["showToast"]["type"] == "success"
+
+
+# ── (d) POST send with no form fields still works (legacy path) ─────────────
+
+
+def test_post_send_with_no_form_fields_is_legacy_unchanged(
+    client, db_session, test_requisition, test_customer_site, test_user
+):
+    """Absent override/cc form fields must not change existing (legacy) send
+    behavior."""
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-LEGACY")
+
+    resp = client.post(f"/v2/partials/quotes/{quote.id}/send")
+
+    assert resp.status_code == 200
+    db_session.refresh(quote)
+    assert quote.status == QuoteStatus.SENT
+    assert quote.sent_at is not None
+
+
+# ── (e) cc value reaches the Graph payload ───────────────────────────────────
+
+
+async def test_service_cc_reaches_graph_payload(db_session, test_requisition, test_customer_site, test_user):
+    """send_quote_email's optional cc param threads into the Graph sendMail payload as
+    ccRecipients."""
+    from app.services.quote_send import send_quote_email
+
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-CC")
+
+    with (
+        patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock) as mock_post,
+        patch("app.email_service._find_sent_message", new_callable=AsyncMock) as mock_find,
+    ):
+        mock_post.return_value = {}
+        mock_find.return_value = {"id": "MSG2", "conversationId": "CONV2"}
+        await send_quote_email(db_session, quote, test_user, token="t", testing=False, cc="cc@example.com")
+
+    assert mock_post.called
+    payload = mock_post.call_args.args[1]
+    assert payload["message"]["ccRecipients"] == [{"emailAddress": {"address": "cc@example.com"}}]
+
+
+async def test_service_empty_cc_is_none_no_cc_recipients_key(
+    db_session, test_requisition, test_customer_site, test_user
+):
+    """An empty/whitespace cc string is treated as no CC — key omitted entirely."""
+    from app.services.quote_send import send_quote_email
+
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-CCEMPTY")
+
+    with (
+        patch("app.utils.graph_client.GraphClient.post_json", new_callable=AsyncMock) as mock_post,
+        patch("app.email_service._find_sent_message", new_callable=AsyncMock) as mock_find,
+    ):
+        mock_post.return_value = {}
+        mock_find.return_value = None
+        await send_quote_email(db_session, quote, test_user, token="t", testing=False, cc="   ")
+
+    assert mock_post.called
+    payload = mock_post.call_args.args[1]
+    assert "ccRecipients" not in payload["message"]

--- a/tests/test_quotes_material_card.py
+++ b/tests/test_quotes_material_card.py
@@ -508,3 +508,22 @@ def test_preload_card_id_dedup():
     result = _preload_last_quoted_prices(db)
     # First quote's price should win for card key
     assert result["card:42"]["sell_price"] == 3.00
+
+
+def test_preload_skips_non_dict_line_items_entry():
+    """B4 fix-round-1: a malformed legacy line_items entry (e.g. a bare string, not a
+    dict) must be skipped rather than raise — and healthy entries on the same and other
+    quotes still get picked up."""
+    q = MagicMock()
+    q.line_items = ["not-a-dict", {"mpn": "LM317T", "sell_price": 2.50, "margin_pct": 15.0}]
+    q.quote_number = "Q-2026-0100"
+    q.sent_at = datetime(2026, 2, 1, tzinfo=UTC)
+    q.created_at = datetime(2026, 1, 28, tzinfo=UTC)
+    q.result = "won"
+    db = MagicMock()
+    db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [q]
+
+    result = _preload_last_quoted_prices(db)  # must not raise
+
+    assert "LM317T" in result
+    assert result["LM317T"]["sell_price"] == 2.50


### PR DESCRIPTION
Phase 3 (do-all plan) quotes stream — Tranche B, all five verified-open items. **Merge is owner-gated — do not merge without the owner's word.**

## What

- **B1 — Send dialog** replaces the blind hx-confirm: shows the resolved recipient (editable override), optional CC, the exact subject, and the preflight warnings at the moment of truth; success toast names who it went to ("sent to bob@acme.com"). Dialog stays open on DNC-block/send errors (typed input preserved). One send path — absent form fields = legacy behavior.
- **B2 — Preview is the email**: renders `_build_quote_email_html` verbatim in a sandboxed iframe with To/Subject strip; the hand-rolled second template (wrong columns, internal Status/notes) is gone. `build_quote_subject` extracted — send, preview, dialog share it.
- **B3 — Preflight on the quote detail page** (same amber card as Build Quote; drafts only).
- **B4 — Sane price seeding**: all three quote-creation paths seed last-quoted price, else cost × default markup (shared `seed_sell_price`, extracted from Build Quote — no invented margins); new preflight warning flags $0/≤-cost lines. Also hardened `preload_last_quoted_prices` against malformed legacy line_items JSON.
- **B5 — "Copy for customer"** (Decision E): sibling button copying MPN/Description/Manufacturer/Qty/Price — no Cost, no Margin; both copy buttons now fire the real toast (the old CustomEvent was dead).

## Evidence

- Full suite in worktree: `24620 passed / 35 skipped`; 25 xdist worker-crash artifacts (concurrent suites on shared host) all **re-ran serially and passed**, independently corroborated by the final reviewer re-running 161 branch tests serially — all green. `npx vitest run`: 203/203 (htmx_app.js touched).
- 5 task reviews (2 fix rounds: dialog error-close guard; preload JSON guard) + whole-branch final review clean; NO migration; DNC hard-block and money math untouched beyond the specified seeding rule.

## Post-deploy check

Open a draft quote → detail shows preflight card if applicable → Preview shows the actual email + To/Subject → Send opens the dialog with the site contact prefilled → send to yourself with a CC → toast names the recipient; check "Copy for customer" paste has no Cost column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkHRARudqRbahKpsFDmUQa