### PR TITLE
Integrations: Graph calendar webhooks + 8x8 poll every 5 minutes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -359,7 +359,7 @@ class Settings(BaseSettings):
     eight_by_eight_pbx_id: str = ""
     eight_by_eight_timezone: str = "America/Los_Angeles"
     eight_by_eight_enabled: bool = False
-    eight_by_eight_poll_interval_minutes: int = 30
+    eight_by_eight_poll_interval_minutes: int = 5
 
     # --- Lusha Enrichment (key via get_credential_cached, NOT a Settings field) ---
     lusha_enrichment_enabled: bool = False  # feature gate; off → chain == today

--- a/app/jobs/eight_by_eight_jobs.py
+++ b/app/jobs/eight_by_eight_jobs.py
@@ -1,6 +1,7 @@
 """eight_by_eight_jobs.py — 8x8 Work Analytics polling job.
 
-Polls 8x8 CDR API every 30 minutes for call activity.
+Polls 8x8 CDR API every 5 minutes for call activity (env-overridable via
+EIGHT_BY_EIGHT_POLL_INTERVAL_MINUTES; cheap because the access token is cached).
 Writes matched calls to activity_log and updates company.last_activity_at.
 
 Business Rules:

--- a/app/services/calendar_intelligence.py
+++ b/app/services/calendar_intelligence.py
@@ -116,12 +116,12 @@ async def scan_calendar_events(token: str, user_id: int, db: Session, lookback_d
                 attendee_emails.append(email)
 
         # Organizer email
-        organizer_data = event.get("organizer", {}).get("emailAddress", {})
+        organizer_data = (event.get("organizer") or {}).get("emailAddress", {})
         organizer_email = (organizer_data.get("address") or "").strip().lower() or None
 
         # Start / end times
-        start_dt = _parse_graph_dt(event.get("start", {}).get("dateTime"))
-        end_dt = _parse_graph_dt(event.get("end", {}).get("dateTime"))
+        start_dt = _parse_graph_dt((event.get("start") or {}).get("dateTime"))
+        end_dt = _parse_graph_dt((event.get("end") or {}).get("dateTime"))
         if start_dt is None:
             continue  # Can't stamp occurred_at without a start time
         if end_dt is None:

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -79,9 +79,9 @@ def _active_subscription(db: Session, user_id: int, resource: str | None = None)
     Graph *resource*.
 
     The single existing-row query behind both create_* paths and
-    ``ensure_all_users_subscribed``. NOTE: the mail create path deliberately passes no
-    resource (its historical check matches ANY active row for the user); every other
-    caller filters by resource.
+    ``ensure_all_users_subscribed``. Every caller filters by resource so an active
+    subscription for one resource (e.g. calendar) never blocks creation of another
+    (e.g. mail).
     """
     q = db.query(GraphSubscription).filter(
         GraphSubscription.user_id == user_id,
@@ -101,14 +101,16 @@ async def _create_graph_subscription(
     webhook_path: str,
     err_label: str,
     created_log: str,
+    change_type: str = "created",
 ) -> GraphSubscription | None:
     """POST a new Graph webhook subscription and persist its GraphSubscription row.
 
     The shared tail of ``create_mail_subscription`` / ``create_teams_subscription`` —
-    identical apart from the resource, webhook path, and log wording (*err_label*
-    prefixes the failure logs; *created_log* is a format template taking
-    ``sub_id``/``email``/``expiration``). Callers have already taken the per-user
-    lock and checked for an existing active row.
+    identical apart from the resource, webhook path, log wording (*err_label* prefixes
+    the failure logs; *created_log* is a format template taking
+    ``sub_id``/``email``/``expiration``), and the Graph ``changeType`` (*change_type*,
+    defaults to ``"created"`` — existing callers are unaffected). Callers have already
+    taken the per-user lock and checked for an existing active row.
     """
     from app.utils.graph_client import GraphClient
 
@@ -116,7 +118,7 @@ async def _create_graph_subscription(
     expiration = datetime.now(UTC) + timedelta(hours=SUBSCRIPTION_LIFETIME_HOURS)
 
     payload = {
-        "changeType": "created",
+        "changeType": change_type,
         "notificationUrl": f"{settings.app_url}{webhook_path}",
         "resource": resource,
         "expirationDateTime": expiration.strftime("%Y-%m-%dT%H:%M:%S.0000000Z"),
@@ -139,7 +141,7 @@ async def _create_graph_subscription(
         user_id=user.id,
         subscription_id=sub_id,
         resource=resource,
-        change_type="created",
+        change_type=change_type,
         expiration_dt=expiration,
         client_state=client_state,
     )
@@ -165,8 +167,9 @@ async def create_mail_subscription(user: User, db: Session) -> GraphSubscription
     # Serialize subscription creation per-user to avoid duplicate active rows
     db.query(User).filter(User.id == user.id).with_for_update().first()
 
-    # Check for existing active subscription
-    existing = _active_subscription(db, user.id)
+    # Check for existing active subscription, scoped to the mail resource so an
+    # active subscription for another resource (e.g. calendar) never blocks this one.
+    existing = _active_subscription(db, user.id, resource="/me/messages")
     if existing:
         logger.debug(f"Active subscription exists for {user.email}: {existing.subscription_id}")
         return existing

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -28,7 +28,7 @@ from app.config import settings
 from app.constants import UserRole
 from app.models import ActivityLog, GraphSubscription, User
 
-# Graph webhook subscriptions for mail expire after max 3 days (4230 min)
+# Graph webhook subscriptions for mail expire after max 7 days (10,080 min)
 SUBSCRIPTION_LIFETIME_HOURS = 70  # ~3 days, renew before expiry
 
 # HTTP status codes returned by GraphClient.patch_json that confirm the
@@ -492,14 +492,14 @@ async def _handle_calendar_notification(notif: dict, token: str, user: User, db:
         return
 
     subject = (event.get("subject") or "").strip()
-    start_dt = _parse_graph_dt(event.get("start", {}).get("dateTime"))
-    end_dt = _parse_graph_dt(event.get("end", {}).get("dateTime"))
+    start_dt = _parse_graph_dt((event.get("start") or {}).get("dateTime"))
+    end_dt = _parse_graph_dt((event.get("end") or {}).get("dateTime"))
     if start_dt is None:
         return
     if end_dt is None:
         end_dt = start_dt
 
-    organizer_data = event.get("organizer", {}).get("emailAddress", {})
+    organizer_data = (event.get("organizer") or {}).get("emailAddress", {})
     organizer_email = (organizer_data.get("address") or "").strip().lower() or None
 
     attendee_emails = []

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -1,11 +1,12 @@
-"""Graph webhook service — subscribe to mail events, process notifications.
+"""Graph webhook service — subscribe to mail/calendar events, process notifications.
 
-Microsoft Graph sends push notifications when emails arrive or are sent.
-We validate, fetch the message details, and auto-log activities.
+Microsoft Graph sends push notifications when emails arrive, are sent, or calendar
+events are created. We validate, fetch the item details, and auto-log activities.
 
 Usage:
-    # Create subscription for a user
+    # Create subscriptions for a user
     await create_mail_subscription(user, db)
+    await create_calendar_subscription(user, db)
 
     # Handle incoming webhook POST (called from the FastAPI endpoint)
     await handle_notification(payload, db)
@@ -20,6 +21,7 @@ import time
 from datetime import UTC, datetime, timedelta
 
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -185,6 +187,45 @@ async def create_mail_subscription(user: User, db: Session) -> GraphSubscription
     )
 
 
+async def create_calendar_subscription(user: User, db: Session) -> GraphSubscription | None:
+    """Create a Graph webhook subscription for a user's calendar.
+
+    Subscribes to /me/events with changeType="created" only — deliberately NOT
+    "created,updated". Graph would also notify on reschedules/detail edits, but
+    log_meeting_activity dedupes on external_id "calendar-{graph_event_id}", so an
+    "updated" notification for an already-logged event is a no-op after burning a Graph
+    fetch for nothing. Routed to the same /api/webhooks/graph endpoint as mail; branched
+    in handle_notification by subscription resource.
+    """
+    from app.scheduler import get_valid_token
+
+    token = await get_valid_token(user, db)
+    if not token:
+        logger.warning(f"No valid token for {user.email}, skipping calendar subscription")
+        return None
+
+    # Serialize subscription creation per-user to avoid duplicate active rows
+    db.scalar(select(User.id).where(User.id == user.id).with_for_update())
+
+    # Check for existing active calendar subscription, scoped to the calendar resource
+    # so an active subscription for another resource (e.g. mail) never blocks this one.
+    existing = _active_subscription(db, user.id, resource="/me/events")
+    if existing:
+        logger.debug(f"Active calendar subscription exists for {user.email}: {existing.subscription_id}")
+        return existing
+
+    return await _create_graph_subscription(
+        user,
+        db,
+        token,
+        resource="/me/events",
+        webhook_path="/api/webhooks/graph",
+        err_label="calendar ",
+        created_log="Created Graph calendar subscription {sub_id} for {email}, expires {expiration}",
+        change_type="created",
+    )
+
+
 async def create_teams_subscription(user: User, db: Session) -> GraphSubscription | None:
     """Create a Graph webhook subscription for Teams chat messages for this user."""
     from app.scheduler import get_valid_token
@@ -296,7 +337,8 @@ async def renew_expiring_subscriptions(db: Session):
 
 
 async def ensure_all_users_subscribed(db: Session):
-    """Create mail and Teams subscriptions for any M365-connected user missing them."""
+    """Create mail, calendar, and Teams subscriptions for any M365-connected user
+    missing them."""
     users = (
         db.query(User)
         .filter(
@@ -310,6 +352,11 @@ async def ensure_all_users_subscribed(db: Session):
         # Mail subscription
         if not _active_subscription(db, user.id, resource="/me/messages"):
             await create_mail_subscription(user, db)
+
+        # Calendar subscription — not mvp_mode-gated (only Teams is; calendar
+        # tracking is core CRM activity logging, not a Teams-specific feature)
+        if not _active_subscription(db, user.id, resource="/me/events"):
+            await create_calendar_subscription(user, db)
 
         # Teams subscription (skip in MVP mode)
         if not settings.mvp_mode:
@@ -404,6 +451,73 @@ def validate_notifications(payload: dict, db: Session) -> list[dict]:
 # ═══════════════════════════════════════════════════════════════════════
 
 
+async def _handle_calendar_notification(notif: dict, token: str, user: User, db: Session) -> None:
+    """Process a single validated calendar notification.
+
+    Fetches the event from Graph, skips cancelled events, then calls
+    log_meeting_activity directly (the daily 06:00 calendar scan's writer, minus its
+    create_unlinked_fallback=True — a real-time notification for a meeting with no CRM-
+    matched attendee logs nothing rather than writing an unlinked row for every
+    personal/internal meeting created). The external_id dedup key
+    ("calendar-{graph_event_id}") is shared with the daily scan, so a webhook
+    notification and a later poll of the same event can never double-log it.
+    """
+    from app.services.activity_service import log_meeting_activity
+    from app.services.calendar_intelligence import _parse_graph_dt
+    from app.utils.graph_client import GraphClient
+
+    resource = notif.get("resource", "")
+
+    gc = GraphClient(token)
+    try:
+        event = await gc.get_json(
+            f"/{resource}",
+            params={"$select": "id,subject,attendees,start,end,location,organizer,isCancelled"},
+        )
+    except Exception as e:
+        logger.error(f"Failed to fetch calendar event for notification: {e}")
+        return
+
+    if event.get("isCancelled"):
+        logger.debug(f"Skipping cancelled event {event.get('id')} for {user.email}")
+        return
+
+    graph_event_id = (event.get("id") or "").strip()
+    if not graph_event_id:
+        return
+
+    subject = (event.get("subject") or "").strip()
+    start_dt = _parse_graph_dt(event.get("start", {}).get("dateTime"))
+    end_dt = _parse_graph_dt(event.get("end", {}).get("dateTime"))
+    if start_dt is None:
+        return
+    if end_dt is None:
+        end_dt = start_dt
+
+    organizer_data = event.get("organizer", {}).get("emailAddress", {})
+    organizer_email = (organizer_data.get("address") or "").strip().lower() or None
+
+    attendee_emails = []
+    for att in event.get("attendees", []):
+        email = (att.get("emailAddress", {}).get("address") or "").strip().lower()
+        if email and "@" in email:
+            attendee_emails.append(email)
+
+    location_name = (event.get("location", {}) or {}).get("displayName") or None
+
+    log_meeting_activity(
+        user_id=user.id,
+        graph_event_id=graph_event_id,
+        subject=subject,
+        start_dt=start_dt,
+        end_dt=end_dt,
+        organizer_email=organizer_email,
+        attendee_emails=attendee_emails,
+        location=location_name,
+        db=db,
+    )
+
+
 async def handle_notification(payload: dict, db: Session, validated: list[dict] | None = None):
     """Process a Graph webhook notification payload.
 
@@ -412,6 +526,10 @@ async def handle_notification(payload: dict, db: Session, validated: list[dict] 
     ``validate_notifications`` — one canonical copy of the security-relevant
     subscription/clientState/replay checks (the production caller always
     pre-validates; the fallback exists for direct/back-compat callers).
+
+    Routes each notification by subscription resource:
+    - /me/messages  → mail path below (fetch message, log_email_activity, poll inbox)
+    - /me/events    → calendar path (_handle_calendar_notification)
 
     Graph sends a list of notifications. For each, we fetch the message
     from Graph, log it as an activity, and trigger inbox poll for RFQ
@@ -431,6 +549,21 @@ async def handle_notification(payload: dict, db: Session, validated: list[dict] 
 
     for notif in items:
         user = notif["_user"]
+        sub = notif["_subscription"]
+
+        # Calendar notifications are routed to their own handler before the mail
+        # branch's own `changeType != "created"` drop below — calendar subscriptions
+        # are created with changeType="created" only (see create_calendar_subscription),
+        # but Graph is checked defensively here too rather than trusted to always honor
+        # the subscribed changeType.
+        if sub.resource == "/me/events":
+            if notif.get("changeType") != "created":
+                continue
+            token = await get_valid_token(user, db)
+            if not token:
+                continue
+            await _handle_calendar_notification(notif, token, user, db)
+            continue
 
         resource = notif.get("resource", "")
         change_type = notif.get("changeType")

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -461,6 +461,11 @@ async def _handle_calendar_notification(notif: dict, token: str, user: User, db:
     personal/internal meeting created). The external_id dedup key
     ("calendar-{graph_event_id}") is shared with the daily scan, so a webhook
     notification and a later poll of the same event can never double-log it.
+
+    Note: an unmatched-attendee meeting isn't lost — the daily scan's unlinked
+    fallback backfills it (latency only). But that scan is a 30-day LOOKBACK
+    (see scan_calendar_events), so a far-future meeting only gets backfilled
+    once its start time has passed into that window.
     """
     from app.services.activity_service import log_meeting_activity
     from app.services.calendar_intelligence import _parse_graph_dt

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -97,7 +97,8 @@ column (not encoded in `activity_type`). Readers that distinguish direction
    `EIGHT_BY_EIGHT_API_KEY`, `EIGHT_BY_EIGHT_USERNAME`,
    `EIGHT_BY_EIGHT_PASSWORD`, `EIGHT_BY_EIGHT_PBX_ID`
    (`EIGHT_BY_EIGHT_TIMEZONE` / `EIGHT_BY_EIGHT_POLL_INTERVAL_MINUTES` have
-   defaults).
+   defaults — the poll defaults to every 5 minutes, cheap since the access
+   token is cached).
 2. Per user whose calls should be logged: set their `eight_by_eight_extension`
    and enable their per-user `eight_by_eight_enabled` toggle in user settings.
 3. On restart, `register_eight_by_eight_jobs()` schedules the CDR poll. Calls
@@ -1659,6 +1660,26 @@ compared with `hmac.compare_digest` against `settings.acs_webhook_secret`
 including the validation handshake — even when `ACS_CONNECTION_STRING` is
 configured; the app lifespan (`app/main.py`) logs a startup warning for that
 misconfiguration.
+
+### 4b. Graph calendar webhook subscriptions (real-time meeting capture)
+
+`create_calendar_subscription` registers a `/me/events` Graph subscription (same
+`webhook_path`, clientState/replay hardening as 4a above) with `changeType="created"`
+only. `handle_notification` dispatches `/me/events` rows to
+`_handle_calendar_notification`, which fetches the event, skips `isCancelled`, and
+calls `log_meeting_activity` directly — **without** the daily scan's
+`create_unlinked_fallback=True`, so a real-time notification for a meeting with no
+CRM-matched attendee logs nothing. That gap is closed, not left open: the daily
+`_job_calendar_scan` (`calendar_intelligence.scan_calendar_events`, 06:00) is retained
+and still runs its own unlinked-fallback pass, sharing the same
+`external_id = "calendar-{graph_event_id}"` dedupe key, so a webhook notification and
+a later scan of the same event can never double-log it. Caveat (documented in-repo on
+`_handle_calendar_notification`): the daily scan is a 30-day **lookback**, not a
+lookahead, so an unmatched-attendee meeting scheduled far in the future is only
+backfilled once its start time has passed into that window. Unrelated cadence note:
+the 8x8 CDR poll (section 1) now defaults to every 5 minutes
+(`EIGHT_BY_EIGHT_POLL_INTERVAL_MINUTES=5`, env-overridable) — cheap because the access
+token is cached.
 
 ## 5. Quote Building
 

--- a/tests/test_8x8_config.py
+++ b/tests/test_8x8_config.py
@@ -23,7 +23,7 @@ def test_settings_loads_8x8_fields():
         assert s.eight_by_eight_pbx_id == ""
         assert s.eight_by_eight_timezone == "America/Los_Angeles"
         assert s.eight_by_eight_enabled is False
-        assert s.eight_by_eight_poll_interval_minutes == 30
+        assert s.eight_by_eight_poll_interval_minutes == 5
 
 
 def test_user_has_8x8_extension_column():

--- a/tests/test_calendar_intelligence.py
+++ b/tests/test_calendar_intelligence.py
@@ -503,6 +503,33 @@ class TestScanCalendarEvents:
         assert result["events_scanned"] == 0
         assert result["activities_logged"] == 0
 
+    def test_scan_tolerates_explicit_null_start_and_organizer(self, db_session):
+        """An event with EXPLICIT null start/organizer (not merely absent keys) is
+        skipped without raising — the event is counted as scanned but not logged, since
+        there's no start_dt to stamp occurred_at with."""
+        event = self._graph_event(
+            event_id="graph-null-001",
+            subject="Malformed Event",
+            start_offset_h=-1,
+            attendee_emails=["someone@acme-scan.com"],
+        )
+        event["start"] = None
+        event["organizer"] = None
+        event["end"] = None
+
+        with patch("app.utils.graph_client.GraphClient") as MockGC:
+            mock_gc = MockGC.return_value
+            mock_gc.get_all_pages = AsyncMock(return_value=[event])
+
+            from app.services.calendar_intelligence import scan_calendar_events
+
+            result = asyncio.run(scan_calendar_events("token", None, db_session))
+
+        assert result["events_scanned"] == 1
+        assert result["activities_logged"] == 0
+        count = db_session.query(ActivityLog).filter(ActivityLog.external_id == "calendar-graph-null-001").count()
+        assert count == 0
+
 
 # ── Tests: calendar scan flag guard (FIX 3a) ─────────────────────────────────
 

--- a/tests/test_services_webhook.py
+++ b/tests/test_services_webhook.py
@@ -115,12 +115,13 @@ def _make_subscription(
     sub_id: str = "sub-001",
     client_state: str = "state123",
     expires_in_hours: int = 48,
+    resource: str = "/me/messages",
 ) -> GraphSubscription:
     """Create a GraphSubscription record for testing."""
     sub = GraphSubscription(
         user_id=user.id,
         subscription_id=sub_id,
-        resource="/me/messages",
+        resource=resource,
         change_type="created",
         expiration_dt=datetime.now(UTC) + timedelta(hours=expires_in_hours),
         client_state=client_state,
@@ -758,6 +759,115 @@ class TestCreateMailSubscription:
             assert payload["notificationUrl"] == "https://myapp.example.com/api/webhooks/graph"
             assert "expirationDateTime" in payload
             assert "clientState" in payload
+
+    def test_active_calendar_subscription_does_not_block_mail_creation(self, db_session, test_user):
+        """Regression lock: an active /me/events (calendar) subscription must NOT block
+        mail subscription creation. Prior to the resource-scoped guard fix,
+        _active_subscription(db, user.id) matched ANY active row for the user, so once a
+        calendar subscription existed, create_mail_subscription was silently blocked
+        forever (see webhook_service.py _active_subscription docstring)."""
+        from app.services.webhook_service import create_mail_subscription
+
+        _make_subscription(db_session, test_user, sub_id="calendar-sub", resource="/me/events")
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "new-mail-sub-id"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as mock_settings,
+        ):
+            mock_settings.app_url = "https://app.example.com"
+            result = _run(create_mail_subscription(test_user, db_session))
+
+            mock_gc.post_json.assert_called_once()
+            assert result is not None
+            assert result.subscription_id == "new-mail-sub-id"
+            assert result.resource == "/me/messages"
+
+    def test_existing_mail_subscription_still_blocks_new_mail_creation(self, db_session, test_user):
+        """Mail-vs-mail idempotency preserved: an active /me/messages row still short-
+        circuits create_mail_subscription without hitting Graph."""
+        from app.services.webhook_service import create_mail_subscription
+
+        _make_subscription(db_session, test_user, sub_id="mail-sub", resource="/me/messages")
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock()
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(create_mail_subscription(test_user, db_session))
+            assert result.subscription_id == "mail-sub"
+            mock_gc.post_json.assert_not_called()
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  _create_graph_subscription() — changeType parameterization
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestCreateGraphSubscriptionChangeType:
+    def test_default_change_type_is_created(self, db_session, test_user):
+        """Omitting change_type preserves existing behavior (defaults to 'created')."""
+        from app.services.webhook_service import _create_graph_subscription
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "default-ct-sub"})
+
+        with (
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as mock_settings,
+        ):
+            mock_settings.app_url = "https://app.example.com"
+            record = _run(
+                _create_graph_subscription(
+                    test_user,
+                    db_session,
+                    "token",
+                    resource="/me/messages",
+                    webhook_path="/api/webhooks/graph",
+                    err_label="",
+                    created_log="Created {sub_id} for {email}, expires {expiration}",
+                )
+            )
+
+            payload = mock_gc.post_json.call_args[0][1]
+            assert payload["changeType"] == "created"
+            assert record.change_type == "created"
+
+    def test_passed_change_type_is_sent_to_graph(self, db_session, test_user):
+        """A caller-supplied change_type is passed through to the Graph POST payload and
+        persisted on the GraphSubscription record."""
+        from app.services.webhook_service import _create_graph_subscription
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "custom-ct-sub"})
+
+        with (
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as mock_settings,
+        ):
+            mock_settings.app_url = "https://app.example.com"
+            record = _run(
+                _create_graph_subscription(
+                    test_user,
+                    db_session,
+                    "token",
+                    resource="/me/events",
+                    webhook_path="/api/webhooks/calendar",
+                    err_label="Calendar ",
+                    created_log="Created {sub_id} for {email}, expires {expiration}",
+                    change_type="updated",
+                )
+            )
+
+            payload = mock_gc.post_json.call_args[0][1]
+            assert payload["changeType"] == "updated"
+            assert record.change_type == "updated"
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/test_webhook_calendar_p4.py
+++ b/tests/test_webhook_calendar_p4.py
@@ -525,6 +525,41 @@ class TestHandleNotificationCalendar:
 
         mock_log_meeting.assert_not_called()
 
+    def test_calendar_notification_explicit_null_start_organizer_tolerated(self, db_session, test_user):
+        """A Graph event with EXPLICIT null start/organizer (not merely absent keys) is
+        skipped without raising, and the batch continues to process the next item."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub1 = _make_calendar_sub(db_session, test_user, sub_id="cal-null-001", client_state="cal-null-state-1")
+        cal_sub2 = _make_calendar_sub(db_session, test_user, sub_id="cal-null-002", client_state="cal-null-state-2")
+        null_item = self._validated_calendar_item(test_user, cal_sub1, resource="Users('u1')/Events('evt-null')")
+        ok_item = self._validated_calendar_item(test_user, cal_sub2, resource="Users('u1')/Events('evt-ok')")
+
+        null_event = _graph_event(event_id="evt-null")
+        null_event["start"] = None
+        null_event["organizer"] = None
+        null_event["end"] = None
+
+        async def mock_get_json(path, params=None):
+            if "evt-null" in path:
+                return null_event
+            return _graph_event(event_id="evt-ok")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = mock_get_json
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING, return_value=[MagicMock()]) as mock_log_meeting,
+        ):
+            _run(handle_notification({}, db_session, validated=[null_item, ok_item]))
+
+        # No start_dt means _handle_calendar_notification returns early for evt-null
+        # (nothing to stamp occurred_at with) without raising — the batch then
+        # continues on to evt-ok, which logs normally.
+        mock_log_meeting.assert_called_once()
+
     def test_mail_and_calendar_mixed_batch(self, db_session, test_user):
         """Mixed batch: mail items -> log_email_activity; calendar items ->
         log_meeting_activity. Also proves the mail branch's own

--- a/tests/test_webhook_calendar_p4.py
+++ b/tests/test_webhook_calendar_p4.py
@@ -1,0 +1,820 @@
+"""test_webhook_calendar_p4.py — Graph calendar subscriptions (Phase 4 Task 2).
+
+Ported from the parked commit ba7ef84d (tag archive/crm-phase4-calendar-webhooks) and
+adapted to current main's shapes:
+  - webhook_service now splits validate_notifications()/handle_notification(validated=)
+    (donor validated inline)
+  - changeType is locked to "created" only here (donor used "created,updated" — see
+    the ruling comment on create_calendar_subscription / _handle_calendar_notification)
+  - calendar activities are logged via activity_service.log_meeting_activity directly
+    (donor routed through calendar_intelligence._log_calendar_activity, the daily-scan
+    wrapper that forces create_unlinked_fallback=True; the webhook path does not, so a
+    meeting with zero CRM-matched attendees logs nothing in real time — see report)
+  - the donor's 8x8-poll-interval section (unrelated Phase-4 delta bundled into the
+    same parked commit) is out of scope for this task and is not ported
+
+Covers:
+1. Resource-scoped subscription guard (mail vs calendar don't collide)
+2. create_calendar_subscription — create, reuse, failure paths
+3. handle_notification calendar routing (_handle_calendar_notification)
+4. ensure_all_users_subscribed wires calendar sub (not mvp_mode-gated)
+5. validate_notifications' shared clientState/replay path covers calendar rows
+
+Called by: pytest
+Depends on: app/services/webhook_service.py, app/services/activity_service.py
+"""
+
+import asyncio
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ["TESTING"] = "1"
+
+from app.models import ActivityLog, GraphSubscription, User, VendorCard, VendorContact
+from app.services.webhook_service import _seen_notifications, validate_notifications
+
+# ── Patch targets ────────────────────────────────────────────────────
+# webhook_service does local imports inside each function, so we patch at the
+# canonical source modules (same convention as test_services_webhook.py).
+_PATCH_GET_TOKEN = "app.scheduler.get_valid_token"
+_PATCH_GRAPH_CLIENT = "app.utils.graph_client.GraphClient"
+_PATCH_LOG_MEETING = "app.services.activity_service.log_meeting_activity"
+_PATCH_LOG_EMAIL = "app.services.activity_service.log_email_activity"
+_PATCH_POLL_INBOX = "app.email_service.poll_inbox"
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ── Shared builders ──────────────────────────────────────────────────
+
+
+def _make_mail_sub(db, user, sub_id="msub-001", client_state="mail-state", expires_in_hours=48):
+    sub = GraphSubscription(
+        user_id=user.id,
+        subscription_id=sub_id,
+        resource="/me/messages",
+        change_type="created",
+        expiration_dt=datetime.now(UTC) + timedelta(hours=expires_in_hours),
+        client_state=client_state,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+
+def _make_calendar_sub(db, user, sub_id="csub-001", client_state="cal-state", expires_in_hours=48):
+    sub = GraphSubscription(
+        user_id=user.id,
+        subscription_id=sub_id,
+        resource="/me/events",
+        change_type="created",
+        expiration_dt=datetime.now(UTC) + timedelta(hours=expires_in_hours),
+        client_state=client_state,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+
+def _graph_event(
+    event_id="evt-001",
+    subject="Vendor Meeting",
+    is_cancelled=False,
+    start="2026-06-23T14:00:00Z",
+    end="2026-06-23T15:00:00Z",
+    attendee_email="vendor@external.com",
+):
+    return {
+        "id": event_id,
+        "subject": subject,
+        "start": {"dateTime": start, "timeZone": "UTC"},
+        "end": {"dateTime": end, "timeZone": "UTC"},
+        "organizer": {"emailAddress": {"address": "user@trioscs.com", "name": "User"}},
+        "attendees": [
+            {"emailAddress": {"address": attendee_email, "name": "Vendor Rep"}},
+        ],
+        "isCancelled": is_cancelled,
+        "location": {"displayName": "Zoom"},
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  1. RESOURCE-SCOPED SUBSCRIPTION GUARD
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestResourceScopedGuard:
+    """create_mail_subscription must be idempotent for /me/messages only; same for
+    create_calendar_subscription for /me/events.
+
+    A user can hold both simultaneously. (The mail-side half of this guard was already
+    locked down in the prior commit, d0db0634; these tests exercise the calendar side
+    added here.)
+    """
+
+    def test_calendar_sub_not_blocked_by_mail_sub(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        _make_mail_sub(db_session, test_user, sub_id="existing-mail")
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "new-cal-sub"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.app_url = "https://app.example.com"
+            result = _run(create_calendar_subscription(test_user, db_session))
+
+        assert result is not None
+        assert result.subscription_id == "new-cal-sub"
+        assert result.resource == "/me/events"
+        mock_gc.post_json.assert_called_once()
+
+    def test_mail_sub_not_blocked_by_existing_calendar_sub(self, db_session, test_user):
+        from app.services.webhook_service import create_mail_subscription
+
+        _make_calendar_sub(db_session, test_user, sub_id="existing-calendar")
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "new-mail-sub"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.app_url = "https://app.example.com"
+            result = _run(create_mail_subscription(test_user, db_session))
+
+        assert result is not None
+        assert result.resource == "/me/messages"
+        mock_gc.post_json.assert_called_once()
+
+    def test_user_can_hold_both_mail_and_calendar_subs(self, db_session, test_user):
+        _make_mail_sub(db_session, test_user, sub_id="mail-sub")
+        _make_calendar_sub(db_session, test_user, sub_id="cal-sub")
+
+        subs = db_session.query(GraphSubscription).filter(GraphSubscription.user_id == test_user.id).all()
+        resources = {s.resource for s in subs}
+        assert "/me/messages" in resources
+        assert "/me/events" in resources
+        assert len(subs) == 2
+
+    def test_calendar_sub_idempotent_with_both_subs_present(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        _make_mail_sub(db_session, test_user, sub_id="mail-other2")
+        _make_calendar_sub(db_session, test_user, sub_id="cal-idem")
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock()
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(create_calendar_subscription(test_user, db_session))
+
+        assert result.subscription_id == "cal-idem"
+        mock_gc.post_json.assert_not_called()
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  2. create_calendar_subscription
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestCreateCalendarSubscription:
+    def test_no_token_returns_none(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        with patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value=None):
+            result = _run(create_calendar_subscription(test_user, db_session))
+        assert result is None
+
+    def test_creates_new_calendar_subscription(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "cal-new-sub"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.app_url = "https://app.example.com"
+            result = _run(create_calendar_subscription(test_user, db_session))
+
+        assert result is not None
+        assert result.subscription_id == "cal-new-sub"
+        assert result.resource == "/me/events"
+        assert result.change_type == "created"
+        assert result.user_id == test_user.id
+        assert result.client_state is not None
+
+    def test_calendar_subscription_payload(self, db_session, test_user):
+        """Verifies the Graph subscription payload shape for calendar — changeType is
+        locked to "created" only (NOT "created,updated" like the donor commit): Graph
+        would also notify on reschedules/edits, but log_meeting_activity dedupes on
+        external_id "calendar-{graph_event_id}", so an "updated" notification for an
+        already-logged event is a no-op that burns a Graph fetch for nothing."""
+        from app.services.webhook_service import create_calendar_subscription
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "cal-payload-sub"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.app_url = "https://myapp.example.com"
+            _run(create_calendar_subscription(test_user, db_session))
+
+        call_args = mock_gc.post_json.call_args
+        path = call_args[0][0]
+        payload = call_args[0][1]
+        assert path == "/subscriptions"
+        assert payload["resource"] == "/me/events"
+        assert payload["changeType"] == "created"
+        assert payload["notificationUrl"] == "https://myapp.example.com/api/webhooks/graph"
+        assert "expirationDateTime" in payload
+        assert "clientState" in payload
+
+    def test_idempotent_returns_existing(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        _make_calendar_sub(db_session, test_user, sub_id="cal-exist")
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock()
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(create_calendar_subscription(test_user, db_session))
+
+        assert result.subscription_id == "cal-exist"
+        mock_gc.post_json.assert_not_called()
+
+    def test_expired_calendar_sub_triggers_creation(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        _make_calendar_sub(db_session, test_user, sub_id="cal-expired", expires_in_hours=-1)
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"id": "cal-fresh"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.app_url = "https://app.example.com"
+            result = _run(create_calendar_subscription(test_user, db_session))
+
+        assert result is not None
+        assert result.subscription_id == "cal-fresh"
+
+    def test_graph_error_returns_none(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(side_effect=Exception("Graph error"))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.app_url = "https://app.example.com"
+            result = _run(create_calendar_subscription(test_user, db_session))
+
+        assert result is None
+
+    def test_no_subscription_id_in_response_returns_none(self, db_session, test_user):
+        from app.services.webhook_service import create_calendar_subscription
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(return_value={"error": "something failed"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.app_url = "https://app.example.com"
+            result = _run(create_calendar_subscription(test_user, db_session))
+
+        assert result is None
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  3. handle_notification — calendar routing
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestHandleNotificationCalendar:
+    """Calendar events routed via _subscription.resource == '/me/events'."""
+
+    def setup_method(self):
+        _seen_notifications.clear()
+
+    def _validated_calendar_item(self, user, sub, change_type="created", resource="Users('u1')/Events('evt-001')"):
+        """Build a pre-validated calendar notification item (validate_notifications'
+        output shape)."""
+        return {
+            "subscriptionId": sub.subscription_id,
+            "changeType": change_type,
+            "resource": resource,
+            "clientState": sub.client_state,
+            "_subscription": sub,
+            "_user": user,
+        }
+
+    def test_calendar_notification_calls_log_meeting_activity(self, db_session, test_user):
+        """Calendar notification fetches event and calls log_meeting_activity (not the
+        mail-side log_email_activity)."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-route-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-xyz')")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(return_value=_graph_event(event_id="evt-xyz"))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING, return_value=[MagicMock()]) as mock_log_meeting,
+            patch(_PATCH_LOG_EMAIL) as mock_log_email,
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        mock_log_meeting.assert_called_once()
+        mock_log_email.assert_not_called()
+
+    def test_calendar_select_fields_are_event_shaped(self, db_session, test_user):
+        """The $select sent to Graph is the event field list, not the mail field list —
+        proves calendar items never fall through into the mail branch (whose $select
+        requests from/toRecipients/isDraft/parentFolderId, all meaningless for an
+        event)."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-select-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-sel')")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(return_value=_graph_event(event_id="evt-sel"))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING, return_value=[]),
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        call_args = mock_gc.get_json.call_args
+        assert call_args[0][0] == "/Users('u1')/Events('evt-sel')"
+        select = call_args[1]["params"]["$select"]
+        for field in ("id", "subject", "attendees", "start", "end", "location", "organizer", "isCancelled"):
+            assert field in select
+        assert "toRecipients" not in select
+        assert "isDraft" not in select
+
+    def test_calendar_notification_cancelled_event_skipped(self, db_session, test_user):
+        """Cancelled calendar events are skipped (no activity logged)."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-cancel-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-cancelled')")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(return_value=_graph_event(event_id="evt-cancelled", is_cancelled=True))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING) as mock_log_meeting,
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        mock_log_meeting.assert_not_called()
+
+    def test_calendar_notification_deleted_change_type_skipped(self, db_session, test_user):
+        """ChangeType='deleted' calendar notifications are skipped without a Graph
+        fetch."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-del-001")
+        item = self._validated_calendar_item(
+            test_user, cal_sub, change_type="deleted", resource="Users('u1')/Events('evt-del')"
+        )
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock()
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING) as mock_log_meeting,
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        mock_gc.get_json.assert_not_called()
+        mock_log_meeting.assert_not_called()
+
+    def test_calendar_notification_updated_change_type_skipped(self, db_session, test_user):
+        """ChangeType='updated' calendar notifications are ALSO skipped here — this
+        deployment locks calendar subscriptions to changeType="created" only (see
+        create_calendar_subscription), so Graph should never send "updated" for our
+        subscriptions, but the handler drops it defensively too rather than trusting
+        Graph to honor the subscribed changeType."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-upd-001")
+        item = self._validated_calendar_item(
+            test_user, cal_sub, change_type="updated", resource="Users('u1')/Events('evt-upd')"
+        )
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(return_value=_graph_event(event_id="evt-upd"))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING) as mock_log_meeting,
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        mock_gc.get_json.assert_not_called()
+        mock_log_meeting.assert_not_called()
+
+    def test_calendar_notification_no_token_skipped(self, db_session, test_user):
+        """Calendar notification with no valid token is skipped gracefully."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-notoken-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-notoken')")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock()
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value=None),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING) as mock_log_meeting,
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        mock_gc.get_json.assert_not_called()
+        mock_log_meeting.assert_not_called()
+
+    def test_calendar_graph_fetch_error_continues(self, db_session, test_user):
+        """Graph fetch failure for calendar event is caught; processing continues."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-fetcherr-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-err')")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(side_effect=Exception("Graph 404"))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING) as mock_log_meeting,
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        mock_log_meeting.assert_not_called()
+
+    def test_calendar_notification_missing_event_id_skipped(self, db_session, test_user):
+        """An event payload with no id (deleted between notify and fetch) is skipped."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-noid-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-noid')")
+
+        event = _graph_event(event_id="evt-noid")
+        event["id"] = ""
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(return_value=event)
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING) as mock_log_meeting,
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        mock_log_meeting.assert_not_called()
+
+    def test_mail_and_calendar_mixed_batch(self, db_session, test_user):
+        """Mixed batch: mail items -> log_email_activity; calendar items ->
+        log_meeting_activity. Also proves the mail branch's own
+        `changeType != "created"` drop (:434 area) is never reached for calendar rows —
+        if it were, the calendar item here (changeType="created") would still pass that
+        check, so this alone isn't a negative proof; the "updated"/"deleted" skip tests
+        above cover the negative case."""
+        from app.services.webhook_service import handle_notification
+
+        mail_sub = _make_mail_sub(db_session, test_user, sub_id="mail-mix-001", client_state="ms")
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-mix-001", client_state="cs")
+
+        mail_item = {
+            "subscriptionId": "mail-mix-001",
+            "changeType": "created",
+            "resource": "Users('u1')/Messages('msg-001')",
+            "clientState": "ms",
+            "_subscription": mail_sub,
+            "_user": test_user,
+        }
+        cal_item = {
+            "subscriptionId": "cal-mix-001",
+            "changeType": "created",
+            "resource": "Users('u1')/Events('evt-mix-001')",
+            "clientState": "cs",
+            "_subscription": cal_sub,
+            "_user": test_user,
+        }
+
+        graph_message = {
+            "id": "msg-001",
+            "subject": "RFQ reply",
+            "from": {"emailAddress": {"address": "vendor@ext.com", "name": "Vendor"}},
+            "toRecipients": [],
+            "isDraft": False,
+            "parentFolderId": "inbox",
+        }
+
+        async def mock_get_json(path, params=None):
+            if "Messages" in path:
+                return graph_message
+            return _graph_event()
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = mock_get_json
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_EMAIL) as mock_log_email,
+            patch(_PATCH_LOG_MEETING, return_value=[MagicMock()]) as mock_log_meeting,
+            patch(_PATCH_POLL_INBOX, new_callable=AsyncMock, return_value=[]),
+        ):
+            _run(handle_notification({}, db_session, validated=[mail_item, cal_item]))
+
+        mock_log_email.assert_called_once()
+        mock_log_meeting.assert_called_once()
+
+    def test_calendar_log_meeting_receives_correct_kwargs(self, db_session, test_user):
+        """log_meeting_activity is called with the fields extracted from the fetched
+        Graph event."""
+        from app.services.webhook_service import handle_notification
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-kwargs-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-kwargs')")
+        event_data = _graph_event(event_id="evt-kwargs", subject="Specific Subject")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(return_value=event_data)
+
+        captured_kwargs = {}
+
+        def _capture_log_meeting(**kwargs):
+            captured_kwargs.update(kwargs)
+            return []
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+            patch(_PATCH_LOG_MEETING, side_effect=_capture_log_meeting),
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        assert captured_kwargs["user_id"] == test_user.id
+        assert captured_kwargs["graph_event_id"] == "evt-kwargs"
+        assert captured_kwargs["subject"] == "Specific Subject"
+        assert captured_kwargs["organizer_email"] == "user@trioscs.com"
+        assert captured_kwargs["attendee_emails"] == ["vendor@external.com"]
+        assert captured_kwargs["location"] == "Zoom"
+        assert captured_kwargs["db"] is db_session
+
+    def test_calendar_notification_creates_real_activity_log_row(self, db_session, test_user):
+        """End-to-end (no log_meeting_activity mock): a created-event notification for a
+        matched vendor attendee lands as a real ActivityLog row, deduped on external_id
+        "calendar-{graph_event_id}" — the same key the daily 06:00 scan uses, so a
+        webhook notification and a later poll of the same event can never double-log
+        it."""
+        from app.services.webhook_service import handle_notification
+
+        card = VendorCard(
+            normalized_name="arrow electronics",
+            display_name="Arrow Electronics",
+            domain="arrow-real.com",
+            is_blacklisted=False,
+            sighting_count=1,
+            created_at=datetime.now(UTC),
+        )
+        db_session.add(card)
+        db_session.flush()
+        db_session.add(
+            VendorContact(vendor_card_id=card.id, email="sales@arrow-real.com", full_name="Rep", source="manual")
+        )
+        db_session.commit()
+
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-real-001")
+        item = self._validated_calendar_item(test_user, cal_sub, resource="Users('u1')/Events('evt-real')")
+
+        mock_gc = MagicMock()
+        mock_gc.get_json = AsyncMock(
+            return_value=_graph_event(event_id="evt-real", attendee_email="sales@arrow-real.com")
+        )
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            _run(handle_notification({}, db_session, validated=[item]))
+
+        row = db_session.query(ActivityLog).filter(ActivityLog.external_id == "calendar-evt-real").first()
+        assert row is not None
+        assert row.vendor_card_id == card.id
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  4. ensure_all_users_subscribed — calendar wiring
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestEnsureAllUsersSubscribedCalendar:
+    def test_creates_calendar_sub_for_user_without_one(self, db_session, test_user):
+        """Calendar sub is created for M365 users that have none."""
+        from app.services.webhook_service import ensure_all_users_subscribed
+
+        with (
+            patch("app.services.webhook_service.create_mail_subscription", new_callable=AsyncMock),
+            patch("app.services.webhook_service.create_calendar_subscription", new_callable=AsyncMock) as mock_cal,
+        ):
+            _run(ensure_all_users_subscribed(db_session))
+            mock_cal.assert_called_once_with(test_user, db_session)
+
+    def test_skips_calendar_create_when_active_cal_sub_exists(self, db_session, test_user):
+        """Does not call create_calendar_subscription when active calendar sub
+        exists."""
+        from app.services.webhook_service import ensure_all_users_subscribed
+
+        _make_mail_sub(db_session, test_user, sub_id="mail-active")
+        _make_calendar_sub(db_session, test_user, sub_id="cal-active")
+
+        with (
+            patch("app.services.webhook_service.create_mail_subscription", new_callable=AsyncMock) as mock_mail,
+            patch("app.services.webhook_service.create_calendar_subscription", new_callable=AsyncMock) as mock_cal,
+        ):
+            _run(ensure_all_users_subscribed(db_session))
+
+        mock_mail.assert_not_called()
+        mock_cal.assert_not_called()
+
+    def test_calendar_sub_created_even_when_mail_sub_exists(self, db_session, test_user):
+        """If mail sub exists but calendar sub doesn't, calendar sub is created."""
+        from app.services.webhook_service import ensure_all_users_subscribed
+
+        _make_mail_sub(db_session, test_user, sub_id="mail-only")
+
+        with (
+            patch("app.services.webhook_service.create_mail_subscription", new_callable=AsyncMock) as mock_mail,
+            patch("app.services.webhook_service.create_calendar_subscription", new_callable=AsyncMock) as mock_cal,
+        ):
+            _run(ensure_all_users_subscribed(db_session))
+
+        mock_mail.assert_not_called()
+        mock_cal.assert_called_once_with(test_user, db_session)
+
+    def test_mail_sub_created_even_when_calendar_sub_exists(self, db_session, test_user):
+        """If calendar sub exists but mail sub doesn't, mail sub is created."""
+        from app.services.webhook_service import ensure_all_users_subscribed
+
+        _make_calendar_sub(db_session, test_user, sub_id="cal-only")
+
+        with (
+            patch("app.services.webhook_service.create_mail_subscription", new_callable=AsyncMock) as mock_mail,
+            patch("app.services.webhook_service.create_calendar_subscription", new_callable=AsyncMock) as mock_cal,
+        ):
+            _run(ensure_all_users_subscribed(db_session))
+
+        mock_mail.assert_called_once_with(test_user, db_session)
+        mock_cal.assert_not_called()
+
+    def test_calendar_sub_created_regardless_of_mvp_mode(self, db_session, test_user):
+        """Calendar is NOT mvp_mode-gated — only Teams is (per ba7ef84d and the task
+        brief).
+
+        With mvp_mode=True, Teams is skipped but calendar still runs.
+        """
+        from app.services.webhook_service import ensure_all_users_subscribed
+
+        with (
+            patch("app.services.webhook_service.create_mail_subscription", new_callable=AsyncMock),
+            patch("app.services.webhook_service.create_calendar_subscription", new_callable=AsyncMock) as mock_cal,
+            patch("app.services.webhook_service.create_teams_subscription", new_callable=AsyncMock) as mock_teams,
+            patch("app.services.webhook_service.settings") as ms,
+        ):
+            ms.mvp_mode = True
+            _run(ensure_all_users_subscribed(db_session))
+
+        mock_cal.assert_called_once_with(test_user, db_session)
+        mock_teams.assert_not_called()
+
+    def test_both_subs_created_for_multiple_users(self, db_session):
+        """Both mail and calendar subs created for each eligible user."""
+        from app.services.webhook_service import ensure_all_users_subscribed
+
+        for role in ("buyer", "sales"):
+            u = User(
+                email=f"{role}@trioscs.com",
+                name=role,
+                role=role,
+                azure_id=f"az-{role}-multi",
+                m365_connected=True,
+                created_at=datetime.now(UTC),
+            )
+            db_session.add(u)
+        db_session.commit()
+
+        with (
+            patch("app.services.webhook_service.create_mail_subscription", new_callable=AsyncMock) as mock_mail,
+            patch("app.services.webhook_service.create_calendar_subscription", new_callable=AsyncMock) as mock_cal,
+        ):
+            _run(ensure_all_users_subscribed(db_session))
+
+        assert mock_mail.call_count == 2
+        assert mock_cal.call_count == 2
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  5. validate_notifications — shared clientState/replay path covers
+#     calendar rows (no calendar-specific validation code exists; this
+#     proves the existing generic path is sufficient)
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestValidateNotificationsCalendar:
+    def setup_method(self):
+        _seen_notifications.clear()
+
+    def test_calendar_subscription_client_state_validated(self, db_session, test_user):
+        """A calendar notification with the correct clientState passes validation and is
+        enriched with _subscription/_user, same as mail."""
+        cal_sub = _make_calendar_sub(db_session, test_user, sub_id="cal-valid-001", client_state="secret-cal")
+        payload = {
+            "value": [
+                {
+                    "subscriptionId": "cal-valid-001",
+                    "clientState": "secret-cal",
+                    "changeType": "created",
+                    "resource": "Users('u1')/Events('evt-v1')",
+                }
+            ]
+        }
+
+        result = validate_notifications(payload, db_session)
+
+        assert len(result) == 1
+        assert result[0]["_subscription"].id == cal_sub.id
+        assert result[0]["_user"].id == test_user.id
+
+    def test_calendar_subscription_wrong_client_state_rejected(self, db_session, test_user):
+        """A calendar notification with a mismatched clientState is dropped — the same
+        timing-safe check used for mail, with no calendar-specific carve-out."""
+        _make_calendar_sub(db_session, test_user, sub_id="cal-invalid-001", client_state="secret-cal")
+        payload = {
+            "value": [
+                {
+                    "subscriptionId": "cal-invalid-001",
+                    "clientState": "wrong-secret",
+                    "changeType": "created",
+                    "resource": "Users('u1')/Events('evt-v2')",
+                }
+            ]
+        }
+
+        result = validate_notifications(payload, db_session)
+
+        assert result == []


### PR DESCRIPTION
Phase 4 (do-all plan) integrations stream. **Merges after the infra branch's solo deploy** (sequencing note — do not merge first).

## What

- **Calendar webhooks**: Graph `/me/events` subscriptions (created-only — updates would be dead work under the dedupe) land meeting activities in real time through the existing hardened webhook machinery (same endpoint, clientState auth, replay cache, resource-agnostic renewal). The daily 06:00 scan stays as the backfill layer — the shared `calendar-{id}` dedupe key makes the two paths collision-free. Re-implemented from the parked ba7ef84d build (spec + 30-test donor), not cherry-picked.
- **Latent bug fixed first**: the mail-subscription idempotency guard matched ANY active row — a calendar sub would have silently blocked mail subscriptions forever. Now resource-scoped, with a regression lock.
- **8x8 CDR poll**: default 30 → 5 minutes (token caching makes it one cheap GET per poll; watermark-on-failure semantics untouched).
- Polish from the final review: explicit-null Graph event fields tolerated in both webhook and scan paths (a `"start": null` payload would have 500'd the public endpoint and dropped the batch).

## Evidence

- Full suite in worktree: `24760 passed, 35 skipped, 0 FAILED`; 30 new calendar tests + null-tolerance tests; Graph subscription lifetime verified against current Microsoft docs (7-day max — the shared 70h constant stands, source cited in the report).
- 3 task reviews + whole-branch final review (mergeable; per-user loop isolation triaged to backlog with verified reasoning) + fix wave re-reviewed.

## Post-deploy check

Within ~5 min of deploy the subscription job should create `/me/events` rows for connected users (GraphSubscription table); create a calendar event in Outlook → activity appears within seconds (not at 06:00); 8x8 job logs show 5-minute cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkHRARudqRbahKpsFDmUQa