### PR TITLE
Approvals workspace: focus fix, stalled flag, PO-confirm sections + buyer gate, honest exports (Tranche G)

### DIFF
--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -1395,7 +1395,11 @@ async def approvals_workspace_list(
     needs = [r for r in rows if r.needs_approval]
     own_confirm = [r for r in rows if r.own_confirm]
     rest = [r for r in rows if not r.needs_approval and not r.own_confirm]
-    default_row = needs[0] if needs else None
+    # A8 follow-up: before the split, own-confirm rows were part of `needs`, so a buyer
+    # with nothing to decide but their own PO to confirm still landed on that row on
+    # first load. Preserve that landing: fall back to the oldest own-confirm row when
+    # there's nothing to decide.
+    default_row = needs[0] if needs else (own_confirm[0] if own_confirm else None)
     select_key = _normalize_select(select, resolved)
     if select_key:
         default_row = _selected_row(db, user, rows, resolved, select_key) or default_row

--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -146,6 +146,10 @@ class WorkspaceRow:
     # 2.5: the plan is silently stalled — no configured approver can decide it
     # (plan_needs_approver_reason). Rendered as an amber warning on BP-tab rows.
     stalled: bool = False
+    # A8: this row is the viewer's own AWAITING_PO line (their confirm-PO buyer work,
+    # not an approval decision) — rendered in its own "Your POs to confirm" section
+    # instead of "Needs your approval". PO tab only; other tabs leave this False.
+    own_confirm: bool = False
 
 
 def _matches(q: str, *fields: str | None) -> bool:
@@ -1364,10 +1368,13 @@ async def approvals_workspace_list(
     """Render one tab's left work list (search + Mine/All + live/closed + age rows).
 
     Rows group "Needs your approval" first (oldest first — decision queues surface the
-    stalest work); the rest render newest-first. The oldest needs-your-approval row is
-    the default selection (dispatched to the pane on first load only). ``select`` (a
-    plan id from a retired /v2/buy-plans/{id} deep link, SO/BP tabs only) overrides
-    that default with the selected plan's pane when the viewer may see the plan.
+    stalest work), then "Your POs to confirm" (A8: the viewer's own AWAITING_PO lines —
+    buyer work, not a decision — PO tab only), then the rest render newest-first (the
+    template further carves a "Stalled — no approver" group out of that rest, A7). The
+    oldest needs-your-approval row is the default selection (dispatched to the pane on
+    first load only). ``select`` (a plan id from a retired /v2/buy-plans/{id} deep
+    link, SO/BP tabs only) overrides that default with the selected plan's pane when
+    the viewer may see the plan.
     """
     resolved = _resolve_tab(tab)
     if resolved is None:
@@ -1381,8 +1388,13 @@ async def approvals_workspace_list(
     else:
         rows = _prepayment_rows(db, user, q=q, scope=scope, show_closed=show_closed)
 
+    # A8: own-confirm rows carve out BEFORE the generic rest, same idiom stalled uses
+    # (carved out of rest, in the template) — needs is never guaranteed disjoint from
+    # stalled (Task 2 caution), so own_confirm is carved the same defensive way: by its
+    # own flag, not by exclusion from needs.
     needs = [r for r in rows if r.needs_approval]
-    rest = [r for r in rows if not r.needs_approval]
+    own_confirm = [r for r in rows if r.own_confirm]
+    rest = [r for r in rows if not r.needs_approval and not r.own_confirm]
     default_row = needs[0] if needs else None
     select_key = _normalize_select(select, resolved)
     if select_key:
@@ -1396,6 +1408,7 @@ async def approvals_workspace_list(
             "scope": scope,
             "show_closed": show_closed,
             "needs_rows": needs,
+            "own_confirm_rows": own_confirm,
             "other_rows": rest,
             "default_row": default_row,
             "list_url": f"/v2/partials/approvals/{resolved}/list",
@@ -1462,7 +1475,9 @@ def _plan_rows(db: Session, user: User, *, lens: str, q: str, scope: str, show_c
     return needs + rest
 
 
-def _po_line_row(line: BuyPlanLine, plan, *, needs: bool, closed: bool = False) -> WorkspaceRow:
+def _po_line_row(
+    line: BuyPlanLine, plan, *, needs: bool, closed: bool = False, own_confirm: bool = False
+) -> WorkspaceRow:
     """Build one PO-tab row from an ORM line (+ its plan)."""
     mpn = None
     if line.requirement is not None:
@@ -1493,6 +1508,7 @@ def _po_line_row(line: BuyPlanLine, plan, *, needs: bool, closed: bool = False) 
         age_at=line.po_confirmed_at or line.created_at,
         copy_number=line.po_number,
         closed=closed,
+        own_confirm=own_confirm,
     )
 
 
@@ -1562,8 +1578,12 @@ def _po_rows(db: Session, user: User, *, q: str, scope: str, show_closed: bool) 
             if ln.buyer_id == user.id or (ln.buy_plan is not None and ln.buy_plan.submitted_by_id == user.id)
         ]
     for line in others:
-        needs = line.status == BuyPlanLineStatus.AWAITING_PO.value and line.buyer_id == user.id
-        rows.append(_po_line_row(line, line.buy_plan, needs=needs))
+        # A8: the viewer's own AWAITING_PO line is buyer work ("confirm the PO"), not
+        # an approval decision — it renders under "Your POs to confirm", never "Needs
+        # your approval" (needs stays False here; the PO-tab badge math at
+        # _po_waiting_on_viewer is untouched and still counts it).
+        own_confirm = line.status == BuyPlanLineStatus.AWAITING_PO.value and line.buyer_id == user.id
+        rows.append(_po_line_row(line, line.buy_plan, needs=False, own_confirm=own_confirm))
 
     return [r for r in rows if _matches(q, r.title, r.subtitle, r.copy_number)]
 

--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -729,6 +729,10 @@ def render_po_pane(
             "can_verify": can_verify_po_line(user, line),
             "can_resource": _can_resource(user),
             "is_assigned_buyer": line.buyer_id == user.id,
+            # A9: the non-assigned pane's read-only card ("Awaiting PO — assigned to
+            # {buyer}") + the manager/admin "Act for the buyer" expander gate.
+            "assigned_buyer": line.buyer,
+            "is_manager_or_admin": is_manager_or_admin(user),
             "line_index": line_index,
             "line_total": len(sibling_ids),
             "partial_ship": (qp.sales_authorized_ship_partial if qp is not None else None),
@@ -808,11 +812,12 @@ async def approvals_po_parse_confirmation(
     filled (advisory mismatch warnings included).
 
     No DB write — the buyer reviews every field and still submits Confirm PO themselves.
-    Ownership, line-status, and a per-user throttle all gate BEFORE the paid AI call.
-    Failure paths return a small #po-paste-result fragment (the pasted text and any
-    typed values stay untouched); success retargets the full #aw-pane.
+    Ownership, the assigned-buyer/manager gate, line-status, and a per-user throttle all
+    gate BEFORE the paid AI call. Failure paths return a small #po-paste-result fragment
+    (the pasted text and any typed values stay untouched); success retargets the full
+    #aw-pane.
     """
-    from ...dependencies import get_buyplan_for_user
+    from ...dependencies import get_buyplan_for_user, is_manager_or_admin
 
     line = db.get(BuyPlanLine, line_id, options=[joinedload(BuyPlanLine.offer), joinedload(BuyPlanLine.requirement)])
     if line is None:
@@ -820,6 +825,11 @@ async def approvals_po_parse_confirmation(
     # Ownership BEFORE any AI work (mirrors approvals_po_sent_check): a restricted
     # non-owner 404s here, never burning a Claude call on a line they can't view.
     get_buyplan_for_user(db, user, line.buy_plan_id)
+    # A9: this route never calls confirm_po (no DB write — it only pre-fills the form),
+    # so it needs its own copy of the same buyer-or-manager gate, or a non-assigned
+    # viewer with plan access could burn a paid AI call on someone else's line.
+    if not (line.buyer_id == user.id or is_manager_or_admin(user)):
+        raise HTTPException(403, "Only the line's buyer or a manager can confirm its PO.")
     if line.status != BuyPlanLineStatus.AWAITING_PO.value:
         # The line moved on (e.g. confirmed in another tab) — the pane's current
         # state IS the feedback; no AI call for a form that no longer renders.

--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -1426,17 +1426,17 @@ def _plan_rows(db: Session, user: User, *, lens: str, q: str, scope: str, show_c
         ).all():
             ages[pid] = submitted_at or created_at
 
-    # Stall detection (2.5, Buy Plans lens): a PENDING plan with no configured
-    # approver sits invisibly — surface plan_needs_approver_reason on its row.
+    # Stall detection (2.5, A7: both plan lenses): a PENDING plan with no configured
+    # approver sits invisibly — surface plan_needs_approver_reason on its row regardless
+    # of which lens (Sales Orders / Buy Plans) is viewing it; both read the same rows.
     stalled_ids: set[int] = set()
-    if lens == "buy-plans":
-        from ...services.buyplan_workflow import plan_needs_approver_reason
+    from ...services.buyplan_workflow import plan_needs_approver_reason
 
-        pending_ids = [t.plan_id for t in tracking if t.status == BuyPlanStatus.PENDING.value]
-        if pending_ids:
-            for plan in db.execute(select(BuyPlan).where(BuyPlan.id.in_(pending_ids))).scalars():
-                if plan_needs_approver_reason(plan, db):
-                    stalled_ids.add(plan.id)
+    pending_ids = [t.plan_id for t in tracking if t.status == BuyPlanStatus.PENDING.value]
+    if pending_ids:
+        for plan in db.execute(select(BuyPlan).where(BuyPlan.id.in_(pending_ids))).scalars():
+            if plan_needs_approver_reason(plan, db):
+                stalled_ids.add(plan.id)
 
     rows = [
         WorkspaceRow(

--- a/app/routers/htmx/approvals_hub.py
+++ b/app/routers/htmx/approvals_hub.py
@@ -226,6 +226,7 @@ def _viewer_badges(db: Session, user: User) -> dict[str, int]:
 async def approvals_hub_shell(
     request: Request,
     tab: str = "",
+    scope: str = "all",
     select: str = "",
     user: User = Depends(require_access(AccessKey.BUY_PLANS)),
     db: Session = Depends(get_db),
@@ -236,15 +237,20 @@ async def approvals_hub_shell(
     lazy body that loads the active tab's split view into ``#ap-hub-body``. ``?tab=``
     threads a deep-link / pushed tab URL; legacy 3-tab keys alias onto the new tabs.
     ``?select=<plan id>`` (the retired /v2/buy-plans/{id} deep-link redirect) threads
-    into the tab body so the SO/BP list preselects that plan's pane.
+    into the tab body so the SO/BP list preselects that plan's pane. ``?scope=`` (A10)
+    threads the same way, so a hard reload or a shared/bookmarked URL restores the
+    Mine/All the viewer had — the tab-switcher pills also carry it in their
+    ``hx-replace-url`` so navigating tabs never drops back to a bare ``?tab=`` URL.
     """
     active_tab = _resolve_tab(tab) or DEFAULT_TAB
+    scope = "mine" if scope == "mine" else "all"
     ctx = _base_ctx(request, user, "buy-plans")
     ctx.update(
         {
             "active_tab": active_tab,
             "tabs": [(key, _TAB_LABELS[key]) for key in _TABS],
             "badges": _viewer_badges(db, user),
+            "scope": scope,
             "select": select,
         }
     )
@@ -1667,16 +1673,24 @@ def _fmt_dt(dt: datetime | None) -> str:
 async def approvals_hub_export(
     tab: str,
     scope: str = "all",
+    q: str = "",
+    show_closed: bool = False,
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
     """Stream one workspace list as a CSV download (attachment).
 
-    Same auth (require_user) and Mine/All scope as the tab list, reusing each tab's
-    exact read model so the download can never drift from what the console shows:
-      - sales-orders / buy-plans → the plan tracking list (buy_plan_tracking_rows);
-      - prepayments → the resolved audit feed (resolved_rows_for_gate);
-      - purchase-orders → the resolved PO decision feed (build_po_queue_view.history).
+    Same auth (require_user), Mine/All scope, search, and live/closed filter as the
+    tab list, reusing each tab's exact read model so the download can never drift from
+    what the console shows (A6 — export honesty):
+      - sales-orders / buy-plans → the plan tracking list (buy_plan_tracking_rows),
+        unfiltered by q/show_closed (unchanged);
+      - prepayments / purchase-orders, ``show_closed=false`` (default) → the SAME live
+        row builders the list renders (``_prepayment_rows`` / ``_po_rows``) — a manager
+        who exports without opening Closed gets the open work in front of them, not a
+        surprise history dump;
+      - prepayments / purchase-orders, ``show_closed=true`` → the resolved audit feed
+        (resolved_rows_for_gate / build_po_queue_view.history), unchanged.
     Legacy 3-tab keys alias; anything else 404s.
     """
     resolved = _resolve_tab(tab)
@@ -1691,6 +1705,22 @@ async def approvals_hub_export(
             for r in buy_plan_tracking_rows(db, user, scope=scope)
         )
         return stream_csv(f"approvals_sales_orders_{scope}.csv", header, rows)
+
+    if resolved == "prepayments" and not show_closed:
+        header = ["Prepayment", "Title", "Detail", "Status", "Amount", "PO Number"]
+        rows = (
+            [r.key, r.title, r.subtitle, r.status_label, r.amount, r.copy_number]
+            for r in _prepayment_rows(db, user, q=q, scope=scope, show_closed=False)
+        )
+        return stream_csv(f"approvals_prepayments_{scope}.csv", header, rows)
+
+    if resolved == "purchase-orders" and not show_closed:
+        header = ["Line", "Title", "Detail", "Status", "Amount", "PO Number"]
+        rows = (
+            [r.key, r.title, r.subtitle, r.status_label, r.amount, r.copy_number]
+            for r in _po_rows(db, user, q=q, scope=scope, show_closed=False)
+        )
+        return stream_csv(f"approvals_purchase_orders_{scope}.csv", header, rows)
 
     if resolved == "prepayments":
         header = [

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -858,6 +858,8 @@ async def buy_plan_confirm_po_partial(
         log_field_edits(db, user=user, buy_plan_id=plan_id, buy_plan_line_id=line_id, edits=edits)
         db.commit()
         await run_notify_bg(notify_po_confirmed, plan_id, line_id=line_id)
+    except PermissionError as e:
+        raise HTTPException(403, str(e)) from e
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -335,16 +335,25 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
     elif current_view == "approvals":
         # The Approvals Workspace at /v2/partials/approvals. Thread ?tab= through
         # (customer deep-link pattern) so a reload/bookmark of a pushed tab URL paints
-        # the right tab, and ?select=<plan id> (the retired /v2/buy-plans/{id} deep-link
-        # redirect) so the workspace lands on that plan's pane. select is digits-only
-        # here — the shell route takes a typed int and would 422 on garbage.
+        # the right tab, ?scope= (A10) so a hard reload / shared link restores the
+        # viewer's Mine instead of snapping back to All, and ?select=<plan id> (the
+        # retired /v2/buy-plans/{id} deep-link redirect) so the workspace lands on that
+        # plan's pane. select is digits-only here — the shell route takes a typed int
+        # and would 422 on garbage.
+        qs_parts: list[tuple[str, str]] = []
         tab_qs = request.query_params.get("tab", "").strip()
-        partial_url = f"/v2/partials/approvals?tab={quote(tab_qs)}" if tab_qs else "/v2/partials/approvals"
+        if tab_qs:
+            qs_parts.append(("tab", tab_qs))
+        if request.query_params.get("scope", "").strip() == "mine":
+            qs_parts.append(("scope", "mine"))
         select_qs = request.query_params.get("select", "").strip()
         # Nav audit #3: select is a row KEY (plan-N / line-N / prepay-N) or bare
         # digits — validated by shape here, resolved per-tab in the workspace list.
         if re.fullmatch(r"(?:plan-|line-|prepay-)?\d+", select_qs or ""):
-            partial_url = f"{partial_url}{'&' if tab_qs else '?'}select={quote(select_qs)}"
+            qs_parts.append(("select", select_qs))
+        partial_url = "/v2/partials/approvals"
+        if qs_parts:
+            partial_url = f"{partial_url}?{urlencode(qs_parts)}"
     else:
         partial_url = f"/v2/partials/{current_view}"
         # Nav audit 2026-08-20 (#10): thread the WHOLE query through so a reload or

--- a/app/routers/po_confirm.py
+++ b/app/routers/po_confirm.py
@@ -117,7 +117,10 @@ async def po_confirm_post(
 
     Idempotent + state-scoped: acts only while the line is still AWAITING_PO on an
     ACTIVE plan — a concurrent confirm (caught as the service ValueError) renders the
-    read-only page and never double-confirms.
+    read-only page and never double-confirms. A9 follow-up: if the line's assigned
+    buyer changed after this token was minted, ``confirm_po``'s actor gate now raises
+    PermissionError — caught here too and rendered as the same graceful "inactive"
+    panel (never a raw 500 on this public, no-login page).
     """
     line, buyer = _load(db, token)
     if line is None or buyer is None:
@@ -154,9 +157,15 @@ async def po_confirm_post(
         )
         log_field_edits(db, user=buyer, buy_plan_id=line.buy_plan_id, buy_plan_line_id=line.id, edits=line_edits)
         db.commit()
-    except ValueError as e:
+    except (ValueError, PermissionError) as e:
         db.rollback()
         db.refresh(line)
+        if isinstance(e, PermissionError):
+            # The line's assigned buyer changed since this token was minted — the
+            # token no longer authorizes this actor. Same graceful "not live anymore"
+            # panel the other stale-link cases render below; never a raw exception on
+            # a public, no-login page.
+            return _render(request, line, "inactive")
         mode = _mode(line)
         if mode != "form":  # overtaken concurrently — read-only, never re-confirm
             return _render(request, line, mode)

--- a/app/services/buyplan_workflow/buyplan_po.py
+++ b/app/services/buyplan_workflow/buyplan_po.py
@@ -54,6 +54,14 @@ def confirm_po(
     records the terms on the Acctivate PO — REQUIRED, one of
     ``PO_LINE_PAYMENT_METHODS`` (wire / PayPal / credit card / ACH / COD); missing,
     blank, or any other value is a ValueError.
+
+    Actor gate (service-side, mirrors ``mark_line_received``): the line's assigned
+    buyer, or a manager/admin acting for them. A9 — the confirm form previously had no
+    ownership check, so any viewer with plan access (e.g. a co-owner sales/trader on
+    the same requisition) could submit someone else's line.
+
+    Raises:
+        PermissionError: actor is neither the line's buyer nor a manager/admin.
     """
     from ...constants import PO_LINE_PAYMENT_METHODS
 
@@ -75,6 +83,12 @@ def confirm_po(
     line = db.get(BuyPlanLine, line_id)
     if not line or line.buy_plan_id != plan_id:
         raise ValueError(f"Line {line_id} not found in plan {plan_id}")
+
+    from ...dependencies import is_manager_or_admin
+
+    if not (line.buyer_id == user.id or is_manager_or_admin(user)):
+        raise PermissionError("Only the line's buyer or a manager can confirm its PO.")
+
     if line.status != BuyPlanLineStatus.AWAITING_PO.value:
         raise ValueError(f"Line must be awaiting PO (current: {line.status})")
 

--- a/app/templates/htmx/partials/approvals/_pane_po_line.html
+++ b/app/templates/htmx/partials/approvals/_pane_po_line.html
@@ -122,7 +122,11 @@
   {% endif %}
   {% endmacro %}
 
-  {% if line.status == 'awaiting_po' %}
+  {# ── A9: the confirm-PO workspace — paste-import + AI banner + the confirm form
+       itself. Shown outright to the assigned buyer; behind a manager/admin's
+       "Act for the buyer" expander otherwise. Factored into a macro so the two call
+       sites below never drift apart. ── #}
+  {% macro po_confirm_workspace() %}
   {# ── Paste PO confirmation (inbound twin of Copy-for-ERP): AI pre-fills the
        confirm form below for REVIEW — its own form (forms can't nest), no DB write,
        the buyer still submits Confirm PO. ── #}
@@ -219,6 +223,33 @@
       <button type="submit" data-loading-disable class="btn-primary btn-sm">Confirm PO</button>
     </div>
   </form>
+  {% endmacro %}
+
+  {% if line.status == 'awaiting_po' %}
+  {% set assigned_buyer_name = (assigned_buyer.name or assigned_buyer.email) if assigned_buyer else 'nobody yet' %}
+  {% if is_assigned_buyer %}
+  {{ po_confirm_workspace() }}
+  {% elif is_manager_or_admin %}
+  {# ── Manager/admin, not the assigned buyer: read-only card + an explicit
+       act-for-buyer expander (never silently pre-open — this is a deliberate
+       stand-in for a buyer who is out, not the default manager path). ── #}
+  <div class="rounded-lg border border-line-base bg-gray-50 p-3 space-y-2" x-data="{ actingForBuyer: false }">
+    <div class="text-sm font-semibold text-gray-700">Awaiting PO — assigned to {{ assigned_buyer_name }}</div>
+    <button type="button" @click="actingForBuyer = !actingForBuyer"
+            class="text-xs font-medium text-accent-600 hover:text-accent-700 underline decoration-dashed"
+            x-text="actingForBuyer ? 'Hide act-for-buyer form' : 'Act for the buyer'">Act for the buyer</button>
+    <div x-show="actingForBuyer" x-cloak x-collapse class="pt-1 space-y-3">
+      {{ po_confirm_workspace() }}
+    </div>
+  </div>
+  {% else %}
+  {# ── Any other viewer with plan access (e.g. sales/trader co-owner): read-only —
+       A9 closes the gap where anyone with plan access could confirm someone else's
+       PO. ── #}
+  <div class="rounded-lg border border-line-base bg-gray-50 p-3">
+    <div class="text-sm font-semibold text-gray-700">Awaiting PO — assigned to {{ assigned_buyer_name }}</div>
+  </div>
+  {% endif %}
 
   {{ flag_issue_form() }}
 

--- a/app/templates/htmx/partials/approvals/_workspace_list.html
+++ b/app/templates/htmx/partials/approvals/_workspace_list.html
@@ -19,7 +19,10 @@
 {% from "htmx/partials/shared/_macros.html" import copy_chip, age_chip %}
 
 {# Badge tone keyed on the RAW backend status; text is the DISPLAY label (spec §5
-   vocabulary — e.g. pending_verify renders "Pending approval"). #}
+   vocabulary — e.g. pending_verify renders "Pending approval"). A3: 'approved' here is
+   prepay_status=approved — signed off but NOT wired yet, so it gets the amber "still
+   open work" tone, never the emerald "done" tone; this status value is Prepayment-only
+   (Prepayment.status), no other tab's row status collides with it. #}
 {% set _STATUS_TONES = {
   'draft': 'bg-slate-50 text-slate-500 border-slate-200',
   'pending': 'bg-amber-50 text-amber-600 border-amber-200',
@@ -34,14 +37,19 @@
   'issue': 'bg-rose-50 text-rose-500 border-rose-200',
   'resourcing': 'bg-orange-50 text-orange-600 border-orange-200',
   'requested': 'bg-amber-50 text-amber-600 border-amber-200',
-  'approved': 'bg-emerald-50 text-emerald-600 border-emerald-200',
+  'approved': 'bg-amber-50 text-amber-600 border-amber-200',
   'paid': 'bg-emerald-50 text-emerald-700 border-emerald-300',
   'void': 'bg-gray-50 text-gray-400 border-gray-200',
   'rejected': 'bg-rose-50 text-rose-500 border-rose-200',
   'expired': 'bg-gray-50 text-gray-400 border-gray-200'
 } %}
+{# Label overrides paired with the tone map above — same A3 case: the default
+   capitalize()'d "Approved" reads as done, so spell out what's actually pending. #}
+{% set _STATUS_LABEL_OVERRIDES = {
+  'approved': 'Approved — awaiting wire'
+} %}
 {% macro aw_badge(row) -%}
-<span class="badge {{ _STATUS_TONES.get(row.status, 'bg-gray-50 text-gray-600 border-gray-200') }}">{{ row.status_label }}</span>
+<span class="badge {{ _STATUS_TONES.get(row.status, 'bg-gray-50 text-gray-600 border-gray-200') }}">{{ _STATUS_LABEL_OVERRIDES.get(row.status, row.status_label) }}</span>
 {%- endmacro %}
 
 {# ── Filters — every control targets #aw-list EXPLICITLY (never inherit). #}
@@ -87,9 +95,14 @@
     New buy plan
   </a>
   {% endif %}
-  {# Export CSV — a REAL browser download (hx-boost=false opts out of nav-boost). #}
-  <a hx-boost="false" href="/v2/partials/approvals/{{ tab }}/export?scope={{ scope }}"
-     class="btn-secondary btn-sm flex-shrink-0 whitespace-nowrap" title="Download this list as a CSV file">Export CSV</a>
+  {# Export CSV — a REAL browser download (hx-boost=false opts out of nav-boost). A6:
+     q/show_closed ride along so the CSV can never drift from what's on screen — Live
+     streams the same live rows the list renders, Closed streams the resolved history;
+     the tooltip says which one this click downloads. #}
+  <a hx-boost="false"
+     href="/v2/partials/approvals/{{ tab }}/export?scope={{ scope }}&show_closed={{ 'true' if show_closed else 'false' }}{% if q %}&q={{ q|urlencode }}{% endif %}"
+     class="btn-secondary btn-sm flex-shrink-0 whitespace-nowrap"
+     title="{{ 'Download the resolved/closed history shown below as a CSV file' if show_closed else 'Download the live rows shown below as a CSV file' }}">Export CSV</a>
 </form>
 
 {# Row wrapper is a role="button" DIV, not a <button>: the copy chip inside it is a

--- a/app/templates/htmx/partials/approvals/_workspace_list.html
+++ b/app/templates/htmx/partials/approvals/_workspace_list.html
@@ -133,6 +133,10 @@
 {% endmacro %}
 
 <div class="flex-1 min-h-0 md:overflow-y-auto">
+  {# A7: stalled rows (no configured approver) get their own group, carved out of
+     other_rows, between "Needs your approval" and "Everything else". #}
+  {% set stalled_rows = other_rows | selectattr('stalled') | list %}
+  {% set rest_rows = other_rows | rejectattr('stalled') | list %}
   {% if needs_rows %}
   <div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-accent-600">Needs your approval</div>
   {# data-aw-needs: the auto-advance hook — after a decide, the split selects the
@@ -141,10 +145,16 @@
     {% for row in needs_rows %}{{ list_row(row) }}{% endfor %}
   </div>
   {% endif %}
-  {% if other_rows %}
-  {% if needs_rows %}<div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Everything else</div>{% endif %}
+  {% if stalled_rows %}
+  <div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-amber-600">Stalled — no approver</div>
+  <div class="divide-y divide-line-subtle border-b border-line-base">
+    {% for row in stalled_rows %}{{ list_row(row) }}{% endfor %}
+  </div>
+  {% endif %}
+  {% if rest_rows %}
+  {% if needs_rows or stalled_rows %}<div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Everything else</div>{% endif %}
   <div class="divide-y divide-line-subtle">
-    {% for row in other_rows %}{{ list_row(row) }}{% endfor %}
+    {% for row in rest_rows %}{{ list_row(row) }}{% endfor %}
   </div>
   {% endif %}
   {% if not needs_rows and not other_rows %}

--- a/app/templates/htmx/partials/approvals/_workspace_list.html
+++ b/app/templates/htmx/partials/approvals/_workspace_list.html
@@ -2,13 +2,17 @@
   approvals/_workspace_list.html — the Approvals Workspace left work list (any tab).
   Search (300ms debounce) + Mine/All toggle + live/closed filter, then the rows:
   "Needs your approval" grouped FIRST (oldest first — decision queues surface the
-  stalest work), everything else below. Every row shows its age; Acctivate numbers
-  (SO#/PO#) render as one-tap copy chips (spec §5). Rows dispatch aw-select to fill
-  the right pane; the oldest needs-your-approval row dispatches aw-default once so
-  opening the tab lands the approver on a decision, never a hunt.
-  Receives: tab, q, scope, show_closed, needs_rows / other_rows (list[WorkspaceRow]),
-            default_row (WorkspaceRow|None — the oldest needs-approval row, or the
-            ?select=-deep-linked plan's row/pane stand-in), list_url.
+  stalest work), then (A8, PO tab only) "Your POs to confirm" — the viewer's own
+  AWAITING_PO lines, buyer work rather than a decision — then everything else below
+  (which the "Stalled — no approver" group, A7, is further carved out of). Every row
+  shows its age; Acctivate numbers (SO#/PO#) render as one-tap copy chips (spec §5).
+  Rows dispatch aw-select to fill the right pane; the oldest needs-your-approval row
+  dispatches aw-default once so opening the tab lands the approver on a decision,
+  never a hunt.
+  Receives: tab, q, scope, show_closed, needs_rows / own_confirm_rows / other_rows
+            (list[WorkspaceRow]), default_row (WorkspaceRow|None — the oldest
+            needs-approval row, or the ?select=-deep-linked plan's row/pane stand-in),
+            list_url.
   Called by: htmx/approvals_hub.py approvals_workspace_list (GET /{tab}/list).
   Depends on: HTMX, Alpine.js, Tailwind; shared copy_chip + age_chip macros.
 #}
@@ -145,6 +149,12 @@
     {% for row in needs_rows %}{{ list_row(row) }}{% endfor %}
   </div>
   {% endif %}
+  {% if own_confirm_rows %}
+  <div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-sky-600">Your POs to confirm</div>
+  <div class="divide-y divide-line-subtle border-b border-line-base">
+    {% for row in own_confirm_rows %}{{ list_row(row) }}{% endfor %}
+  </div>
+  {% endif %}
   {% if stalled_rows %}
   <div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-amber-600">Stalled — no approver</div>
   <div class="divide-y divide-line-subtle border-b border-line-base">
@@ -152,12 +162,12 @@
   </div>
   {% endif %}
   {% if rest_rows %}
-  {% if needs_rows or stalled_rows %}<div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Everything else</div>{% endif %}
+  {% if needs_rows or own_confirm_rows or stalled_rows %}<div class="px-3 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Everything else</div>{% endif %}
   <div class="divide-y divide-line-subtle">
     {% for row in rest_rows %}{{ list_row(row) }}{% endfor %}
   </div>
   {% endif %}
-  {% if not needs_rows and not other_rows %}
+  {% if not needs_rows and not own_confirm_rows and not other_rows %}
   <div class="px-4 py-10 text-center text-sm text-brand-400">
     {% if q %}Nothing matches “{{ q }}”.{% elif show_closed %}No closed items{% if scope == 'mine' %} of yours{% endif %}.{% else %}Nothing here{% if scope == 'mine' %} for you{% endif %} — all clear.{% endif %}
   </div>

--- a/app/templates/htmx/partials/approvals/_workspace_list.html
+++ b/app/templates/htmx/partials/approvals/_workspace_list.html
@@ -96,13 +96,16 @@
   </a>
   {% endif %}
   {# Export CSV — a REAL browser download (hx-boost=false opts out of nav-boost). A6:
-     q/show_closed ride along so the CSV can never drift from what's on screen — Live
-     streams the same live rows the list renders, Closed streams the resolved history;
-     the tooltip says which one this click downloads. #}
+     q/show_closed ride along so the CSV can never drift from what's on screen — on
+     prepayments/purchase-orders, Live streams the same live rows the list renders and
+     Closed streams the resolved history, so the tooltip there says which one this click
+     downloads. Sales Orders / Buy Plans export ignores show_closed by design (still the
+     full plan tracking list, live+closed together) — its tooltip stays generic so it
+     never promises a closed-only download it doesn't deliver. #}
   <a hx-boost="false"
      href="/v2/partials/approvals/{{ tab }}/export?scope={{ scope }}&show_closed={{ 'true' if show_closed else 'false' }}{% if q %}&q={{ q|urlencode }}{% endif %}"
      class="btn-secondary btn-sm flex-shrink-0 whitespace-nowrap"
-     title="{{ 'Download the resolved/closed history shown below as a CSV file' if show_closed else 'Download the live rows shown below as a CSV file' }}">Export CSV</a>
+     title="{% if tab in ('sales-orders', 'buy-plans') %}Download this list as a CSV file{% elif show_closed %}Download the resolved/closed history shown below as a CSV file{% else %}Download the live rows shown below as a CSV file{% endif %}">Export CSV</a>
 </form>
 
 {# Row wrapper is a role="button" DIV, not a <button>: the copy chip inside it is a

--- a/app/templates/htmx/partials/approvals/_workspace_list.html
+++ b/app/templates/htmx/partials/approvals/_workspace_list.html
@@ -43,7 +43,7 @@
 {# ── Filters — every control targets #aw-list EXPLICITLY (never inherit). #}
 <form id="aw-filters" class="flex items-center gap-2 p-2 border-b border-line-base bg-gray-50 flex-shrink-0"
       @submit.prevent>
-  <input type="text" name="q" value="{{ q }}" placeholder="Search customer, SO#, part…"
+  <input type="text" id="aw-q" name="q" value="{{ q }}" placeholder="Search customer, SO#, part…"
          aria-label="Search {{ tab }}"
          class="input input-sm flex-1 min-w-0"
          hx-get="{{ list_url }}"

--- a/app/templates/htmx/partials/approvals/_workspace_split.html
+++ b/app/templates/htmx/partials/approvals/_workspace_split.html
@@ -25,9 +25,16 @@
          // Back into the workspace restores that snapshot from cache INSTANTLY — the
          // right tab and deal — instead of a full reload (nav audit #3/#6). Still REPLACE,
          // so the workspace stays ONE history entry and Back exits it in one press.
+         // A10 follow-up: every row click (and the near-immediate aw-default
+         // auto-select) replaces this URL, so it must carry the LIVE scope too — read
+         // it off the filter form's own hidden input (the same source #aw-list's
+         // refetch already trusts via hx-include), not the tab's baked-at-render
+         // value, so Mine never gets silently dropped a moment after a reload restores
+         // it. Defaults to 'all' — unchanged behavior when the form hasn't rendered yet.
+         const liveScope = this.$root.querySelector('#aw-filters [name=scope]')?.value || 'all';
          htmx.ajax('GET', url, {
            target: '#aw-pane', swap: 'innerHTML', indicator: '#aw-pane-ind',
-           replace: '/v2/approvals?tab={{ tab }}&select=' + encodeURIComponent(key),
+           replace: '/v2/approvals?tab={{ tab }}&select=' + encodeURIComponent(key) + '&scope=' + encodeURIComponent(liveScope),
          });
          // Auto-selection (aw-default) must not yank the phone viewport mid-pane
          // (nav audit #8) — scroll only on an explicit row tap.

--- a/app/templates/htmx/partials/approvals/approvals_hub.html
+++ b/app/templates/htmx/partials/approvals/approvals_hub.html
@@ -6,6 +6,9 @@
   into #ap-hub-body. Decisions never navigate — panes decide in place.
   Receives: active_tab (str, one of the four tab keys), tabs (list[(key, label)]),
             badges (dict tab_key → int, items waiting on the viewer),
+            scope ('all'|'mine' — A10: rides the lazy body URL AND each pill's
+            hx-replace-url so a hard reload / shared link keeps Mine instead of
+            snapping back to All),
             select (int|None — plan id from a /v2/buy-plans/{id} deep link; rides the
             lazy body URL so the SO/BP list preselects that plan's pane).
   Called by: htmx/approvals_hub.py approvals_hub_shell (GET /v2/partials/approvals).
@@ -33,7 +36,7 @@
             hx-target="#ap-hub-body"
             hx-swap="innerHTML"
             hx-include="#aw-filters"
-            hx-replace-url="/v2/approvals?tab={{ key }}"
+            hx-replace-url="/v2/approvals?tab={{ key }}&scope={{ scope }}"
             @click="tab = '{{ key }}'"
             :class="tab === '{{ key }}'
                     ? 'bg-accent-600 text-white shadow-sm'
@@ -47,7 +50,7 @@
 
   {# ── Lazy tab body ── (lazy_body macro structurally enforces the explicit hx-target
      guard — see shared/_macros.html for the landmine rationale) #}
-  {% call lazy_body('ap-hub-body', '/v2/partials/approvals/' ~ active_tab ~ (('?select=' ~ select) if select else '')) %}
+  {% call lazy_body('ap-hub-body', '/v2/partials/approvals/' ~ active_tab ~ '?scope=' ~ scope ~ (('&select=' ~ select) if select else '')) %}
     <div class="p-4 text-center text-gray-400 text-sm flex items-center justify-center gap-2">
       <svg class="h-5 w-5 text-gray-400 animate-spin" viewBox="0 0 24 24" fill="none">
         <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2193,6 +2193,34 @@ warnings. The route re-renders the SAME pane via `render_po_pane(po_prefill=…)
 buyer reviews and still clicks Confirm PO. Empty paste / AI failure render
 `po_paste_note` instead. ERP stays untouched: the human transports the text.
 
+**Workspace polish (Tranche G).** Five fixes closed gaps found in a pass over the
+workspace. (A4) The search input got a stable `id="aw-q"` so a list refresh no longer
+steals focus mid-keystroke. (A7) The no-configured-approver stall flag (
+`plan_needs_approver_reason`) now surfaces on BOTH plan lenses — Sales Orders as well
+as Buy Plans, previously Buy-Plans-only — as its own "Stalled — no approver" row
+group, carved out of "Everything else" the same way "Needs your approval" is. (A8) A
+buyer's own AWAITING_PO lines get a dedicated "Your POs to confirm" group instead of
+being folded into "Needs your approval" (`own_confirm` on `WorkspaceRow`, carved out
+by its own flag rather than by exclusion, since `needs` and `own_confirm` aren't
+guaranteed disjoint); `default_row` falls back to the oldest own-confirm row when
+there's nothing to decide, so a buyer with no approvals still lands on their PO work
+on first load. **(A9) authorization tightening on Confirm PO** —
+`confirm_po` (`services/buyplan_workflow/buyplan_po.py`) previously had no ownership
+check; it now raises `PermissionError` unless the actor is the line's assigned buyer
+or a manager/admin, closing a gap where any viewer with plan access (e.g. a co-owner
+sales/trader on the same requisition) could submit someone else's line. The tokenized
+no-login page (`routers/po_confirm.py`) catches `PermissionError` and renders the same
+graceful "inactive" panel — never a raw 500 on a public page — when a token's line was
+reassigned to a different buyer after the link was minted, and the AI paste-prefill
+route carries its own copy of the same gate since it never calls `confirm_po` (no DB
+write) and would otherwise burn a paid AI call on someone else's line. (A6/A3/A10)
+Prepayments/Purchase-Orders exports now stream the SAME live rows the list renders
+(not a surprise history dump) when Closed isn't checked, with `q`/`show_closed` riding
+along so the CSV can never drift from what's on screen; prepayment status `approved`
+reads as amber "Approved — awaiting wire" rather than emerald, since signed-off is not
+yet paid; and `?scope=mine` now threads end-to-end — `v2_page` → the shell route →
+each tab pill's `hx-replace-url` → each row's pushed URL — so a hard reload or a
+shared/bookmarked link restores the viewer's Mine instead of snapping back to All.
 
 **Resell workspace — resell/excess split-panel (Chunk F, ADDITIVE).** `/v2/resell` is
 its own primary-nav tab (9th item in `mobile_nav.html`) served by the `v2_page` shell →

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -502,12 +502,30 @@ def test_po_list_own_awaiting_po_gets_confirm_section(hub_client: TestClient, db
     assert f"line-{line.id}" in body
 
 
+def test_po_list_own_confirm_only_becomes_default_row(hub_client: TestClient, db_session: Session, test_user: User):
+    """A8 follow-up: before the split, own-confirm rows counted as `needs` and could
+    default-select — a buyer with nothing to decide but their own PO to confirm must
+    still land on that row on first load, not a blank pane."""
+    req, q, rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db_session, bp, rq, test_user, status=BuyPlanLineStatus.AWAITING_PO.value)
+    db_session.commit()
+
+    body = hub_client.get("/v2/partials/approvals/purchase-orders/list").text
+    assert "aw-default" in body
+    dispatch = body.split("aw-default")[1]
+    assert f"line-{line.id}" in dispatch
+    assert f"/v2/partials/approvals/po/{line.id}/pane" in dispatch
+
+
 def test_po_list_needs_approval_row_unmoved_by_confirm_split(
     hub_client: TestClient, db_session: Session, test_user: User
 ):
     """A8: a decide-eligible PENDING_VERIFY row still renders under "Needs your
     approval" even when the viewer also has an own-confirm row on the same list — the
-    two sections are disjoint and ordered needs-first, confirm-second."""
+    two sections are disjoint and ordered needs-first, confirm-second. The default row
+    still prefers a decide-eligible row over an own-confirm row (needs-present case
+    unchanged by the A8 follow-up fallback)."""
     req, q, rq = _req_quote(db_session, test_user)
     bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
     verify_line = _pending_verify_line(db_session, bp, rq, test_user)
@@ -523,6 +541,10 @@ def test_po_list_needs_approval_row_unmoved_by_confirm_split(
     confirm_row_idx = body.index(f"line-{confirm_line.id}")
     assert needs_idx < verify_row_idx < confirm_idx  # decide-eligible row IN the needs section
     assert confirm_idx < confirm_row_idx  # own-confirm row IN the confirm section, below it
+
+    dispatch = body.split("aw-default")[1]
+    assert f"line-{verify_line.id}" in dispatch  # default still prefers the decide-eligible row
+    assert f"line-{confirm_line.id}" not in dispatch
 
 
 def test_po_badge_unchanged_by_confirm_split(hub_client: TestClient, db_session: Session, test_user: User):

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -905,6 +905,29 @@ def test_export_anchor_threads_q_scope_show_closed(hub_client: TestClient, db_se
     assert "/v2/partials/approvals/prepayments/export?scope=mine&show_closed=true&q=acme" in r.text
 
 
+@pytest.mark.parametrize("tab", ["sales-orders", "buy-plans"])
+@pytest.mark.parametrize("qs", ["", "?show_closed=true"])
+def test_export_tooltip_generic_for_so_bp_tabs(hub_client: TestClient, tab: str, qs: str):
+    """A6 fix (review finding 1): SO/BP export ignores show_closed by design — it's
+    still the full plan tracking list either way — so its tooltip must never claim a
+    live-only or closed-only download it doesn't actually deliver."""
+    html = hub_client.get(f"/v2/partials/approvals/{tab}/list{qs}").text
+    assert 'title="Download this list as a CSV file"' in html
+    assert "resolved/closed history" not in html
+    assert "live rows shown below" not in html
+
+
+@pytest.mark.parametrize("tab", ["prepayments", "purchase-orders"])
+def test_export_tooltip_live_vs_closed_for_prepayments_and_po(hub_client: TestClient, tab: str):
+    """A6: on the two tabs where show_closed actually changes what's exported, the
+    tooltip says which one this click downloads."""
+    live_html = hub_client.get(f"/v2/partials/approvals/{tab}/list").text
+    assert 'title="Download the live rows shown below as a CSV file"' in live_html
+
+    closed_html = hub_client.get(f"/v2/partials/approvals/{tab}/list?show_closed=true").text
+    assert 'title="Download the resolved/closed history shown below as a CSV file"' in closed_html
+
+
 # ── Origination + hub home (unchanged homes) ─────────────────────────────
 
 

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -487,6 +487,63 @@ def test_po_list_buyer_awaiting_po_lines_listed(hub_client: TestClient, db_sessi
     assert "Awaiting PO" in body
 
 
+def test_po_list_own_awaiting_po_gets_confirm_section(hub_client: TestClient, db_session: Session, test_user: User):
+    """A8: the viewer's own AWAITING_PO line is buyer work ("cut/confirm the PO"), not
+    an approval decision — it renders under "Your POs to confirm", never under "Needs
+    your approval"."""
+    req, q, rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db_session, bp, rq, test_user, status=BuyPlanLineStatus.AWAITING_PO.value)
+    db_session.commit()
+
+    body = hub_client.get("/v2/partials/approvals/purchase-orders/list").text
+    assert "Your POs to confirm" in body
+    assert "Needs your approval" not in body
+    assert f"line-{line.id}" in body
+
+
+def test_po_list_needs_approval_row_unmoved_by_confirm_split(
+    hub_client: TestClient, db_session: Session, test_user: User
+):
+    """A8: a decide-eligible PENDING_VERIFY row still renders under "Needs your
+    approval" even when the viewer also has an own-confirm row on the same list — the
+    two sections are disjoint and ordered needs-first, confirm-second."""
+    req, q, rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    verify_line = _pending_verify_line(db_session, bp, rq, test_user)
+    confirm_line = _line(db_session, bp, rq, test_user, status=BuyPlanLineStatus.AWAITING_PO.value)
+    db_session.commit()
+
+    body = hub_client.get("/v2/partials/approvals/purchase-orders/list").text
+    assert "Needs your approval" in body
+    assert "Your POs to confirm" in body
+    needs_idx = body.index("Needs your approval")
+    confirm_idx = body.index("Your POs to confirm")
+    verify_row_idx = body.index(f"line-{verify_line.id}")
+    confirm_row_idx = body.index(f"line-{confirm_line.id}")
+    assert needs_idx < verify_row_idx < confirm_idx  # decide-eligible row IN the needs section
+    assert confirm_idx < confirm_row_idx  # own-confirm row IN the confirm section, below it
+
+
+def test_po_badge_unchanged_by_confirm_split(hub_client: TestClient, db_session: Session, test_user: User):
+    """A8: the PO tab's "waiting on you" badge is computed independently
+    (_po_waiting_on_viewer) and must not change value because the list now groups
+    own-confirm rows separately from decide-eligible rows."""
+    req, q, rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    _pending_verify_line(db_session, bp, rq, test_user)
+    _line(db_session, bp, rq, test_user, status=BuyPlanLineStatus.AWAITING_PO.value)
+    db_session.commit()
+
+    from app.routers.htmx.approvals_hub import _viewer_badges
+
+    expected = _viewer_badges(db_session, test_user)["purchase-orders"]
+    assert expected == 2  # 1 decide-eligible + 1 own-awaiting, same seed as above
+
+    shell_body = hub_client.get("/v2/partials/approvals").text
+    assert f">{expected}<" in shell_body
+
+
 def test_po_list_closed_shows_verified(hub_client: TestClient, db_session: Session, test_user: User):
     req, q, rq = _req_quote(db_session, test_user)
     bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -423,6 +423,38 @@ def test_so_list_age_on_every_row(hub_client: TestClient, db_session: Session, t
     assert "just now" in txt or "m ago" in txt or "h ago" in txt or "now" in txt.lower()
 
 
+def test_so_list_stalled_pending_plan_warns(hub_client: TestClient, db_session: Session, test_user: User):
+    """A7: stalled_ids is no longer gated to the Buy Plans lens — a PENDING plan with no
+    eligible approver must warn on the SALES ORDERS tab list too, not just Buy Plans."""
+    req, q, _ = _req_quote(db_session, test_user)
+    _plan(db_session, req, q, status=BuyPlanStatus.PENDING.value)
+    # Nobody holds the buy-plan approval right → the pending plan is stalled.
+    test_user.can_approve_buy_plans = False
+    db_session.commit()
+
+    body = hub_client.get("/v2/partials/approvals/sales-orders/list").text
+    assert "No approver configured — stalled" in body
+
+
+def test_so_list_stalled_group_header_present_only_when_stalled(
+    hub_client: TestClient, db_session: Session, test_user: User
+):
+    """A7: a "Stalled — no approver" group renders between "Needs your approval" and
+    "Everything else" when any row is stalled, and is absent otherwise."""
+    req, q, _ = _req_quote(db_session, test_user)
+    _plan(db_session, req, q, status=BuyPlanStatus.PENDING.value)
+    test_user.can_approve_buy_plans = False
+    db_session.commit()
+
+    stalled_body = hub_client.get("/v2/partials/approvals/sales-orders/list").text
+    assert "Stalled — no approver" in stalled_body
+
+    test_user.can_approve_buy_plans = True
+    db_session.commit()
+    clear_body = hub_client.get("/v2/partials/approvals/sales-orders/list").text
+    assert "Stalled — no approver" not in clear_body
+
+
 # ── Purchase Orders list ─────────────────────────────────────────────────
 
 

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -270,6 +270,14 @@ def test_shell_legacy_tab_keys_alias(hub_client: TestClient, legacy: str, mapped
     assert f"/v2/partials/approvals/{mapped}" in r.text  # lazy body loads the MAPPED tab
 
 
+def test_shell_pill_replace_url_carries_scope(hub_client: TestClient):
+    """A10: the tab pill's hx-replace-url carries the current scope — a hard reload or
+    a shared link off that URL restores Mine instead of snapping back to All."""
+    r = hub_client.get("/v2/partials/approvals?scope=mine")
+    assert r.status_code == 200
+    assert 'hx-replace-url="/v2/approvals?tab=sales-orders&scope=mine"' in r.text
+
+
 def test_shell_badges_show_waiting_on_viewer(hub_client: TestClient, db_session: Session, test_user: User):
     req, q, _ = _req_quote(db_session, test_user)
     bp = _plan(db_session, req, q, status=BuyPlanStatus.PENDING.value)
@@ -706,6 +714,24 @@ def test_prepayments_list_approved_unpaid_in_live_and_closed(
     assert f"prepay-{pp.id}" in closed_txt
 
 
+def test_prepayments_list_approved_unpaid_amber_awaiting_wire_label(
+    hub_client: TestClient, db_session: Session, test_user: User
+):
+    """A3: an APPROVED-but-unpaid prepayment row reads as still-open work — amber tone,
+    not the emerald "done" tone a plain 'Approved' would imply."""
+    req, q, _ = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    ar, pp = _pending_prepay_request(db_session, bp, test_user)
+    ar.status = ApprovalRequestStatus.APPROVED.value
+    ar.resolved_at = datetime.now(UTC)
+    pp.status = "approved"
+    db_session.commit()
+
+    txt = hub_client.get("/v2/partials/approvals/prepayments/list").text
+    assert "Approved — awaiting wire" in txt
+    assert "bg-amber-50 text-amber-600 border-amber-200" in txt
+
+
 def test_prepayments_list_paid_stays_out_of_live(hub_client: TestClient, db_session: Session, test_user: User):
     req, q, _ = _req_quote(db_session, test_user)
     bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
@@ -821,6 +847,64 @@ def test_export_streams_csv(hub_client: TestClient, tab: str):
     assert "text/csv" in r.headers["content-type"]
 
 
+def test_prepayments_export_default_is_live_not_resolved_only(
+    hub_client: TestClient, db_session: Session, test_user: User
+):
+    """A6: default export params (no show_closed) build the CSV from the SAME live row
+    builder the list renders — a REQUESTED (decidable-now) row is present; a resolved
+    (terminal) row is not."""
+    req, q, _ = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    _ar, pp = _pending_prepay_request(db_session, bp, test_user)  # live REQUESTED row
+
+    req2, q2, _ = _req_quote(db_session, test_user)
+    bp2 = _plan(db_session, req2, q2, status=BuyPlanStatus.ACTIVE.value)
+    ar2, pp2 = _pending_prepay_request(db_session, bp2, test_user)
+    ar2.status = ApprovalRequestStatus.REJECTED.value  # resolved/terminal — history only
+    ar2.resolved_at = datetime.now(UTC)
+    db_session.commit()
+
+    body = hub_client.get("/v2/partials/approvals/prepayments/export").text
+    assert f"prepay-{pp.id}" in body
+    assert f"prepay-{pp2.id}" not in body
+
+
+def test_prepayments_export_show_closed_contains_resolved_row(
+    hub_client: TestClient, db_session: Session, test_user: User
+):
+    """A6: show_closed=true switches the export to the resolved decision feed."""
+    req, q, _ = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    ar, pp = _pending_prepay_request(db_session, bp, test_user)
+    ar.status = ApprovalRequestStatus.REJECTED.value
+    ar.resolved_at = datetime.now(UTC)
+    db_session.commit()
+
+    body = hub_client.get("/v2/partials/approvals/prepayments/export?show_closed=true").text
+    assert str(pp.id) in body
+
+
+def test_po_export_default_is_live_not_resolved_only(hub_client: TestClient, db_session: Session, test_user: User):
+    """A6: same honesty contract on the Purchase Orders tab — a live PENDING_VERIFY line
+    is in the default export; the resolved decision feed is not."""
+    req, q, rq = _req_quote(db_session, test_user)
+    bp = _plan(db_session, req, q, status=BuyPlanStatus.ACTIVE.value)
+    line = _pending_verify_line(db_session, bp, rq, test_user)
+    db_session.commit()
+
+    body = hub_client.get("/v2/partials/approvals/purchase-orders/export").text
+    assert f"line-{line.id}" in body
+    assert "Outcome" not in body  # the resolved feed's header, absent from the live one
+
+
+def test_export_anchor_threads_q_scope_show_closed(hub_client: TestClient, db_session: Session, test_user: User):
+    """A6: the export button's URL carries the list's current q/scope/show_closed so the
+    download always matches what's on screen."""
+    r = hub_client.get("/v2/partials/approvals/prepayments/list?scope=mine&show_closed=true&q=acme")
+    assert r.status_code == 200
+    assert "/v2/partials/approvals/prepayments/export?scope=mine&show_closed=true&q=acme" in r.text
+
+
 # ── Origination + hub home (unchanged homes) ─────────────────────────────
 
 
@@ -860,10 +944,32 @@ def test_select_threads_shell_to_tab_body_to_list(hub_client: TestClient):
     the full chain a redirected deep link travels."""
     shell = hub_client.get("/v2/partials/approvals?tab=buy-plans&select=42")
     assert shell.status_code == 200
-    assert "/v2/partials/approvals/buy-plans?select=42" in shell.text
+    # The lazy body's hx-get is Jinja-autoescaped (an attribute VALUE, not literal
+    # template text like the pill's hx-replace-url) — & renders as &amp;.
+    assert "/v2/partials/approvals/buy-plans?scope=all&amp;select=42" in shell.text
     body = hub_client.get("/v2/partials/approvals/buy-plans?select=42")
     assert body.status_code == 200
     assert "/v2/partials/approvals/buy-plans/list?scope=all&select=42" in body.text
+
+
+def test_shell_scope_threads_to_tab_body_to_list(hub_client: TestClient):
+    """A10: ?scope= rides the shell's lazy tab-body URL, then the tab body's lazy list
+    URL, down to the list's own hidden scope input — a hard reload or shared link off
+    /v2/approvals?scope=mine restores Mine end to end."""
+    shell = hub_client.get("/v2/partials/approvals?tab=buy-plans&scope=mine")
+    assert shell.status_code == 200
+    assert "/v2/partials/approvals/buy-plans?scope=mine" in shell.text
+    body = hub_client.get("/v2/partials/approvals/buy-plans?scope=mine")
+    assert body.status_code == 200
+    assert "/v2/partials/approvals/buy-plans/list?scope=mine" in body.text
+    list_html = hub_client.get("/v2/partials/approvals/buy-plans/list?scope=mine").text
+    assert 'name="scope" value="mine"' in list_html
+
+
+def test_shell_scope_defaults_to_all(hub_client: TestClient):
+    """No ?scope= on the shell defaults to 'all', unchanged."""
+    shell = hub_client.get("/v2/partials/approvals?tab=buy-plans")
+    assert "/v2/partials/approvals/buy-plans?scope=all" in shell.text
 
 
 def test_list_select_preselects_that_plan_not_the_oldest(hub_client: TestClient, db_session: Session, test_user: User):

--- a/tests/test_approvals_hub_tabs.py
+++ b/tests/test_approvals_hub_tabs.py
@@ -549,6 +549,13 @@ def test_split_refetch_includes_filter_form(hub_client: TestClient, db_session: 
     assert 'hx-include="#aw-filters"' in body
 
 
+def test_search_input_has_stable_id(hub_client: TestClient, db_session: Session, test_user: User):
+    """A4: the search input carries a stable id="aw-q" so htmx restores focus+caret
+    across the 300ms-debounced #aw-list innerHTML swaps instead of stealing focus."""
+    body = hub_client.get("/v2/partials/approvals/sales-orders/list").text
+    assert 'id="aw-q"' in body
+
+
 # ── Prepayments list ─────────────────────────────────────────────────────
 
 

--- a/tests/test_approvals_module_shell.py
+++ b/tests/test_approvals_module_shell.py
@@ -87,6 +87,18 @@ def test_approvals_page_threads_select(nonadmin_client: TestClient):
     assert "select=abc" not in bad.text
 
 
+def test_approvals_page_threads_scope(nonadmin_client: TestClient):
+    """A10: a hard reload of the pushed /v2/approvals?tab=...&scope=mine URL threads
+    scope into the lazy partial URL so the workspace lands back on Mine, not All."""
+    r = nonadmin_client.get("/v2/approvals?tab=buy-plans&scope=mine")
+    assert r.status_code == 200
+    # Jinja autoescapes the & inside hx-get="{{ partial_url }}".
+    assert "/v2/partials/approvals?tab=buy-plans&amp;scope=mine" in r.text
+    # scope=all is the unchanged default — never carried, keeping bare URLs bare.
+    default = nonadmin_client.get("/v2/approvals?tab=buy-plans&scope=all")
+    assert 'hx-get="/v2/partials/approvals?tab=buy-plans"' in default.text
+
+
 def test_approvals_shell_renders_four_tabs(nonadmin_client: TestClient):
     """The Approvals Workspace shell renders all four tab URLs + the lazy-body guard."""
     r = nonadmin_client.get("/v2/partials/approvals")

--- a/tests/test_approvals_resell_export.py
+++ b/tests/test_approvals_resell_export.py
@@ -255,7 +255,9 @@ def test_prepayment_resolved_export_row(client: TestClient, db_session: Session,
     pp = _resolved_prepay(db_session, bp, test_user, beneficiary="Northwind Components LLC")
     db_session.commit()
 
-    resp = client.get("/v2/partials/approvals/prepayment/export")
+    # A6: the resolved audit feed lives behind show_closed=true (default now streams the
+    # SAME live rows the list renders — see test_approvals_hub_tabs.py for that case).
+    resp = client.get("/v2/partials/approvals/prepayment/export?show_closed=true")
     _assert_attachment(resp, filename_contains="approvals_prepayments_resolved_all.csv")
     rows = _parse_csv(resp.text)
 
@@ -277,10 +279,10 @@ def test_prepayment_export_scope_mine_filters_to_own(client: TestClient, db_sess
     theirs = _resolved_prepay(db_session, bp, other, beneficiary="Their Payee LLC")
     db_session.commit()
 
-    all_body = client.get("/v2/partials/approvals/prepayment/export?scope=all").text
+    all_body = client.get("/v2/partials/approvals/prepayment/export?scope=all&show_closed=true").text
     assert str(mine.id) in all_body and str(theirs.id) in all_body
 
-    mine_body = client.get("/v2/partials/approvals/prepayment/export?scope=mine").text
+    mine_body = client.get("/v2/partials/approvals/prepayment/export?scope=mine&show_closed=true").text
     assert "Mine Payee LLC" in mine_body
     assert "Their Payee LLC" not in mine_body
 
@@ -294,7 +296,9 @@ def test_po_approval_history_export_row(client: TestClient, db_session: Session,
     _po_history(db_session, bp, test_user)
     db_session.commit()
 
-    resp = client.get("/v2/partials/approvals/po-approval/export")
+    # A6: the resolved PO decision feed lives behind show_closed=true (default now
+    # streams the SAME live rows the list renders).
+    resp = client.get("/v2/partials/approvals/po-approval/export?show_closed=true")
     _assert_attachment(resp, filename_contains="approvals_po_resolved.csv")
     rows = _parse_csv(resp.text)
 

--- a/tests/test_buyplan_workflow.py
+++ b/tests/test_buyplan_workflow.py
@@ -498,7 +498,9 @@ class TestConfirmPO:
         self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
     ):
         plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value)
-        line = _make_line(db_session, plan, status=BuyPlanLineStatus.AWAITING_PO.value)
+        # A9: confirm_po now gates to the line's assigned buyer or a manager/admin —
+        # test_user is the actor here, so it must also be the line's buyer.
+        line = _make_line(db_session, plan, status=BuyPlanLineStatus.AWAITING_PO.value, buyer_id=test_user.id)
         db_session.refresh(plan)
 
         ship_date = datetime.now(UTC) + timedelta(days=7)
@@ -532,7 +534,9 @@ class TestConfirmPO:
         self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
     ):
         plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value)
-        line = _make_line(db_session, plan, status=BuyPlanLineStatus.VERIFIED.value)
+        # A9: the actor gate runs before the state check, so test_user must be the
+        # line's buyer to reach the "must be awaiting PO" ValueError this test targets.
+        line = _make_line(db_session, plan, status=BuyPlanLineStatus.VERIFIED.value, buyer_id=test_user.id)
         with pytest.raises(ValueError, match="Line must be awaiting PO"):
             confirm_po(plan.id, line.id, "PO-X", datetime.now(UTC), test_user, db_session, payment_method="wire")
 

--- a/tests/test_nav_wayfinding.py
+++ b/tests/test_nav_wayfinding.py
@@ -350,6 +350,16 @@ def test_select_drives_url_through_htmx_not_raw_pushstate():
     assert "history.replaceState(history.state" not in src
 
 
+def test_select_replace_url_carries_live_scope():
+    # A10 follow-up: a row click (and the near-immediate aw-default auto-select) must
+    # NOT strip Mine back to All in the address bar — select() reads the LIVE scope off
+    # the filter form's own hidden input (not a value baked at the tab body's render)
+    # and appends it to the same replace: URL.
+    src = (_T / "approvals/_workspace_split.html").read_text()
+    assert "#aw-filters [name=scope]" in src
+    assert "&scope=' + encodeURIComponent(liveScope)" in src
+
+
 def test_hub_tab_seeds_from_url():
     # The tab-pill highlight (Alpine `tab`) must seed from the URL, so a history restore
     # shows the restored tab active instead of the first-rendered tab.

--- a/tests/test_po_confirm_gate.py
+++ b/tests/test_po_confirm_gate.py
@@ -244,8 +244,17 @@ class TestParseConfirmationGate:
     ):
         bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
 
+        prefill = {
+            "po_number": "PO-99123",
+            "estimated_ship_date": None,
+            "payment_method": None,
+            "serial_numbers": None,
+            "warnings": [],
+        }
         with patch(
-            "app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock, return_value=None
+            "app.routers.htmx.approvals_hub.parse_po_confirmation",
+            new_callable=AsyncMock,
+            return_value=prefill,
         ) as mock_parse:
             resp = manager_client.post(
                 f"/v2/partials/approvals/po/{line.id}/parse-confirmation",
@@ -253,3 +262,8 @@ class TestParseConfirmationGate:
             )
         assert resp.status_code == 200
         mock_parse.assert_called_once()
+        # A manager may act for the buyer through this gate: the route re-renders the
+        # pane with the AI-filled banner and the mocked parse result's PO number
+        # actually landed in the confirm-form field — not just a 200 with no content.
+        assert "AI-filled from your paste" in resp.text
+        assert 'value="PO-99123"' in resp.text

--- a/tests/test_po_confirm_gate.py
+++ b/tests/test_po_confirm_gate.py
@@ -1,0 +1,255 @@
+"""tests/test_po_confirm_gate.py — A9: confirm-PO gated to the line's assigned buyer or
+a manager/admin (service + route + pane + AI paste-prefill).
+
+Before this fix, ANY viewer with plan access (e.g. a co-owner sales/trader on the same
+requisition) could submit the confirm-PO form for someone else's line — the service had
+no actor check at all. This closes that gap by mirroring the exact buyer-or-manager
+idiom ``mark_line_received`` already enforces (buyplan_po.py:126) inside ``confirm_po``,
+and gives the AI paste-prefill route (which never calls confirm_po — it only pre-fills
+the form, no DB write) its own copy of the same gate.
+
+Covers:
+  - SERVICE: confirm_po raises PermissionError for a non-assigned non-manager; an
+    assigned buyer and a manager/admin both proceed.
+  - ROUTE: POSTing the confirm form as a non-assigned, non-manager viewer → 403, line
+    unchanged; a manager acting for the buyer → 200.
+  - PANE: a non-assigned viewer's pane shows the read-only "Awaiting PO — assigned to
+    {buyer}" card and NOT the confirm form; a manager's pane shows the same card plus
+    an "Act for the buyer" expander that reveals the form; the assigned buyer still
+    sees the form outright.
+  - parse-confirmation: refuses the same non-assigned, non-manager user, with no AI
+    call burned.
+
+Called by: pytest
+Depends on: conftest (db_session, test_user, manager_user, client, manager_client),
+    tests.test_approvals_hub_tabs builders (_req_quote, _plan, _line),
+    app.services.buyplan_workflow (confirm_po).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import BuyPlanLineStatus, BuyPlanStatus
+from app.database import get_db
+from app.dependencies import require_user
+from app.models import User
+from app.services.buyplan_workflow import confirm_po
+from tests.test_approvals_hub_tabs import _line, _plan, _req_quote
+
+# ── Fixtures / builders ──────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def other_buyer(db_session: Session) -> User:
+    """A second buyer-role user, distinct from test_user — the line's ACTUAL assigned
+    buyer in the gap scenarios below."""
+    user = User(
+        email="otherbuyer@trioscs.com",
+        name="Other Buyer",
+        role="buyer",
+        azure_id=f"test-azure-id-other-buyer-{uuid.uuid4().hex[:8]}",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _line_assigned_to_other(db: Session, owner: User, other: User, **overrides) -> tuple:
+    """An ACTIVE plan OWNED by *owner* (so per-record ownership/get_buyplan_for_user
+    passes) whose AWAITING_PO line is assigned to *other* — the exact non-assigned-
+    non-manager gap A9 closes: the viewer has plan access but is not the line's buyer."""
+    req, q, rq = _req_quote(db, owner)
+    bp = _plan(db, req, q, status=BuyPlanStatus.ACTIVE.value)
+    line = _line(db, bp, rq, owner, status=BuyPlanLineStatus.AWAITING_PO.value, buyer_id=other.id, **overrides)
+    db.commit()
+    return bp, line
+
+
+def _client_as(db_session: Session, user: User) -> TestClient:
+    """A raw TestClient authed as *user* — for actors with no dedicated conftest fixture
+    (the line's own assigned buyer, who is a fresh per-test user here)."""
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: user
+    return TestClient(app)
+
+
+def _pop_overrides():
+    from app.main import app
+
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(require_user, None)
+
+
+# ── (a) SERVICE gate ─────────────────────────────────────────────────────
+
+
+class TestConfirmPoServiceGate:
+    def test_non_assigned_non_manager_blocked(self, db_session: Session, test_user: User, other_buyer: User):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        with pytest.raises(PermissionError, match="buyer or a manager"):
+            confirm_po(bp.id, line.id, "PO-HACK", datetime.now(UTC), test_user, db_session, payment_method="wire")
+        db_session.rollback()
+        db_session.refresh(line)
+        assert line.status == BuyPlanLineStatus.AWAITING_PO.value
+        assert line.po_number is None
+
+    def test_assigned_buyer_proceeds(self, db_session: Session, test_user: User, other_buyer: User):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        updated = confirm_po(
+            bp.id, line.id, "PO-BUYER", datetime.now(UTC), other_buyer, db_session, payment_method="wire"
+        )
+        assert updated.status == BuyPlanLineStatus.PENDING_VERIFY.value
+        assert updated.po_number == "PO-BUYER"
+
+    def test_manager_proceeds(self, db_session: Session, test_user: User, other_buyer: User, manager_user: User):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        updated = confirm_po(
+            bp.id, line.id, "PO-MGR", datetime.now(UTC), manager_user, db_session, payment_method="wire"
+        )
+        assert updated.status == BuyPlanLineStatus.PENDING_VERIFY.value
+
+    def test_admin_proceeds(self, db_session: Session, test_user: User, other_buyer: User, admin_user: User):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        updated = confirm_po(
+            bp.id, line.id, "PO-ADMIN", datetime.now(UTC), admin_user, db_session, payment_method="wire"
+        )
+        assert updated.status == BuyPlanLineStatus.PENDING_VERIFY.value
+
+
+# ── (b) ROUTE gate ───────────────────────────────────────────────────────
+
+
+class TestConfirmPoRouteGate:
+    def test_non_assigned_viewer_403s_line_unchanged(
+        self, client: TestClient, db_session: Session, test_user: User, other_buyer: User
+    ):
+        """Client is authed as test_user, who owns the plan but is NOT the line's buyer
+        — exactly the reported gap."""
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        resp = client.post(
+            f"/v2/partials/buy-plans/{bp.id}/lines/{line.id}/confirm-po",
+            data={"po_number": "PO-HACK", "payment_method": "wire"},
+        )
+        assert resp.status_code == 403
+        db_session.expire_all()
+        assert line.status == BuyPlanLineStatus.AWAITING_PO.value
+        assert line.po_number is None
+
+    def test_manager_route_succeeds_acting_for_the_buyer(
+        self, manager_client: TestClient, db_session: Session, test_user: User, other_buyer: User
+    ):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        with patch("app.services.buyplan_notifications.run_notify_bg", new_callable=AsyncMock):
+            resp = manager_client.post(
+                f"/v2/partials/buy-plans/{bp.id}/lines/{line.id}/confirm-po",
+                data={"po_number": "PO-MGR-ROUTE", "payment_method": "wire"},
+            )
+        assert resp.status_code == 200
+        db_session.expire_all()
+        assert line.status == BuyPlanLineStatus.PENDING_VERIFY.value
+        assert line.po_number == "PO-MGR-ROUTE"
+
+    def test_assigned_buyer_route_still_succeeds(self, db_session: Session, test_user: User, other_buyer: User):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        c = _client_as(db_session, other_buyer)
+        try:
+            with patch("app.services.buyplan_notifications.run_notify_bg", new_callable=AsyncMock):
+                resp = c.post(
+                    f"/v2/partials/buy-plans/{bp.id}/lines/{line.id}/confirm-po",
+                    data={"po_number": "PO-SELF", "payment_method": "wire"},
+                )
+        finally:
+            _pop_overrides()
+        assert resp.status_code == 200
+        db_session.expire_all()
+        assert line.status == BuyPlanLineStatus.PENDING_VERIFY.value
+
+
+# ── (c) PANE rendering ───────────────────────────────────────────────────
+
+
+class TestPoPanePresentsByActor:
+    def test_non_assigned_viewer_sees_readonly_card_not_form(
+        self, client: TestClient, db_session: Session, test_user: User, other_buyer: User
+    ):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        body = client.get(f"/v2/partials/approvals/po/{line.id}/pane").text
+        assert "Awaiting PO — assigned to Other Buyer" in body
+        assert "Confirm the PO you cut in Acctivate" not in body
+        assert 'name="po_number"' not in body
+        assert "Act for the buyer" not in body  # plain viewer, not a manager
+
+    def test_manager_pane_shows_expander_revealing_the_same_form(
+        self, manager_client: TestClient, db_session: Session, test_user: User, other_buyer: User
+    ):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        body = manager_client.get(f"/v2/partials/approvals/po/{line.id}/pane").text
+        assert "Awaiting PO — assigned to Other Buyer" in body
+        assert "Act for the buyer" in body
+        # The form is present in the DOM (behind x-show), so the manager can act.
+        assert "Confirm the PO you cut in Acctivate" in body
+        assert 'name="po_number"' in body
+
+    def test_assigned_buyer_pane_shows_form_outright(self, db_session: Session, test_user: User, other_buyer: User):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        c = _client_as(db_session, other_buyer)
+        try:
+            body = c.get(f"/v2/partials/approvals/po/{line.id}/pane").text
+        finally:
+            _pop_overrides()
+        assert "Confirm the PO you cut in Acctivate" in body
+        assert "Awaiting PO — assigned to" not in body
+
+
+# ── (d) parse-confirmation gate ──────────────────────────────────────────
+
+
+class TestParseConfirmationGate:
+    def test_non_assigned_non_manager_403s_without_ai_call(
+        self, client: TestClient, db_session: Session, test_user: User, other_buyer: User
+    ):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        with patch("app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock) as mock_parse:
+            resp = client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation",
+                data={"pasted_text": "PO confirmation text"},
+            )
+        assert resp.status_code == 403
+        mock_parse.assert_not_called()
+
+    def test_manager_parse_confirmation_allowed(
+        self, manager_client: TestClient, db_session: Session, test_user: User, other_buyer: User
+    ):
+        bp, line = _line_assigned_to_other(db_session, test_user, other_buyer)
+
+        with patch(
+            "app.routers.htmx.approvals_hub.parse_po_confirmation", new_callable=AsyncMock, return_value=None
+        ) as mock_parse:
+            resp = manager_client.post(
+                f"/v2/partials/approvals/po/{line.id}/parse-confirmation",
+                data={"pasted_text": "PO confirmation text"},
+            )
+        assert resp.status_code == 200
+        mock_parse.assert_called_once()

--- a/tests/test_po_confirm_link.py
+++ b/tests/test_po_confirm_link.py
@@ -20,6 +20,7 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -125,6 +126,40 @@ def test_resourcing_line_renders_inactive_panel(client: TestClient, db_session, 
     r = client.get(f"/po/confirm/{token}")
     assert r.status_code == 200
     assert "isn't awaiting a PO" in r.text
+
+
+def test_reassigned_buyer_renders_inactive_panel_not_500(client: TestClient, db_session, test_user: User):
+    """A9 follow-up: the line's buyer was reassigned after the confirm email (and its
+    token) went out. confirm_po's actor gate now raises PermissionError for the stale
+    token's buyer — the route must never surface that as a raw 500 on this public,
+    no-login page; it renders the same graceful inactive panel other stale-link cases
+    use, and the line stays untouched."""
+    _bp, line = _active_line(db_session, test_user)
+    token = mint_po_confirm_token(line.id, test_user.id)
+
+    other_buyer = User(
+        email="reassigned-buyer@trioscs.com",
+        name="Reassigned Buyer",
+        role="buyer",
+        azure_id="test-azure-id-reassigned-buyer",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(other_buyer)
+    db_session.commit()
+    line.buyer_id = other_buyer.id  # reassigned AFTER the token above was minted
+    db_session.commit()
+
+    r = client.post(
+        f"/po/confirm/{token}",
+        data={"po_number": "PO-STALE", "estimated_ship_date": "2026-09-01", "payment_method": "wire"},
+    )
+    assert r.status_code == 200
+    assert "isn't awaiting a PO" in r.text  # the SAME inactive-panel copy, not a 500
+
+    db_session.expire_all()
+    fresh = db_session.get(BuyPlanLine, line.id)
+    assert fresh.status == BuyPlanLineStatus.AWAITING_PO.value  # unchanged
+    assert fresh.po_number is None
 
 
 # ── The approval notification carries the relay links ─────────────────────


### PR DESCRIPTION
Phase 3 (do-all plan) approvals-ux stream — the re-verified Tranche G residuals. **Merge is owner-gated — do not merge without the owner's word.**

## What

- **A4** — the workspace search box no longer eats keystrokes: stable id lets htmx restore focus across the debounce swap.
- **A7** — "No approver configured — stalled" now flags on the Sales Orders tab too (was buy-plans-only), with a dedicated "Stalled — no approver" section for rows nobody can act on.
- **A8** — buyers' cut-the-PO work gets its own "Your POs to confirm" section instead of masquerading as "Needs your approval"; the tab badge stays the sum; first-load landing preserved (falls back to your confirm row when no approvals wait).
- **A9 (authz fix)** — confirm-PO is now gated to the assigned buyer or a manager, at the SERVICE level (previously any viewer with plan access could confirm someone else's line). Others see a read-only "assigned to {buyer}" card; managers get an "Act for the buyer" expander. The AI paste-prefill route carries the same gate; the public tokenized confirm page renders its graceful stale panel (not a 500) if the buyer was reassigned after the email went out.
- **A6/A3/A10** — Export CSV now downloads the live rows the list shows (resolved history behind the Closed toggle; honest per-tab tooltip); approved-unpaid prepayments render amber "Approved — awaiting wire"; Mine/All scope survives tab switches, row selection, hard reloads, and shared links.

## Evidence

- Full suite in worktree: `24626 passed, 35 skipped, 0 FAILED` (pasted in the gate report).
- 5 task reviews (3 fix rounds: default-row landing, tokenized stale panel, tooltip + live-scope URL) + whole-branch final review clean — the reviewer independently swept every confirm-PO path for gate bypasses and found none. NO migration.

## Post-deploy check

Approvals workspace: type in search (focus holds); Sales Orders tab shows a stalled flag if any plan lacks an approver; PO tab shows "Your POs to confirm" separately; open another buyer's awaiting-PO line (read-only card, no form); toggle Mine → switch tabs → F5 (stays Mine); Export on Prepayments Live downloads the pending rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkHRARudqRbahKpsFDmUQa