### PR TITLE
Infra runtime: Redis SSE, dedicated scheduler container, 2 uvicorn workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,12 @@ DATABASE_URL=postgresql://availai:availai@db:5432/availai
 POSTGRES_USER=availai
 POSTGRES_PASSWORD=availai
 POSTGRES_DB=availai
+# Per-process connection pool caps (Phase-4 infra: sized against Postgres
+# max_connections=100 across app --workers 2 + scheduler + enrichment-worker +
+# host workers — see the connection-budget comment above the module-level
+# `engine` in app/database.py before raising either value).
+DB_POOL_SIZE=5
+DB_MAX_OVERFLOW=5
 
 # ── Redis ──
 # docker-compose.yml composes REDIS_URL for app/enrichment-worker from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,13 +298,15 @@ jobs:
         # ships. Uses INTEGRATION_REDIS_URL because conftest.py blanks REDIS_URL
         # for test isolation; -o addopts="" drops the suite-wide xdist/ignore opts.
         # Shard 0 only — this is a fixed, single-file integration check, not
-        # part of the sharded unit-test split.
+        # part of the sharded unit-test split. test_sse_broker_redis.py's
+        # two-instance test (two SSEBroker()s, one real Redis) is skipif-gated
+        # on this same var everywhere else, so it only actually runs here.
         if: matrix.shard == 0
         env:
           INTEGRATION_REDIS_URL: redis://localhost:6379/0
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          pytest tests/integration/test_redis_integration.py -v -o addopts=""
+          pytest tests/integration/test_redis_integration.py tests/test_sse_broker_redis.py -v -o addopts=""
 
       - name: Upload test results (shard ${{ matrix.shard }})
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,9 @@ COPY alembic/ alembic/
 # Overlay Vite build output from stage 1
 COPY --from=builder /build/app/static/dist/ app/static/dist/
 
-# Copy entrypoint
-COPY docker-entrypoint.sh .
+# Copy entrypoint (+ its migration-lock helper — see docker-entrypoint-migrate.py
+# for why `alembic upgrade head` is wrapped instead of invoked bare)
+COPY docker-entrypoint.sh docker-entrypoint-migrate.py .
 RUN chmod +x docker-entrypoint.sh
 
 # Create non-root user for running the app process

--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,15 @@ class Settings(BaseSettings):
     encryption_salt: str = ""
     database_url: str = "postgresql://availai:availai@db:5432/availai"
 
+    # --- Database connection pool (Phase-4 infra: multi-worker sizing) ---
+    # Per-process caps passed to SQLAlchemy's create_engine in app/database.py.
+    # Defaults are sized for uvicorn --workers 2 alongside the scheduler,
+    # enrichment-worker, and host workers all sharing one Postgres instance —
+    # see the connection-budget arithmetic above the module-level `engine` in
+    # app/database.py. Env: DB_POOL_SIZE / DB_MAX_OVERFLOW.
+    db_pool_size: int = Field(default=5, ge=1)
+    db_max_overflow: int = Field(default=5, ge=0)
+
     # --- Sentry ---
     sentry_dsn: str = ""
     sentry_traces_sample_rate: float = 0.1

--- a/app/database.py
+++ b/app/database.py
@@ -52,12 +52,17 @@ class UTCDateTime(TypeDecorator[datetime]):
         return value
 
 
-def _make_engine(database_url: str):
+def _make_engine(database_url: str, *, pool_size: int = 5, max_overflow: int = 5):
     """Build the SQLAlchemy engine for ``database_url``.
 
     Split out from module scope so the PostgreSQL configuration branch is unit-testable
     directly — re-importing this module to exercise it would rebuild the shared engine
     and corrupt parallel (xdist) tests.
+
+    ``pool_size``/``max_overflow`` are per-process caps (ignored on the sqlite
+    branch, which always uses StaticPool). Defaults match ``Settings.db_pool_size``/
+    ``db_max_overflow`` — see the connection-budget comment above the module-level
+    ``engine`` below for how those defaults were sized.
     """
     if database_url.startswith("sqlite"):
         from sqlalchemy.pool import StaticPool
@@ -74,8 +79,8 @@ def _make_engine(database_url: str):
 
     return create_engine(
         database_url,
-        pool_size=20,
-        max_overflow=20,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
         pool_timeout=10,
         pool_pre_ping=True,
         pool_recycle=1800,
@@ -83,7 +88,27 @@ def _make_engine(database_url: str):
     )
 
 
-engine = _make_engine(settings.database_url)
+# Phase-4 infra: connection-budget arithmetic against Postgres max_connections=100
+# (docker-compose.yml's `db` service takes the postgres:16-alpine image default,
+# which is 100 — no explicit max_connections override exists). Each engine caps
+# itself at pool_size + max_overflow simultaneous connections; DB_POOL_SIZE /
+# DB_MAX_OVERFLOW default to 5 + 5 = 10 max per process. Every process that
+# imports this module and opens connections:
+#   - `app` service:       2 uvicorn workers (docker-compose.yml --workers 2),
+#                           10 each                                    = 20
+#   - `scheduler` service: 1 process (full app, single uvicorn worker), 10  = 10
+#   - `enrichment-worker`: 1 process, 10                                    = 10
+#   - 3 host workers (avail-nc-worker, avail-ics-worker, avail-tbf-worker),
+#     each one long-running process importing this module, 10 each     = 30
+#   Total: 20 + 10 + 10 + 30 = 70, leaving 30 connections of headroom under
+#   max_connections=100 for psql/admin sessions, one-off scripts, and Alembic
+#   migrations. Re-run this arithmetic before raising DB_POOL_SIZE/
+#   DB_MAX_OVERFLOW or the uvicorn --workers count.
+engine = _make_engine(
+    settings.database_url,
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
+)
 
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 

--- a/app/main.py
+++ b/app/main.py
@@ -178,47 +178,59 @@ async def lifespan(app):
 
     _is_testing = os.environ.get("TESTING") == "1"
 
-    if not _is_testing:
-        from .startup import seed_api_sources, seed_browser_workers
+    # RUN_SCHEDULER gates the APScheduler process and everything that seeds or
+    # feeds it (source/browser-worker seeding, the deferred startup backfills).
+    # Default "1" preserves today's single-process behavior (instant rollback
+    # knob). In the split-process deploy, the app service sets RUN_SCHEDULER=0
+    # and a dedicated `scheduler` service sets it to "1" — exactly one process
+    # must run the scheduler, since the approval-notification outbox has no
+    # cross-process locking and two schedulers would double-send emails.
+    _run_scheduler = os.environ.get("RUN_SCHEDULER", "1") == "1"
 
-        seed_api_sources()
-        seed_browser_workers()
+    if not _is_testing:
+        if _run_scheduler:
+            from .startup import seed_api_sources, seed_browser_workers
+
+            seed_api_sources()
+            seed_browser_workers()
         from .connector_status import log_connector_status
 
         _connector_status = log_connector_status()
         app.state.connector_status = _connector_status
 
-        from .scheduler import configure_scheduler, scheduler
+        if _run_scheduler:
+            from .scheduler import configure_scheduler, scheduler
 
-        configure_scheduler()
-        scheduler.start()
-        logger.info("APScheduler started")
+            configure_scheduler()
+            scheduler.start()
+            logger.info("APScheduler started")
 
-        # P2.7: launch the SLOW, idempotent startup backfills + ANALYZE as a
-        # post-yield background task instead of running them inline before /health
-        # can answer (docs/CODE_AUDIT_AND_HARDENING_PLAN.md P2.7). run_startup_migrations()
-        # above already ran the FAST, order-critical ops synchronously.
-        from .services.prepayment_notifications import set_main_event_loop
-        from .startup import mark_deferred_backfills_pending, run_deferred_startup_backfills
-        from .utils.async_helpers import safe_background_task
+            # P2.7: launch the SLOW, idempotent startup backfills + ANALYZE as a
+            # post-yield background task instead of running them inline before /health
+            # can answer (docs/CODE_AUDIT_AND_HARDENING_PLAN.md P2.7). run_startup_migrations()
+            # above already ran the FAST, order-critical ops synchronously.
+            from .services.prepayment_notifications import set_main_event_loop
+            from .startup import mark_deferred_backfills_pending, run_deferred_startup_backfills
+            from .utils.async_helpers import safe_background_task
 
-        # run_deferred_startup_backfills executes on an asyncio.to_thread worker
-        # thread with no running loop of its own; register the main loop so
-        # schedule_prepayment_notify can still deliver a DO-NOT-WIRE stand-down
-        # notification if that sweep auto-completes a buy plan with a pending
-        # prepayment (see prepayment_notifications.py's cross-thread fallback).
-        set_main_event_loop(asyncio.get_running_loop())
-        mark_deferred_backfills_pending()
-        await safe_background_task(
-            asyncio.to_thread(run_deferred_startup_backfills),
-            task_name="deferred_startup_backfills",
-        )
+            # run_deferred_startup_backfills executes on an asyncio.to_thread worker
+            # thread with no running loop of its own; register the main loop so
+            # schedule_prepayment_notify can still deliver a DO-NOT-WIRE stand-down
+            # notification if that sweep auto-completes a buy plan with a pending
+            # prepayment (see prepayment_notifications.py's cross-thread fallback).
+            set_main_event_loop(asyncio.get_running_loop())
+            mark_deferred_backfills_pending()
+            await safe_background_task(
+                asyncio.to_thread(run_deferred_startup_backfills),
+                task_name="deferred_startup_backfills",
+            )
 
     yield
 
     if not _is_testing:
-        logger.info("Shutting down scheduler (waiting for running jobs)...")
-        scheduler.shutdown(wait=True)
+        if _run_scheduler:
+            logger.info("Shutting down scheduler (waiting for running jobs)...")
+            scheduler.shutdown(wait=True)
         from .http_client import close_clients
 
         await close_clients()

--- a/app/main.py
+++ b/app/main.py
@@ -839,8 +839,16 @@ async def health(
         except Exception:
             redis_status = "error"
 
-        scheduler_running = getattr(sched_mod.scheduler, "running", False)
-        scheduler_status = "ok" if scheduler_running else "off"
+        if os.environ.get("RUN_SCHEDULER", "1") == "1":
+            scheduler_running = getattr(sched_mod.scheduler, "running", False)
+            scheduler_status = "ok" if scheduler_running else "off"
+        else:
+            # Phase-4 infra split: this process deliberately never starts
+            # APScheduler (RUN_SCHEDULER=0, set on the `app` compose service) —
+            # it runs in the dedicated `scheduler` service instead. "off" would
+            # read as an unexpected outage; report the true, by-design state
+            # so "off" keeps meaning "should be running here and isn't."
+            scheduler_status = "external (scheduler service)"
 
         connector_status = getattr(request.app.state, "connector_status", {})
         connectors_enabled = sum(1 for v in connector_status.values() if v)

--- a/app/services/sse_broker.py
+++ b/app/services/sse_broker.py
@@ -12,6 +12,14 @@ the web process (it already publishes today, e.g. app/email_service.py) and once
 runs multiple workers. Redis unavailable/TESTING: falls straight back to the original
 in-process dict fan-out, byte-behavior-identical to before Redis support existed.
 
+The reader task self-heals: a connect failure at listen()-start or a mid-stream drop
+does not end the task — it retries with capped backoff, re-checking Redis each attempt,
+for as long as the listen() call is alive. This also covers a listener that starts while
+Redis is down: it attaches once Redis recovers, instead of staying cross-process-deaf for
+the rest of the SSE connection. During an outage, publish()'s in-process fallback still
+reaches any listener in the SAME process (both write onto the same local queue) — only
+delivery to a *different* worker process is lost for the outage's duration.
+
 The public API (subscribe/unsubscribe/publish/listen) and the module-level ``broker``
 singleton are unchanged — only the internals of publish()/listen() gained a Redis path.
 
@@ -26,6 +34,7 @@ app.config.settings, app.utils.json_helpers
 import asyncio
 import contextlib
 import os
+import random
 import time
 from collections import defaultdict
 from collections.abc import AsyncGenerator
@@ -41,6 +50,11 @@ _REDIS_CHANNEL_PREFIX = "sse:"
 # app.cache.redis_probe.REPROBE_INTERVAL_S so a Redis blip self-heals without hammering
 # the socket-connect timeout on every publish()/listen() call.
 _REDIS_REPROBE_INTERVAL_S = 30.0
+
+# _redis_reader's own reconnect backoff (separate from the _get_redis probe interval
+# above): how long it waits between attempts after "no client yet" or a mid-stream drop.
+# Capped exponential, ±10% jitter so many listeners reconnecting at once don't thunder.
+_READER_BACKOFF_SCHEDULE_S: tuple[float, ...] = (1.0, 2.0, 5.0, 30.0)
 
 
 def _redis_channel(channel: str) -> str:
@@ -74,11 +88,13 @@ class SSEBroker:
     async def _get_redis(self):
         """Return a live ``redis.asyncio`` client, or None when Redis is unavailable.
 
-        Never raises — a connect/ping failure marks the broker degraded and returns None
-        so callers fall back to the in-process path. Re-probes the real Redis at most once
-        per ``_REDIS_REPROBE_INTERVAL_S`` while degraded and recovers automatically.
-        TESTING or a non-Redis ``cache_backend`` disables the probe permanently (no
-        retries), matching ``app.cache.intel_cache._connect_intel_redis``.
+        Never raises — a connect/ping failure (including a malformed ``redis_url``, which
+        ``from_url`` rejects with ``ValueError`` rather than a connection error) marks the
+        broker degraded and returns None so callers fall back to the in-process path.
+        Re-probes the real Redis at most once per ``_REDIS_REPROBE_INTERVAL_S`` while
+        degraded and recovers automatically. TESTING or a non-Redis ``cache_backend``
+        disables the probe permanently (no retries), matching
+        ``app.cache.intel_cache._connect_intel_redis``.
         """
         if self._redis_disabled:
             return None
@@ -111,7 +127,7 @@ class SSEBroker:
                 retry_on_timeout=True,
             )
             await client.ping()
-        except (redis.RedisError, OSError) as e:
+        except (redis.RedisError, OSError, ValueError) as e:
             was_degraded = self._redis_degraded
             self._redis_degraded = True
             log = logger.warning if not was_degraded else logger.debug
@@ -123,6 +139,28 @@ class SSEBroker:
         self._redis_degraded = False
         self._redis_client = client
         return client
+
+    def _invalidate_redis_client(self) -> None:
+        """Drop the cached client after a reader failure so the next ``_get_redis()``
+        call re-verifies liveness with a real ping instead of trusting a connection that
+        just dropped.
+
+        Leaves ``_redis_disabled`` untouched — TESTING / a non-Redis
+        ``cache_backend`` stays permanently off — and leaves ``_redis_last_probe`` alone
+        too, so the existing reprobe-interval gate still throttles how often that
+        re-verification actually hits the network.
+        """
+        self._redis_client = None
+
+    async def _sleep_backoff(self, attempt: int) -> None:
+        """Sleep the reader's reconnect backoff for *attempt* (0-indexed), with jitter.
+
+        A plain ``asyncio.sleep`` — cancellation (the listener disconnecting mid-backoff)
+        raises immediately, same as any other await point, so ``listen()``'s cleanup
+        never waits out a pending backoff.
+        """
+        delay = _READER_BACKOFF_SCHEDULE_S[min(attempt, len(_READER_BACKOFF_SCHEDULE_S) - 1)]
+        await asyncio.sleep(delay + random.uniform(0, delay * 0.1))
 
     def subscribe(self, channel: str) -> asyncio.Queue:
         """Create a new listener queue for the given channel."""
@@ -171,19 +209,22 @@ class SSEBroker:
         """Yield events from the channel as they arrive.
 
         Always registers a local queue via subscribe() — that queue is the delivery
-        buffer callers await on either way. When Redis is available, a background task
-        (``_redis_reader``) additionally subscribes to the namespaced Redis channel and
-        relays each message onto that same queue; that reader task is what lets this
-        listener see a publish() issued by a *different* process. The reader task is
-        cancelled and its pubsub connection closed in ``finally`` — alongside the existing
-        unsubscribe() — so a disconnecting SSE client never leaks a Redis pubsub
-        connection, and never leaves a dangling entry in ``_channels`` either.
+        buffer callers await on either way. Unless Redis is permanently disabled
+        (TESTING or a non-Redis ``cache_backend``), a background task (``_redis_reader``)
+        additionally runs for the lifetime of this call, relaying messages from the
+        namespaced Redis channel onto that same queue; that reader task is what lets this
+        listener see a publish() issued by a *different* process, and it self-heals
+        (see ``_redis_reader``) so it also attaches for a listener that started before
+        Redis was reachable. The reader task is cancelled and its current pubsub
+        connection closed in ``finally`` — alongside the existing unsubscribe() — so a
+        disconnecting SSE client never leaks a Redis pubsub connection, and never leaves
+        a dangling entry in ``_channels`` either.
         """
         q = self.subscribe(channel)
         reader_task: asyncio.Task | None = None
-        redis_client = await self._get_redis()
-        if redis_client is not None:
-            reader_task = asyncio.create_task(self._redis_reader(redis_client, channel, q))
+        await self._get_redis()  # settles _redis_disabled (permanent TESTING/backend gate)
+        if not self._redis_disabled:
+            reader_task = asyncio.create_task(self._redis_reader(channel, q))
         try:
             while True:
                 msg = await q.get()
@@ -195,42 +236,66 @@ class SSEBroker:
                     await reader_task
             self.unsubscribe(channel, q)
 
-    async def _redis_reader(self, redis_client, channel: str, q: asyncio.Queue) -> None:
-        """Background task: relay messages from the Redis channel onto *q*.
+    async def _redis_reader(self, channel: str, q: asyncio.Queue) -> None:
+        """Background task: relay messages from the Redis channel onto *q*, self-healing
+        for the lifetime of the owning listen() call.
 
-        One dedicated pubsub connection per listen() call while Redis is active — it is
-        always closed in ``finally`` (whether from listen()'s cleanup cancelling this
-        task, or the connection dropping on its own), so listeners never accumulate open
-        pubsub connections.
+        Loops until cancelled. Each iteration re-fetches ``_get_redis()`` rather than
+        trusting a client handed to it once — so a listener that started while Redis was
+        down (no client yet) or one whose stream just dropped (a mid-loop RedisError/
+        OSError) both retry with capped backoff (``_sleep_backoff``) and attach/reattach
+        as soon as Redis is reachable again, instead of going permanently silent for the
+        rest of the SSE connection. A stream failure also invalidates the cached client
+        (``_invalidate_redis_client``) so the next ``_get_redis()`` call re-verifies
+        liveness with a real ping rather than reusing a connection that just broke.
+        One pubsub connection is open at a time; it is always closed in ``finally``
+        before the next reconnect attempt or on cancellation, so listeners never
+        accumulate open pubsub connections.
         """
-        pubsub = redis_client.pubsub()
-        try:
-            await pubsub.subscribe(_redis_channel(channel))
-            async for message in pubsub.listen():
-                if message["type"] != "message":
-                    continue  # subscribe/unsubscribe confirmations — not payloads
-                try:
-                    msg = json.loads(message["data"])
-                except (TypeError, ValueError):
-                    logger.warning("SSE broker: dropped malformed Redis message on '{}'", channel)
-                    continue
-                try:
-                    if q.full():
-                        q.get_nowait()
-                    q.put_nowait(msg)
-                except asyncio.QueueFull:
-                    logger.warning("SSE: dropped Redis-relayed event — queue full")
-        except asyncio.CancelledError:
-            raise
-        except (redis.RedisError, OSError) as e:
-            logger.warning("SSE broker: Redis pubsub reader for '{}' stopped: {}", channel, e)
-        finally:
-            # Best-effort teardown — the connection may already be dead (that's often why
-            # we're here), so a failure closing it must not mask the original error.
-            with contextlib.suppress(redis.RedisError, OSError):
-                await pubsub.unsubscribe(_redis_channel(channel))
-            with contextlib.suppress(redis.RedisError, OSError):
-                await pubsub.aclose()
+        attempt = 0
+        while True:
+            redis_client = await self._get_redis()
+            if redis_client is None:
+                await self._sleep_backoff(attempt)
+                attempt += 1
+                continue
+
+            pubsub = redis_client.pubsub()
+            stream_dropped = False
+            try:
+                await pubsub.subscribe(_redis_channel(channel))
+                attempt = 0  # connected — next failure starts backoff over from 1s
+                async for message in pubsub.listen():
+                    if message["type"] != "message":
+                        continue  # subscribe/unsubscribe confirmations — not payloads
+                    try:
+                        msg = json.loads(message["data"])
+                    except (TypeError, ValueError):
+                        logger.warning("SSE broker: dropped malformed Redis message on '{}'", channel)
+                        continue
+                    try:
+                        if q.full():
+                            q.get_nowait()
+                        q.put_nowait(msg)
+                    except asyncio.QueueFull:
+                        logger.warning("SSE: dropped Redis-relayed event — queue full")
+            except asyncio.CancelledError:
+                raise
+            except (redis.RedisError, OSError) as e:
+                logger.warning("SSE broker: Redis pubsub reader for '{}' dropped ({}) — reconnecting", channel, e)
+                self._invalidate_redis_client()
+                stream_dropped = True
+            finally:
+                # Best-effort teardown — the connection may already be dead (that's often
+                # why we're here), so a failure closing it must not mask the original error.
+                with contextlib.suppress(redis.RedisError, OSError):
+                    await pubsub.unsubscribe(_redis_channel(channel))
+                with contextlib.suppress(redis.RedisError, OSError):
+                    await pubsub.aclose()
+
+            if stream_dropped:
+                await self._sleep_backoff(attempt)
+                attempt += 1
 
 
 # Singleton broker instance

--- a/app/services/sse_broker.py
+++ b/app/services/sse_broker.py
@@ -1,30 +1,128 @@
 """Server-Sent Events broker for real-time page updates.
 
-Manages a set of connected SSE clients per channel. When a change
-event fires (e.g. requisition status change), all listeners on
-that channel receive a push notification.
+Manages a set of connected SSE clients per channel. When a change event fires (e.g.
+requisition status change), all listeners on that channel receive a push notification.
 
-Called by: app/routers/htmx_views.py (stream endpoint + action endpoints)
-Depends on: asyncio
+Redis-backed fan-out (new): when Redis is configured and reachable, publish() does a
+Redis PUBLISH on a namespaced channel (``sse:{channel}``) and every listen() call runs a
+background pubsub reader task that relays messages onto the caller's local queue. This is
+what lets a publish() issued in one worker process reach a listener connected to a
+*different* worker process — the scenario that matters once the scheduler moves out of
+the web process (it already publishes today, e.g. app/email_service.py) and once uvicorn
+runs multiple workers. Redis unavailable/TESTING: falls straight back to the original
+in-process dict fan-out, byte-behavior-identical to before Redis support existed.
+
+The public API (subscribe/unsubscribe/publish/listen) and the module-level ``broker``
+singleton are unchanged — only the internals of publish()/listen() gained a Redis path.
+
+Called by: app/routers/events.py, app/routers/htmx/search_views.py,
+app/routers/sightings.py, app/routers/crm/offers.py, app/search_service.py,
+app/email_service.py (scheduler path), app/services/customer_enrichment_service.py
+Depends on: asyncio, redis (for the RedisError/OSError exception types), redis.asyncio
+(lazy import, only when Redis is configured — no connection opens at import time),
+app.config.settings, app.utils.json_helpers
 """
 
 import asyncio
+import contextlib
+import os
+import time
 from collections import defaultdict
 from collections.abc import AsyncGenerator
 
+import redis
 from loguru import logger
+
+from app.utils import json_helpers as json
+
+_REDIS_CHANNEL_PREFIX = "sse:"
+
+# While degraded, re-attempt the real Redis at most this often — mirrors
+# app.cache.redis_probe.REPROBE_INTERVAL_S so a Redis blip self-heals without hammering
+# the socket-connect timeout on every publish()/listen() call.
+_REDIS_REPROBE_INTERVAL_S = 30.0
+
+
+def _redis_channel(channel: str) -> str:
+    """Namespace a broker channel name for the Redis pub/sub keyspace."""
+    return f"{_REDIS_CHANNEL_PREFIX}{channel}"
 
 
 class SSEBroker:
     """Fan-out broker for SSE channels.
 
     Each channel (e.g. 'requisitions') has a set of asyncio.Queue listeners. publish()
-    pushes to all queues; subscribe() yields from one queue.
+    pushes to all queues; subscribe() yields from one queue. When Redis is configured
+    and reachable, delivery is routed through Redis PUBLISH/SUBSCRIBE instead (see
+    module docstring) so a publish() and a listen() can live in different worker
+    processes; otherwise this is pure in-process fan-out, exactly as before Redis
+    support was added.
     """
 
     def __init__(self):
         self._channels: dict[str, set[asyncio.Queue]] = defaultdict(set)
         self._queue_maxsize = 200
+        # Lazy asyncio Redis client + probe state — mirrors app.cache.redis_probe.RedisProbe
+        # (disabled / degraded / backoff), reimplemented async here because publish() and
+        # listen() both run on the request event loop and RedisProbe's connect-and-ping
+        # contract is synchronous (redis.from_url(...).ping()), which would block it.
+        self._redis_client = None
+        self._redis_disabled = False  # TESTING or cache_backend != "redis" — permanent
+        self._redis_degraded = False  # a probe failed and we have not yet recovered
+        self._redis_last_probe = 0.0
+
+    async def _get_redis(self):
+        """Return a live ``redis.asyncio`` client, or None when Redis is unavailable.
+
+        Never raises — a connect/ping failure marks the broker degraded and returns None
+        so callers fall back to the in-process path. Re-probes the real Redis at most once
+        per ``_REDIS_REPROBE_INTERVAL_S`` while degraded and recovers automatically.
+        TESTING or a non-Redis ``cache_backend`` disables the probe permanently (no
+        retries), matching ``app.cache.intel_cache._connect_intel_redis``.
+        """
+        if self._redis_disabled:
+            return None
+        if self._redis_client is not None:
+            return self._redis_client
+
+        now = time.monotonic()
+        if self._redis_last_probe and (now - self._redis_last_probe) < _REDIS_REPROBE_INTERVAL_S:
+            return None  # inside the backoff window — stay degraded without hammering
+        self._redis_last_probe = now
+
+        if os.environ.get("TESTING"):
+            self._redis_disabled = True
+            return None
+
+        from app.config import settings
+
+        if settings.cache_backend != "redis":
+            self._redis_disabled = True
+            return None
+
+        try:
+            import redis.asyncio as aioredis
+
+            client = aioredis.from_url(
+                settings.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=3,
+                socket_timeout=2,
+                retry_on_timeout=True,
+            )
+            await client.ping()
+        except (redis.RedisError, OSError) as e:
+            was_degraded = self._redis_degraded
+            self._redis_degraded = True
+            log = logger.warning if not was_degraded else logger.debug
+            log("SSE broker: Redis degraded (in-process fallback active): {}", e)
+            return None
+
+        if self._redis_degraded:
+            logger.info("SSE broker: Redis recovered — pub/sub fan-out re-enabled")
+        self._redis_degraded = False
+        self._redis_client = client
+        return client
 
     def subscribe(self, channel: str) -> asyncio.Queue:
         """Create a new listener queue for the given channel."""
@@ -39,7 +137,26 @@ class SSEBroker:
         logger.debug(f"SSE: unsubscribed from '{channel}' (total: {len(self._channels[channel])})")
 
     async def publish(self, channel: str, event: str, data: str = ""):
-        """Push an event to all listeners on the channel."""
+        """Push an event to all listeners on the channel.
+
+        Redis available: PUBLISH on the namespaced Redis channel — every listen() reader
+        task (this process and any other worker process sharing the same Redis) picks it
+        up. Redis unavailable/TESTING, or the PUBLISH itself fails: the original direct
+        write onto each locally registered queue, so an event is never silently dropped
+        just because of a transient Redis blip.
+        """
+        redis_client = await self._get_redis()
+        if redis_client is not None:
+            payload = json.dumps({"event": event, "data": data})
+            try:
+                await redis_client.publish(_redis_channel(channel), payload)
+                return
+            except (redis.RedisError, OSError) as e:
+                logger.warning("SSE broker: Redis publish failed ({}) — falling back to in-process delivery", e)
+        self._publish_local(channel, event, data)
+
+    def _publish_local(self, channel: str, event: str, data: str) -> None:
+        """Direct in-process fan-out — the original (pre-Redis) publish() body."""
         listeners = list(self._channels.get(channel, set()))
         for q in listeners:
             try:
@@ -51,14 +168,69 @@ class SSEBroker:
                 logger.warning("SSE: dropped event — queue full")
 
     async def listen(self, channel: str) -> AsyncGenerator[dict]:
-        """Yield events from the channel as they arrive."""
+        """Yield events from the channel as they arrive.
+
+        Always registers a local queue via subscribe() — that queue is the delivery
+        buffer callers await on either way. When Redis is available, a background task
+        (``_redis_reader``) additionally subscribes to the namespaced Redis channel and
+        relays each message onto that same queue; that reader task is what lets this
+        listener see a publish() issued by a *different* process. The reader task is
+        cancelled and its pubsub connection closed in ``finally`` — alongside the existing
+        unsubscribe() — so a disconnecting SSE client never leaks a Redis pubsub
+        connection, and never leaves a dangling entry in ``_channels`` either.
+        """
         q = self.subscribe(channel)
+        reader_task: asyncio.Task | None = None
+        redis_client = await self._get_redis()
+        if redis_client is not None:
+            reader_task = asyncio.create_task(self._redis_reader(redis_client, channel, q))
         try:
             while True:
                 msg = await q.get()
                 yield msg
         finally:
+            if reader_task is not None:
+                reader_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await reader_task
             self.unsubscribe(channel, q)
+
+    async def _redis_reader(self, redis_client, channel: str, q: asyncio.Queue) -> None:
+        """Background task: relay messages from the Redis channel onto *q*.
+
+        One dedicated pubsub connection per listen() call while Redis is active — it is
+        always closed in ``finally`` (whether from listen()'s cleanup cancelling this
+        task, or the connection dropping on its own), so listeners never accumulate open
+        pubsub connections.
+        """
+        pubsub = redis_client.pubsub()
+        try:
+            await pubsub.subscribe(_redis_channel(channel))
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue  # subscribe/unsubscribe confirmations — not payloads
+                try:
+                    msg = json.loads(message["data"])
+                except (TypeError, ValueError):
+                    logger.warning("SSE broker: dropped malformed Redis message on '{}'", channel)
+                    continue
+                try:
+                    if q.full():
+                        q.get_nowait()
+                    q.put_nowait(msg)
+                except asyncio.QueueFull:
+                    logger.warning("SSE: dropped Redis-relayed event — queue full")
+        except asyncio.CancelledError:
+            raise
+        except (redis.RedisError, OSError) as e:
+            logger.warning("SSE broker: Redis pubsub reader for '{}' stopped: {}", channel, e)
+        finally:
+            # Best-effort teardown — the connection may already be dead (that's often why
+            # we're here), so a failure closing it must not mask the original error.
+            with contextlib.suppress(redis.RedisError, OSError):
+                await pubsub.unsubscribe(_redis_channel(channel))
+            with contextlib.suppress(redis.RedisError, OSError):
+                await pubsub.aclose()
 
 
 # Singleton broker instance

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime, timedelta
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from app.cache.intel_cache import _get_redis
 from app.config import settings
 from app.constants import UserRole
 from app.models import ActivityLog, GraphSubscription, User
@@ -39,8 +40,13 @@ RENEW_BUFFER_HOURS = 6  # renew when less than 6h remaining
 RENEW_FAIL_THRESHOLD = 3
 _M365_SUB_ERROR_MSG = "Email tracking degraded — Graph subscription renewal failing"
 
-# Replay protection: reject duplicate notifications within this window
+# Replay protection: reject duplicate notifications within this window. Shared across
+# worker processes via a Redis SET NX EX (mirrors the token-refresh lock idiom in
+# app/jobs/core_jobs.py:_safe_refresh); _seen_notifications is the in-process fallback
+# used when Redis is unavailable (TESTING, or an outage) — unchanged from before Redis
+# support was added.
 REPLAY_WINDOW_SECONDS = 300  # 5 minutes
+_REPLAY_REDIS_PREFIX = "webhook:replay:"
 _seen_notifications: dict[str, float] = {}  # key -> timestamp
 
 # Validation-echo bounds. Microsoft Graph requires the raw ``validationToken``
@@ -320,11 +326,34 @@ async def ensure_all_users_subscribed(db: Session):
 
 
 def _prune_replay_cache():
-    """Remove expired entries from the replay-protection cache."""
+    """Remove expired entries from the in-process replay-protection fallback cache."""
     cutoff = time.monotonic() - REPLAY_WINDOW_SECONDS
     expired = [k for k, ts in _seen_notifications.items() if ts < cutoff]
     for k in expired:
         del _seen_notifications[k]
+
+
+def _replay_check_and_mark(replay_key: str, now: float) -> bool:
+    """Return True if *replay_key* is a replay (already seen within the window).
+
+    Redis available: an atomic ``SET NX EX`` on the shared substrate (same client as
+    ``app.rate_limit`` / ``app.jobs.core_jobs``) — the 5-minute window is enforced across
+    every worker process, not just this one. Redis unavailable (TESTING, or the SET call
+    itself errors): falls back to the original in-process ``_seen_notifications`` dict,
+    exactly as before Redis support was added.
+    """
+    redis = _get_redis()
+    if redis is not None:
+        try:
+            acquired = redis.set(f"{_REPLAY_REDIS_PREFIX}{replay_key}", "1", nx=True, ex=REPLAY_WINDOW_SECONDS)
+            return not acquired
+        except Exception as e:
+            logger.warning("Webhook replay cache: Redis error ({}) — falling back to in-process cache", e)
+
+    if replay_key in _seen_notifications:
+        return True
+    _seen_notifications[replay_key] = now
+    return False
 
 
 def validate_notifications(payload: dict, db: Session) -> list[dict]:
@@ -380,10 +409,9 @@ def validate_notifications(payload: dict, db: Session) -> list[dict]:
         # Replay protection
         resource = notif.get("resource", "")
         replay_key = f"{sub_id}:{resource}"
-        if replay_key in _seen_notifications:
+        if _replay_check_and_mark(replay_key, now):
             logger.warning(f"Replay detected for {replay_key}, ignoring")
             continue
-        _seen_notifications[replay_key] = now
 
         user = db.get(User, sub.user_id)
         if not user:

--- a/deploy.sh
+++ b/deploy.sh
@@ -91,13 +91,14 @@ fi
 # input-pinned layers (apt, gh, pip, Chromium, `npm ci`) stay cached. ~4x faster deploys
 # with no stale-template risk. The unique timestamp also invalidates --no-commit deploys.
 BUILD_COMMIT="$(git rev-parse --short HEAD)-$(date +%s)"
-echo "==> Rebuilding app + enrichment-worker images (build tag: $BUILD_COMMIT)..."
-# app and enrichment-worker share `build: .` (same Dockerfile), so building both
-# here reuses every cached layer — the worker image is nearly free. This stops the
-# worker from silently running stale wheels after a dependency bump: it shares
-# requirements.txt with the app (e.g. redis-py, anthropic), and deploy.sh used to
-# rebuild only the app, leaving the worker on the old image until someone noticed.
-docker compose build --build-arg BUILD_COMMIT="$BUILD_COMMIT" app enrichment-worker
+echo "==> Rebuilding app + enrichment-worker + scheduler images (build tag: $BUILD_COMMIT)..."
+# app, enrichment-worker, and scheduler all share `build: .` (same Dockerfile),
+# so building all three here reuses every cached layer — worker/scheduler images
+# are nearly free. This stops either from silently running stale wheels after a
+# dependency bump: they share requirements.txt with the app (e.g. redis-py,
+# anthropic), and deploy.sh used to rebuild only the app, leaving siblings on
+# the old image until someone noticed.
+docker compose build --build-arg BUILD_COMMIT="$BUILD_COMMIT" app enrichment-worker scheduler
 
 # Step 2b: Record the currently-running app image BEFORE we recreate the container,
 # so a failed health check can roll the app back to the last-known-good image instead
@@ -117,6 +118,23 @@ if [ -n "$PREV_APP_CONTAINER" ]; then
     echo "==> Recorded current app image for rollback: ${PREV_APP_IMAGE_REF:-unknown} (${PREV_APP_IMAGE_ID:-none})"
 else
     echo "==> No running app container found — no rollback target (first deploy?)."
+fi
+
+# Same capture for `scheduler` (Phase-4 infra split): app and scheduler are
+# recreated together in Step 3, both BEFORE the health-check gate, so a failed
+# deploy needs a rollback target for scheduler too — restoring only app's image
+# would leave scheduler running the broken new build (same image content, same
+# app.main:app entrypoint, just RUN_SCHEDULER=1). Empty on the first deploy of
+# the scheduler split — rollback_app() degrades gracefully when unset.
+PREV_SCHEDULER_CONTAINER="$(docker compose ps -q scheduler 2>/dev/null || true)"
+PREV_SCHEDULER_IMAGE_ID=""
+PREV_SCHEDULER_IMAGE_REF=""
+if [ -n "$PREV_SCHEDULER_CONTAINER" ]; then
+    PREV_SCHEDULER_IMAGE_ID="$(docker inspect -f '{{.Image}}' "$PREV_SCHEDULER_CONTAINER" 2>/dev/null || true)"
+    PREV_SCHEDULER_IMAGE_REF="$(docker inspect -f '{{.Config.Image}}' "$PREV_SCHEDULER_CONTAINER" 2>/dev/null || true)"
+    echo "==> Recorded current scheduler image for rollback: ${PREV_SCHEDULER_IMAGE_REF:-unknown} (${PREV_SCHEDULER_IMAGE_ID:-none})"
+else
+    echo "==> No running scheduler container found — no rollback target (first deploy of the scheduler split?)."
 fi
 
 # Capture the DB's alembic revision BEFORE the new container migrates on startup.
@@ -163,7 +181,23 @@ rollback_app() {
         echo "==> ROLLBACK ERROR: could not re-tag the previous image — manual intervention required." >&2
         return 1
     fi
-    docker compose up -d --force-recreate app || true
+    # scheduler is a separately-tagged image (compose tags per service even when
+    # they share `build: .`), so restoring app's tag does NOT also restore
+    # scheduler — it must be re-tagged on its own. Recreate both together so
+    # there's never a moment with a stale-app/fresh-scheduler (or vice versa)
+    # mismatch, and so the exactly-one-scheduler invariant holds throughout.
+    RECREATE_TARGETS="app"
+    if [ -n "$PREV_SCHEDULER_IMAGE_ID" ] && [ -n "$PREV_SCHEDULER_IMAGE_REF" ]; then
+        echo "==> ROLLBACK: restoring previous scheduler image ${PREV_SCHEDULER_IMAGE_REF} -> ${PREV_SCHEDULER_IMAGE_ID}"
+        if ! docker tag "$PREV_SCHEDULER_IMAGE_ID" "$PREV_SCHEDULER_IMAGE_REF"; then
+            echo "==> ROLLBACK ERROR: could not re-tag the previous scheduler image — manual intervention required." >&2
+            return 1
+        fi
+        RECREATE_TARGETS="app scheduler"
+    else
+        echo "==> ROLLBACK WARNING: no previous scheduler image recorded — scheduler stays on its current (new) image." >&2
+    fi
+    docker compose up -d --force-recreate $RECREATE_TARGETS || true
     echo "==> ROLLBACK: waiting for the restored app to become healthy..."
     RB_TRIES=0
     RB_STATUS="unknown"
@@ -181,12 +215,17 @@ rollback_app() {
     return 1
 }
 
-# Step 3: Recreate only the app container with the new image
+# Step 3: Recreate the app + scheduler containers with the new images.
+# Recreated together (scheduler is not gated behind the health-check loop
+# below, which stays app-only): `down` fully removes both old containers
+# before `up` starts the new ones, so there is never a window with two live
+# scheduler containers (old + new) — compose only ever runs one instance per
+# service name either way.
 # Clean up any orphaned rename containers from previous deploys
-echo "==> Restarting app..."
-docker compose down app 2>/dev/null || true
+echo "==> Restarting app + scheduler..."
+docker compose down app scheduler 2>/dev/null || true
 docker container prune -f --filter "label=com.docker.compose.project=availai" 2>/dev/null || true
-docker compose up -d app
+docker compose up -d app scheduler
 
 # Step 4: Wait for health check to pass
 echo "==> Waiting for app to become healthy..."
@@ -236,6 +275,63 @@ if [ "$DEPLOYED_COMMIT" != "$BUILD_COMMIT" ]; then
     exit 1
 fi
 echo "==> MATCH: deployed build tag ($DEPLOYED_COMMIT)"
+
+# Step 5a: Verify the scheduler container, then enforce the exactly-one-
+# scheduler invariant. This is the riskiest part of the Phase-4 infra split:
+# the approval-notification outbox has no cross-process locking, so two live
+# schedulers means double-sent emails. Done after app is confirmed healthy +
+# on the right build (scheduler was recreated alongside app in Step 3, but
+# the health-check loop above is app-only — scheduler has no HTTP healthcheck
+# to poll).
+echo ""
+echo "==> Verifying scheduler container..."
+sleep 3
+SCHEDULER_CONTAINER=$(docker compose ps -q scheduler)
+if [ "$(docker inspect --format='{{.State.Running}}' "$SCHEDULER_CONTAINER" 2>/dev/null)" != "true" ]; then
+    echo "==> ERROR: scheduler is not running after recreate"
+    echo "==> Last 50 log lines:"
+    docker compose logs --tail=50 scheduler
+    echo "==> Attempting automatic rollback..."
+    if rollback_app; then
+        echo "==> Rollback complete: previous images restored and app healthy. Deploy FAILED."
+    else
+        echo "==> Rollback did NOT fully succeed — investigate immediately."
+    fi
+    exit 1
+fi
+SCHEDULER_COMMIT=$(docker compose exec -T scheduler printenv BUILD_COMMIT 2>/dev/null | tr -d '[:space:]' || echo "UNKNOWN")
+if [ "$SCHEDULER_COMMIT" != "$BUILD_COMMIT" ]; then
+    echo "==> MISMATCH: scheduler ($SCHEDULER_COMMIT) does NOT match build ($BUILD_COMMIT)"
+    exit 1
+fi
+echo "==> MATCH: scheduler build tag ($SCHEDULER_COMMIT)"
+
+# The exactly-one-scheduler check itself. app/jobs/__init__.py logs
+# "APScheduler configured with N jobs" exactly once per process where
+# configure_scheduler() actually runs (RUN_SCHEDULER=1, gated in
+# app/main.py's lifespan). docker-compose.yml sets RUN_SCHEDULER=0 on `app`
+# and =1 on `scheduler` — so this must read exactly ONE occurrence in the
+# scheduler container's logs and exactly ZERO in the app container's logs.
+# Any other count means the RUN_SCHEDULER split failed (env not applied, code
+# gate broken, etc.) and must not be left live.
+echo ""
+echo "==> Verifying exactly-one-scheduler invariant..."
+SCHED_LOG_COUNT=$(docker compose logs scheduler 2>/dev/null | grep -c "APScheduler configured" || true)
+APP_LOG_COUNT=$(docker compose logs app 2>/dev/null | grep -c "APScheduler configured" || true)
+echo "==> 'APScheduler configured' occurrences — scheduler: ${SCHED_LOG_COUNT:-0}, app: ${APP_LOG_COUNT:-0}"
+if [ "${SCHED_LOG_COUNT:-0}" -ne 1 ] || [ "${APP_LOG_COUNT:-0}" -ne 0 ]; then
+    echo "==> CRITICAL: exactly-one-scheduler invariant VIOLATED (scheduler=${SCHED_LOG_COUNT:-0}, app=${APP_LOG_COUNT:-0})." >&2
+    echo "==>           Two live schedulers double-send approval-notification emails (no cross-process" >&2
+    echo "==>           locking on that outbox) — this deploy MUST NOT stay live." >&2
+    echo "==> Attempting automatic rollback..."
+    if rollback_app; then
+        echo "==> Rollback complete: previous images restored and app healthy. Deploy FAILED."
+    else
+        echo "==> Rollback did NOT fully succeed — investigate immediately."
+    fi
+    exit 1
+fi
+echo "==> OK: exactly one scheduler process running, zero in app."
 
 # Step 5b: Recreate the enrichment-worker on the freshly-built image.
 # The worker has no HTTP health check, so confirm it is running and verify the

--- a/deploy.sh
+++ b/deploy.sh
@@ -186,44 +186,82 @@ rollback_app() {
     # scheduler — it must be re-tagged on its own. Recreate both together so
     # there's never a moment with a stale-app/fresh-scheduler (or vice versa)
     # mismatch, and so the exactly-one-scheduler invariant holds throughout.
-    RECREATE_TARGETS="app"
     if [ -n "$PREV_SCHEDULER_IMAGE_ID" ] && [ -n "$PREV_SCHEDULER_IMAGE_REF" ]; then
         echo "==> ROLLBACK: restoring previous scheduler image ${PREV_SCHEDULER_IMAGE_REF} -> ${PREV_SCHEDULER_IMAGE_ID}"
         if ! docker tag "$PREV_SCHEDULER_IMAGE_ID" "$PREV_SCHEDULER_IMAGE_REF"; then
             echo "==> ROLLBACK ERROR: could not re-tag the previous scheduler image — manual intervention required." >&2
             return 1
         fi
-        RECREATE_TARGETS="app scheduler"
-    else
-        # CRITICAL: no previous scheduler image to restore to means this is the
-        # first deploy of the scheduler split -- the app image we're about to
-        # restore predates RUN_SCHEDULER entirely, so it starts its own
-        # in-process scheduler unconditionally (today's pre-split behavior).
-        # Leaving the `scheduler` container running after that restore would
-        # mean TWO live schedulers -- exactly the failure mode this feature
-        # exists to prevent. Stop it BEFORE recreating app (not after), so
-        # there is never a window with both alive.
-        echo "==> ROLLBACK: no previous scheduler image recorded (first deploy of the split)." >&2
-        echo "==>           Stopping the scheduler container: the restored (pre-split) app image" >&2
-        echo "==>           runs its own scheduler unconditionally, so leaving scheduler running" >&2
-        echo "==>           too would mean two live schedulers." >&2
-        docker compose stop scheduler || true
+        docker compose up -d --force-recreate app scheduler || true
+        echo "==> ROLLBACK: waiting for the restored app to become healthy..."
+        RB_TRIES=0
+        RB_STATUS="unknown"
+        while [ $RB_TRIES -lt "$MAX_TRIES" ]; do
+            RB_CONTAINER="$(docker compose ps -q app 2>/dev/null || true)"
+            RB_STATUS="$(docker inspect --format='{{.State.Health.Status}}' "$RB_CONTAINER" 2>/dev/null || echo "unknown")"
+            if [ "$RB_STATUS" = "healthy" ]; then
+                echo "==> ROLLBACK: previous app version is healthy again."
+                return 0
+            fi
+            RB_TRIES=$((RB_TRIES + 1))
+            sleep 2
+        done
+        echo "==> ROLLBACK CRITICAL: restored app did NOT become healthy (last status: ${RB_STATUS}) — manual intervention required." >&2
+        return 1
     fi
-    docker compose up -d --force-recreate $RECREATE_TARGETS || true
-    echo "==> ROLLBACK: waiting for the restored app to become healthy..."
-    RB_TRIES=0
-    RB_STATUS="unknown"
-    while [ $RB_TRIES -lt "$MAX_TRIES" ]; do
-        RB_CONTAINER="$(docker compose ps -q app 2>/dev/null || true)"
-        RB_STATUS="$(docker inspect --format='{{.State.Health.Status}}' "$RB_CONTAINER" 2>/dev/null || echo "unknown")"
-        if [ "$RB_STATUS" = "healthy" ]; then
-            echo "==> ROLLBACK: previous app version is healthy again."
-            return 0
-        fi
-        RB_TRIES=$((RB_TRIES + 1))
-        sleep 2
-    done
-    echo "==> ROLLBACK CRITICAL: restored app did NOT become healthy (last status: ${RB_STATUS}) — manual intervention required." >&2
+
+    # CRITICAL (transition-deploy hazard, final review C1): no previous
+    # scheduler image exists, meaning this is the FIRST deploy of the
+    # scheduler split — PREV_APP_IMAGE predates RUN_SCHEDULER entirely (starts
+    # APScheduler unconditionally) AND predates the app's move to multiple
+    # uvicorn workers. `docker compose up` always uses the CURRENT compose
+    # file's `command:` for app (--workers 2) regardless of which image is
+    # tagged there — an image's own baked-in CMD is irrelevant once compose
+    # overrides it. Force-recreating app here would run the OLD
+    # unconditional-scheduler code under the NEW multi-worker command: an
+    # in-process scheduler in EVERY worker process, with the app healthcheck
+    # passing throughout (silent — nobody would notice without reading logs).
+    #
+    # Rejected alternative: synthesize a temporary compose override pinning
+    # app back to the old single-worker command and force-recreate under it.
+    # That trades this hazard for a different one — a hardcoded "known-old"
+    # command baked into deploy.sh that can silently go stale the next time
+    # app's command changes, applied automatically during an already-failed,
+    # unattended rollback. Refusing and handing off to a human is simpler and
+    # strictly safer: this is a ONE-TIME transitional case (once this deploy
+    # succeeds, PREV_SCHEDULER_IMAGE_ID is never empty again), and an obvious,
+    # loud outage beats a silent multi-scheduler one every time.
+    echo "==> ROLLBACK CRITICAL: cannot safely auto-recreate app on this transition deploy." >&2
+    echo "==>   No previous scheduler image exists, so the previous app image predates" >&2
+    echo "==>   RUN_SCHEDULER (unconditional in-process scheduler) while the CURRENT" >&2
+    echo "==>   compose file's app command runs --workers 2 — recreating app under that" >&2
+    echo "==>   combination would silently start a scheduler in EVERY worker process," >&2
+    echo "==>   with the healthcheck still passing throughout. Refusing." >&2
+    echo "==>" >&2
+    echo "==>   Stopping app (scheduler is already stopped) — the site is going DOWN." >&2
+    echo "==>   MANUAL RECOVERY REQUIRED:" >&2
+    echo "==>     1. git log --oneline -5   (identify the bad commit(s) on this host)" >&2
+    echo "==>     2. git revert <bad commit>   (or checkout the last known-good commit)" >&2
+    echo "==>     3. Re-run ./deploy.sh from that reverted state — a full clean deploy of" >&2
+    echo "==>        the pre-split shape, not a partial mix of old image + new command." >&2
+    docker compose stop app scheduler 2>/dev/null || true
+
+    # Verified, not assumed: confirm the end state really is zero schedulers
+    # running anywhere before returning, per the "at most ONE scheduler
+    # anywhere, verified by the script" requirement. `-a` (not just `ps -q`)
+    # so a container that failed to stop for some reason is still found.
+    echo "==> ROLLBACK: verifying app + scheduler are both stopped (zero schedulers running)..."
+    APP_ID="$(docker compose ps -aq app 2>/dev/null || true)"
+    SCHED_ID="$(docker compose ps -aq scheduler 2>/dev/null || true)"
+    APP_RUNNING="false"
+    [ -n "$APP_ID" ] && APP_RUNNING="$(docker inspect --format='{{.State.Running}}' "$APP_ID" 2>/dev/null || echo false)"
+    SCHED_RUNNING="false"
+    [ -n "$SCHED_ID" ] && SCHED_RUNNING="$(docker inspect --format='{{.State.Running}}' "$SCHED_ID" 2>/dev/null || echo false)"
+    if [ "$APP_RUNNING" = "true" ] || [ "$SCHED_RUNNING" = "true" ]; then
+        echo "==> ROLLBACK CRITICAL: app or scheduler is STILL running after stop (app=${APP_RUNNING}, scheduler=${SCHED_RUNNING}) — manual intervention required IMMEDIATELY." >&2
+        return 1
+    fi
+    echo "==> ROLLBACK: confirmed app and scheduler are both stopped — zero schedulers running. Manual recovery required (see above)."
     return 1
 }
 
@@ -328,11 +366,47 @@ echo "==> MATCH: scheduler build tag ($SCHEDULER_COMMIT)"
 # gate broken, etc.) and must not be left live.
 echo ""
 echo "==> Verifying exactly-one-scheduler invariant..."
-SCHED_LOG_COUNT=$(docker compose logs scheduler 2>/dev/null | grep -c "APScheduler configured" || true)
+
+# app must NEVER log this line (RUN_SCHEDULER=0 there — no code path reaches
+# it regardless of how long we wait), so this half stays a strict, immediate,
+# single check — no polling needed for a condition that can't legitimately be
+# "still arriving."
 APP_LOG_COUNT=$(docker compose logs app 2>/dev/null | grep -c "APScheduler configured" || true)
-echo "==> 'APScheduler configured' occurrences — scheduler: ${SCHED_LOG_COUNT:-0}, app: ${APP_LOG_COUNT:-0}"
-if [ "${SCHED_LOG_COUNT:-0}" -ne 1 ] || [ "${APP_LOG_COUNT:-0}" -ne 0 ]; then
-    echo "==> CRITICAL: exactly-one-scheduler invariant VIOLATED (scheduler=${SCHED_LOG_COUNT:-0}, app=${APP_LOG_COUNT:-0})." >&2
+if [ "${APP_LOG_COUNT:-0}" -ne 0 ]; then
+    echo "==> CRITICAL: exactly-one-scheduler invariant VIOLATED (app=${APP_LOG_COUNT:-0}, must be 0)." >&2
+    echo "==>           Two live schedulers double-send approval-notification emails (no cross-process" >&2
+    echo "==>           locking on that outbox) — this deploy MUST NOT stay live." >&2
+    echo "==> Attempting automatic rollback..."
+    if rollback_app; then
+        echo "==> Rollback complete: previous images restored and app healthy. Deploy FAILED."
+    else
+        echo "==> Rollback did NOT fully succeed — investigate immediately."
+    fi
+    exit 1
+fi
+
+# scheduler, unlike app, can legitimately take a while to reach this log line
+# — the alembic advisory lock may be waiting behind app's own migration, then
+# the full app import graph + seeds + register_all_jobs() (61 jobs) all run
+# before it logs. A single early snapshot (final review I1) reads a healthy-
+# but-still-booting scheduler as 0 occurrences: a false violation that
+# triggers an unnecessary rollback. Poll instead, with a bounded window —
+# declare victory the moment it reads exactly 1, and only declare a real
+# violation once the window is exhausted.
+SCHED_POLL_TRIES=0
+SCHED_POLL_MAX=12   # 12 x 10s = up to 120s
+SCHED_LOG_COUNT=0
+while [ $SCHED_POLL_TRIES -lt $SCHED_POLL_MAX ]; do
+    SCHED_LOG_COUNT=$(docker compose logs scheduler 2>/dev/null | grep -c "APScheduler configured" || true)
+    if [ "${SCHED_LOG_COUNT:-0}" -eq 1 ]; then
+        break
+    fi
+    SCHED_POLL_TRIES=$((SCHED_POLL_TRIES + 1))
+    sleep 10
+done
+echo "==> 'APScheduler configured' occurrences — scheduler: ${SCHED_LOG_COUNT:-0} (after ${SCHED_POLL_TRIES} x 10s poll(s)), app: ${APP_LOG_COUNT:-0}"
+if [ "${SCHED_LOG_COUNT:-0}" -ne 1 ]; then
+    echo "==> CRITICAL: exactly-one-scheduler invariant VIOLATED (scheduler=${SCHED_LOG_COUNT:-0}, must be 1) after waiting up to $((SCHED_POLL_MAX * 10))s." >&2
     echo "==>           Two live schedulers double-send approval-notification emails (no cross-process" >&2
     echo "==>           locking on that outbox) — this deploy MUST NOT stay live." >&2
     echo "==> Attempting automatic rollback..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -195,7 +195,19 @@ rollback_app() {
         fi
         RECREATE_TARGETS="app scheduler"
     else
-        echo "==> ROLLBACK WARNING: no previous scheduler image recorded — scheduler stays on its current (new) image." >&2
+        # CRITICAL: no previous scheduler image to restore to means this is the
+        # first deploy of the scheduler split -- the app image we're about to
+        # restore predates RUN_SCHEDULER entirely, so it starts its own
+        # in-process scheduler unconditionally (today's pre-split behavior).
+        # Leaving the `scheduler` container running after that restore would
+        # mean TWO live schedulers -- exactly the failure mode this feature
+        # exists to prevent. Stop it BEFORE recreating app (not after), so
+        # there is never a window with both alive.
+        echo "==> ROLLBACK: no previous scheduler image recorded (first deploy of the split)." >&2
+        echo "==>           Stopping the scheduler container: the restored (pre-split) app image" >&2
+        echo "==>           runs its own scheduler unconditionally, so leaving scheduler running" >&2
+        echo "==>           too would mean two live schedulers." >&2
+        docker compose stop scheduler || true
     fi
     docker compose up -d --force-recreate $RECREATE_TARGETS || true
     echo "==> ROLLBACK: waiting for the restored app to become healthy..."

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,7 +7,23 @@ services:
     environment:
       - TESTING=1
       - EXTRA_LOGS=0
+      - RUN_SCHEDULER=0
     # Hot-reload: mount source code so changes reflect immediately without rebuild
+    volumes:
+      - ./app:/app/app
+      - /app/app/static/dist    # preserve Vite-built assets from image
+      - ./scripts:/app/scripts
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "172.28.0.0/24", "--reload", "--reload-dir", "/app/app"]
+
+  # Same split as prod: dedicated scheduler service. TESTING=1 here too (like
+  # `app` above) so local dev never boots a live APScheduler by default — flip
+  # TESTING off in .env to actually exercise it locally. Hot-reload mounted the
+  # same way as `app` for iterating on app/scheduler.py / app/jobs/.
+  scheduler:
+    environment:
+      - TESTING=1
+      - EXTRA_LOGS=0
+      - RUN_SCHEDULER=1
     volumes:
       - ./app:/app/app
       - /app/app/static/dist    # preserve Vite-built assets from image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,12 @@ services:
     # Trust X-Forwarded-* headers only from the compose network (where Caddy
     # is the sole HTTP client) — never "*", which would trust a spoofed
     # X-Forwarded-For from any client that reached uvicorn directly.
-    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "172.28.0.0/24"]
+    # Phase-4 infra: --workers 2 (locked ruling, not 4) — sync ORM handlers no
+    # longer serialize requests behind one process. DB_POOL_SIZE/
+    # DB_MAX_OVERFLOW in app/database.py are sized per-process against this
+    # worker count; see the connection-budget comment there before raising
+    # either number. The `scheduler` service below stays single-worker.
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "172.28.0.0/24", "--workers", "2"]
     env_file: .env
     # P1.4: REDIS_URL is composed here (not left to whatever plain value is in
     # .env) so redis auth wiring can never drift from the redis service's own
@@ -183,11 +188,13 @@ services:
         max-file: "5"
 
   # --- Scheduler (Phase-4 infra: split out of `app` — APScheduler runs here,
-  # and ONLY here. Same image/command as `app` (single uvicorn worker), just
-  # with RUN_SCHEDULER=1 flipped on and RUN_SCHEDULER=0 on `app` above.
-  # Not reachable from Caddy (no ports mapping) — it exists to run background
-  # jobs, not serve traffic. See app/main.py lifespan + deploy.sh's post-deploy
-  # "exactly one scheduler" verification. ---
+  # and ONLY here. Same image as `app`, but deliberately single-worker (no
+  # --workers flag, unlike `app`'s --workers 2) — APScheduler's in-process job
+  # store/locks assume exactly one process, and RUN_SCHEDULER=1 here vs.
+  # RUN_SCHEDULER=0 on `app` above is what keeps it the only process that runs
+  # jobs at all. Not reachable from Caddy (no ports mapping) — it exists to run
+  # background jobs, not serve traffic. See app/main.py lifespan + deploy.sh's
+  # post-deploy "exactly one scheduler" verification. ---
   scheduler:
     build: .
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,13 @@ services:
     # redis://redis:6379/0 (unchanged default local-dev behavior).
     environment:
       - REDIS_URL=redis://${REDIS_PASSWORD:+:${REDIS_PASSWORD}@}redis:6379/0
+      # Phase-4 infra: the scheduler process now lives in its own `scheduler`
+      # service below. RUN_SCHEDULER=0 keeps this app process free of
+      # APScheduler + the seeds/backfills that feed it — exactly one process
+      # (the scheduler service) must run APScheduler, since the
+      # approval-notification outbox has no cross-process locking and two
+      # schedulers would double-send emails.
+      - RUN_SCHEDULER=0
     stop_grace_period: 60s
     depends_on:
       db:
@@ -162,6 +169,42 @@ services:
       redis:
         condition: service_healthy
       app:
+        condition: service_healthy
+    healthcheck:
+      disable: true
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+  # --- Scheduler (Phase-4 infra: split out of `app` — APScheduler runs here,
+  # and ONLY here. Same image/command as `app` (single uvicorn worker), just
+  # with RUN_SCHEDULER=1 flipped on and RUN_SCHEDULER=0 on `app` above.
+  # Not reachable from Caddy (no ports mapping) — it exists to run background
+  # jobs, not serve traffic. See app/main.py lifespan + deploy.sh's post-deploy
+  # "exactly one scheduler" verification. ---
+  scheduler:
+    build: .
+    restart: always
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "172.28.0.0/24"]
+    env_file: .env
+    # stop_grace_period 60s: matches `app` — APScheduler's shutdown handler
+    # (app/main.py lifespan) waits for in-flight jobs to finish rather than
+    # being SIGKILLed mid-run.
+    stop_grace_period: 60s
+    environment:
+      # P1.4: same REDIS_URL composition as `app` — keep in sync if changed.
+      - REDIS_URL=redis://${REDIS_PASSWORD:+:${REDIS_PASSWORD}@}redis:6379/0
+      - RUN_SCHEDULER=1
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       disable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,7 +211,13 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          # App parity, not enrichment-worker's 512M: this runs the full
+          # app.main:app import graph + 61 registered jobs (register_all_jobs),
+          # not a lazy polling loop.
+          memory: 2G
+          cpus: '2'
+        reservations:
+          memory: 1G
     logging:
       driver: json-file
       options:

--- a/docker-entrypoint-migrate.py
+++ b/docker-entrypoint-migrate.py
@@ -1,0 +1,78 @@
+"""docker-entrypoint-migrate.py — serialize `alembic upgrade head` across containers
+sharing one database.
+
+Phase-4 infra split gave APScheduler its own `scheduler` compose service,
+which shares the app image/Dockerfile/ENTRYPOINT (docker-entrypoint.sh) with
+`app` and `enrichment-worker`. Every container from this image runs `alembic
+upgrade head` at boot; `scheduler`'s depends_on is db+redis only (not `app`,
+per the Phase-4 locked ruling), so on a schema-changing deploy `app` and
+`scheduler` can start their migration runs at the same moment. Plain
+`alembic upgrade head` has no built-in concurrency protection — two
+containers racing DDL against the same schema can deadlock or partially
+apply a migration.
+
+This wrapper takes a Postgres session-level advisory lock BEFORE invoking
+alembic and holds it for the lock's connection's lifetime (i.e. until this
+process exits, since session-level advisory locks release automatically when
+their connection closes — no explicit pg_advisory_unlock needed). A
+container that loses the race simply blocks until the winner's migration
+completes; by the time it acquires the lock, alembic is already at head and
+its own `alembic upgrade head` is a no-op.
+
+Runs BEFORE any app code is meaningfully importable as a server process, so
+this stays dependency-free beyond what the image already ships for the app
+itself: psycopg2-binary (already a hard requirement.txt dependency — the
+same driver SQLAlchemy uses) and the stdlib.
+
+Called by: docker-entrypoint.sh, in place of a bare `alembic upgrade head`,
+via `runuser -u appuser -- python3 docker-entrypoint-migrate.py` (so the
+alembic subprocess it spawns inherits the same non-root appuser identity the
+bare command ran under before this change).
+"""
+
+import os
+import subprocess
+import sys
+
+import psycopg2
+
+# Fixed, arbitrary lock key — must be identical across every process running
+# this script (app, enrichment-worker, scheduler) so they all contend for the
+# SAME lock. Two-int (classid, objid) form for readability; the values carry
+# no meaning beyond "unique to AVAIL migrations" and must never collide with
+# another advisory lock elsewhere in the codebase.
+_LOCK_CLASSID = 87_412_301
+_LOCK_OBJID = 1
+
+
+def main() -> int:
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        print("ERROR: DATABASE_URL is not set — cannot acquire the migration lock.", file=sys.stderr)
+        return 1
+
+    try:
+        conn = psycopg2.connect(database_url)
+    except Exception as exc:
+        print(f"ERROR: could not connect to the database to acquire the migration lock: {exc}", file=sys.stderr)
+        return 1
+
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            print("Waiting for migration lock...", flush=True)
+            cur.execute("SELECT pg_advisory_lock(%s, %s)", (_LOCK_CLASSID, _LOCK_OBJID))
+            print("Migration lock acquired. Running alembic upgrade head...", flush=True)
+
+        result = subprocess.run(["alembic", "upgrade", "head"])
+        return result.returncode
+    finally:
+        # Closing the connection releases the session-level advisory lock
+        # automatically — the next-in-line container's pg_advisory_lock call
+        # unblocks as soon as this happens, whether we got here via a clean
+        # return or an exception from alembic/subprocess above.
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,8 +41,15 @@ fi
 # risks data corruption and masks the real problem. `alembic upgrade head` is
 # idempotent — it is a no-op when the schema is already current, so a non-zero
 # exit always means a genuine failure.
+#
+# Wrapped in docker-entrypoint-migrate.py (a Postgres advisory lock around the
+# alembic call) rather than invoked bare: `app`, `enrichment-worker`, and
+# `scheduler` all share this entrypoint and can boot concurrently, so without
+# serialization two containers could race `alembic upgrade head` against the
+# same DB. The wrapper still just runs `alembic upgrade head` under the hood —
+# see that file for why.
 echo "Running alembic upgrade head..."
-if ! runuser -u appuser -- alembic upgrade head 2>&1; then
+if ! runuser -u appuser -- python3 docker-entrypoint-migrate.py 2>&1; then
     echo "ERROR: alembic upgrade head failed — refusing to start the app." >&2
     echo "The database schema is not at head. Investigate the migration failure" >&2
     echo "before restarting; do not start the app against a stale schema." >&2

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -26,12 +26,42 @@ AvailAI is a production electronic component sourcing platform and CRM. Buyers s
 
 | Container | Purpose | Resources |
 |-----------|---------|-----------|
-| **app** | FastAPI on port 8000 | 2 GB / 2 CPU |
+| **app** | FastAPI on port 8000, `uvicorn --workers 2` | 2 GB / 2 CPU |
+| **scheduler** | Same image as `app`, single-worker, `RUN_SCHEDULER=1` — runs APScheduler, not reachable from Caddy | 2 GB / 2 CPU |
 | **db** | PostgreSQL 16 | 2 GB / 1.5 CPU |
 | **redis** | Cache + coordination | 768 MB |
 | **caddy** | Reverse proxy, HTTPS | 512 MB |
 | **db-backup** | pg_dump every 6 hours | 256 MB |
 | **enrichment-worker** | Paced material-card enrichment — trust chain `verified` (distributor API) → `web_sourced` (Claude web search, authorized domains) → **OEM cross-ref** (grounded web, double-verify against distributors → `verified`) → **OEM description** (`oem_sourced`, single official OEM page) → `ai_inferred` (Opus 4.8, ≥0.95, flagged) → `not_catalogued` (recognised OEM/FRU, no public specs) / `not_found`. OEM tiers gated by a pure regex classifier (`oem_classifier.py`). `web_meter` tracks per-card billable web calls + Claude health for exact budget accounting and circuit-breaker reset. Fast-lane: newest-added parts head the queue (`select_batch` orders `unenriched-first, then search_count DESC, created_at DESC` — never-resolved parts drain before `not_found` re-checks, so old low-demand cards aren't starved by the daily re-check churn); ~60s idle poll | 512 MB |
+
+**Phase-4 infra split (multi-process runtime):** `app` runs `uvicorn --workers 2`
+(locked ruling) so sync ORM handlers no longer serialize behind one process;
+APScheduler moved out into the dedicated `scheduler` service (same image,
+single-worker, `RUN_SCHEDULER=1`) while `app` sets `RUN_SCHEDULER=0` — gated in
+`app/main.py`'s lifespan, because the approval-notification outbox has no
+cross-process locking and two live schedulers would double-send emails.
+(`enrichment-worker` runs `python -m app.services.enrichment_worker` directly,
+never `uvicorn app.main:app`, so the flag doesn't apply to it — it never
+touches the lifespan/scheduler code at all.) `RUN_SCHEDULER` is the instant
+rollback knob if the split ever needs collapsing back to one process, and
+`/health`'s `scheduler` field reports `"external (scheduler service)"` on `app`
+rather than a misleading `"off"`. Real-time SSE (`app/services/sse_broker.py`) fans out
+over Redis pub/sub (namespaced `sse:{channel}`) so a `publish()` from one
+worker or from the scheduler reaches a `listen()`-er attached to a different
+worker; each listener's background reader task self-heals a dropped or
+never-connected Redis with capped exponential backoff, and the whole path
+falls back to the original in-process dict fan-out (same-process delivery
+only) when Redis is unavailable or `TESTING`. Every container built from the
+app image (`app`, `scheduler`, `enrichment-worker`) migrates through
+`docker-entrypoint-migrate.py`, which wraps `alembic upgrade head` in a
+Postgres session-level advisory lock so concurrent boots on a schema-changing
+deploy can't race DDL — the loser blocks until the winner finishes, then
+no-ops. Per-process DB pool sizing (`DB_POOL_SIZE`/`DB_MAX_OVERFLOW`, default
+5+5) is budgeted against Postgres `max_connections=100` across every process
+that imports `app/database.py`; the full connection-budget table (2 app
+workers + scheduler + enrichment-worker + 3 host workers = 70 of 100, 30
+headroom) lives in the comment above the module-level `engine` in
+`app/database.py`.
 
 ## Request Flow — Browser to Database
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,6 +31,12 @@ ignore = [
 "scripts/*" = ["F841", "ASYNC230", "T201", "BLE001"]
 # CLI management commands (python -m app.management.*): stdout is their UX.
 "app/management/*" = ["T201"]
+# Bootstrap migration-lock wrapper invoked by docker-entrypoint.sh before the
+# app itself (and its loguru setup) is running -- stdout IS its UX, same
+# reasoning as scripts/*, and the top-level connect failure is a deliberate
+# catch-log-exit(1) so a DB outage prints a clear message instead of a raw
+# traceback before anything is logging yet.
+"docker-entrypoint-migrate.py" = ["T201", "BLE001"]
 # Deliberate broad-catch orchestrators: scheduler jobs must never let one failing
 # item kill the whole run.
 "app/jobs/*" = ["BLE001"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,8 @@ class TestDefaults:
             ("rate_limit_enabled", True),
             ("admin_emails", []),
             ("own_domains", frozenset({"trioscs.com"})),
+            ("db_pool_size", 5),
+            ("db_max_overflow", 5),
         ],
     )
     def test_default(self, attr, expected):
@@ -82,6 +84,40 @@ class TestDatabaseUrlValidator:
         env = {"DATABASE_URL": "sqlite://", "TESTING": ""}
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(ValidationError, match="DATABASE_URL must start with"):
+                _make()
+
+
+class TestDbPoolSettings:
+    """DB_POOL_SIZE / DB_MAX_OVERFLOW are env-tunable per-process pool caps (Phase-4
+    infra: sized against Postgres max_connections=100 across the 2 app workers +
+    scheduler + enrichment-worker + 3 host workers — see the budget comment in
+    app/database.py)."""
+
+    def test_env_override(self):
+        s = _settings_with({"DB_POOL_SIZE": "8", "DB_MAX_OVERFLOW": "12"})
+        assert s.db_pool_size == 8
+        assert s.db_max_overflow == 12
+        assert isinstance(s.db_pool_size, int)
+        assert isinstance(s.db_max_overflow, int)
+
+    def test_pool_size_rejects_zero(self):
+        with patch.dict(os.environ, {"DB_POOL_SIZE": "0"}, clear=True):
+            with pytest.raises(ValidationError):
+                _make()
+
+    def test_pool_size_rejects_negative(self):
+        with patch.dict(os.environ, {"DB_POOL_SIZE": "-1"}, clear=True):
+            with pytest.raises(ValidationError):
+                _make()
+
+    def test_max_overflow_allows_zero(self):
+        """max_overflow=0 (no bursting past pool_size) is a valid, deliberate config."""
+        s = _settings_with({"DB_MAX_OVERFLOW": "0"})
+        assert s.db_max_overflow == 0
+
+    def test_max_overflow_rejects_negative(self):
+        with patch.dict(os.environ, {"DB_MAX_OVERFLOW": "-1"}, clear=True):
+            with pytest.raises(ValidationError):
                 _make()
 
 

--- a/tests/test_database_coverage.py
+++ b/tests/test_database_coverage.py
@@ -188,8 +188,14 @@ class TestMakeEngine:
     """
 
     def test_postgresql_branch_passes_pool_and_timeout_args(self):
-        """A postgresql:// URL gets the production pool settings and the
-        statement_timeout / lock_timeout connect option."""
+        """A postgresql:// URL gets the default (env-tunable) pool settings and the
+        statement_timeout / lock_timeout connect option.
+
+        Defaults (5 + 5 = 10
+        max per process) match Settings.db_pool_size/db_max_overflow — see the
+        connection-budget comment above the module-level `engine` in
+        app/database.py for the arithmetic against Postgres max_connections.
+        """
         import app.database as database
 
         with patch.object(database, "create_engine") as mock_create:
@@ -198,13 +204,31 @@ class TestMakeEngine:
         assert mock_create.call_count == 1
         args, kwargs = mock_create.call_args
         assert args[0] == "postgresql://user:pass@localhost/testdb"
-        assert kwargs["pool_size"] == 20
-        assert kwargs["max_overflow"] == 20
+        assert kwargs["pool_size"] == 5
+        assert kwargs["max_overflow"] == 5
         assert kwargs["pool_timeout"] == 10
         assert kwargs["pool_pre_ping"] is True
         assert kwargs["pool_recycle"] == 1800
         assert "statement_timeout" in kwargs["connect_args"]["options"]
         assert "lock_timeout" in kwargs["connect_args"]["options"]
+
+    def test_postgresql_branch_honors_explicit_pool_kwargs(self):
+        """pool_size/max_overflow passed to _make_engine (as the module-level `engine`
+        does, from settings.db_pool_size/db_max_overflow) override the defaults — this
+        is the env-driven knob the scheduler/enrichment-worker/ host-worker processes
+        all share via the same Settings instance."""
+        import app.database as database
+
+        with patch.object(database, "create_engine") as mock_create:
+            database._make_engine(
+                "postgresql://user:pass@localhost/testdb",
+                pool_size=8,
+                max_overflow=12,
+            )
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["pool_size"] == 8
+        assert kwargs["max_overflow"] == 12
 
     def test_sqlite_branch_uses_static_pool(self):
         """A sqlite:// URL builds a StaticPool engine with check_same_thread off."""
@@ -228,18 +252,46 @@ class TestMakeEngine:
 
         assert mock_create.call_count == 1
         _, kwargs = mock_create.call_args
-        assert kwargs["pool_size"] == 20
+        assert kwargs["pool_size"] == 5
         assert "options" not in kwargs["connect_args"]
 
     def test_make_engine_postgresql_builds_real_queue_pool(self):
         """Sanity check with create_engine un-patched: a postgresql:// URL
-        yields a real QueuePool engine (no connection is opened)."""
+        yields a real QueuePool engine (no connection is opened), sized to the
+        default 5 (matching Settings.db_pool_size's default)."""
         from app.database import _make_engine
 
         eng = _make_engine("postgresql://user:pass@localhost:5432/testdb")
         try:
             assert eng.pool.__class__.__name__ == "QueuePool"
-            assert eng.pool.size() == 20
+            assert eng.pool.size() == 5
             assert eng.dialect.name == "postgresql"
         finally:
             eng.dispose()
+
+    def test_make_engine_postgresql_honors_explicit_pool_size(self):
+        """Sanity check with create_engine un-patched: explicit pool_size is
+        honored on a real QueuePool (no connection is opened)."""
+        from app.database import _make_engine
+
+        eng = _make_engine(
+            "postgresql://user:pass@localhost:5432/testdb",
+            pool_size=8,
+            max_overflow=12,
+        )
+        try:
+            assert eng.pool.size() == 8
+            assert eng.pool._max_overflow == 12
+        finally:
+            eng.dispose()
+
+    def test_module_engine_uses_settings_pool_values(self):
+        """The module-level `engine` is built with settings.db_pool_size /
+        settings.db_max_overflow, not a hardcoded literal — this is what makes
+        DB_POOL_SIZE/DB_MAX_OVERFLOW an actual runtime knob."""
+        from app.config import settings
+        from app.database import engine as db_engine
+
+        if db_engine.dialect.name != "postgresql":
+            pytest.skip("module engine is sqlite in TESTING mode; pool sizing N/A")
+        assert db_engine.pool.size() == settings.db_pool_size

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -794,6 +794,44 @@ class TestHealthPublicVsAuth:
             assert "redis" in data
 
 
+# ── Health endpoint: RUN_SCHEDULER-aware scheduler field ──────────────
+
+
+class TestHealthSchedulerField:
+    """Phase-4 infra: on a process with RUN_SCHEDULER=0 (the `app` compose
+    service), APScheduler deliberately never starts -- the /health `scheduler`
+    field must say so honestly instead of reporting the permanently-wrong
+    "off" (which would read as an unexpected outage on every single request).
+    """
+
+    def test_run_scheduler_zero_reports_external(self, client):
+        """RUN_SCHEDULER=0 -> "external (scheduler service)", not "off"."""
+        original = os.environ.pop("RUN_SCHEDULER", None)
+        try:
+            os.environ["RUN_SCHEDULER"] = "0"
+            with patch("app.main.settings.metrics_token", "test-token"):
+                resp = client.get("/health", headers={"x-metrics-token": "test-token"})
+                data = resp.json()
+                assert data["scheduler"] == "external (scheduler service)"
+        finally:
+            os.environ.pop("RUN_SCHEDULER", None)
+            if original is not None:
+                os.environ["RUN_SCHEDULER"] = original
+
+    def test_run_scheduler_default_keeps_off_meaning(self, client):
+        """RUN_SCHEDULER unset (default "1") -- scheduler not running under TESTING
+        still reports "off", exactly as before this change."""
+        original = os.environ.pop("RUN_SCHEDULER", None)
+        try:
+            with patch("app.main.settings.metrics_token", "test-token"):
+                resp = client.get("/health", headers={"x-metrics-token": "test-token"})
+                data = resp.json()
+                assert data["scheduler"] == "off"
+        finally:
+            if original is not None:
+                os.environ["RUN_SCHEDULER"] = original
+
+
 # ── P2.7: liveness/readiness split ────────────────────────────────────
 
 

--- a/tests/test_run_scheduler_flag.py
+++ b/tests/test_run_scheduler_flag.py
@@ -1,0 +1,181 @@
+"""Tests for the RUN_SCHEDULER flag (Phase-4 infra: dedicated scheduler service).
+
+Verifies app/main.py's lifespan gates the APScheduler start/shutdown, the
+source/browser-worker seeds, and the deferred startup backfills behind
+``os.environ.get("RUN_SCHEDULER", "1") == "1"``. Default "1" preserves
+today's single-process behavior (instant rollback knob). docker-compose.yml
+sets RUN_SCHEDULER=0 on the `app` service and RUN_SCHEDULER=1 on the new
+`scheduler` service -- exactly one process must run the scheduler, since the
+approval-notification outbox has no cross-process locking and two schedulers
+would double-send emails.
+
+Mirrors the lifespan-test technique tests/test_main.py already uses
+(no_testing_env() + run_lifespan(), draining the P2.7 background task) rather
+than importing it, so this file stays self-contained.
+"""
+
+import asyncio
+import os
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@contextmanager
+def no_testing_env():
+    """Temporarily unset TESTING, restoring it to "1" on exit.
+
+    The lifespan's RUN_SCHEDULER gate only matters on the `if not _is_testing:`
+    branch -- under TESTING=1 (the suite default, set in conftest.py) the whole
+    branch is skipped regardless of RUN_SCHEDULER.
+    """
+    original = os.environ.pop("TESTING", None)
+    try:
+        yield
+    finally:
+        os.environ["TESTING"] = original if original is not None else "1"
+
+
+@contextmanager
+def run_scheduler_env(value):
+    """Temporarily set RUN_SCHEDULER to `value` (None = leave unset, to exercise the
+    default), restoring the prior value/absence on exit."""
+    original = os.environ.pop("RUN_SCHEDULER", None)
+    try:
+        if value is not None:
+            os.environ["RUN_SCHEDULER"] = value
+        yield
+    finally:
+        os.environ.pop("RUN_SCHEDULER", None)
+        if original is not None:
+            os.environ["RUN_SCHEDULER"] = original
+
+
+def run_lifespan(mock_app):
+    """Run the app lifespan async context (enter + exit) on a fresh event loop.
+
+    Also drains any fire-and-forget background tasks the lifespan scheduled (P2.7's
+    deferred startup-backfill task via safe_background_task) before closing the loop --
+    mirrors tests/test_main.py's helper of the same name.
+    """
+    from app.main import lifespan
+
+    async def _run():
+        async with lifespan(mock_app):
+            pass
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+@contextmanager
+def _lifespan_mocks():
+    """Patch every lifespan dependency so a real (non-TESTING) boot can run end to end
+    without touching a real DB/scheduler/Sentry, yielding the mocks relevant to the
+    RUN_SCHEDULER assertions."""
+    with (
+        patch("app.main.settings") as mock_settings,
+        patch("app.startup.run_startup_migrations"),
+        patch("app.startup.ensure_screenshot_storage"),
+        patch("app.startup.ensure_avatar_storage"),
+        patch("app.startup.seed_api_sources") as mock_seed_api,
+        patch("app.startup.seed_browser_workers") as mock_seed_browser,
+        patch("app.startup.mark_deferred_backfills_pending") as mock_mark,
+        patch("app.startup.run_deferred_startup_backfills") as mock_deferred,
+        patch("app.connector_status.log_connector_status", return_value={}) as mock_connector,
+        patch("app.scheduler.configure_scheduler") as mock_configure,
+        patch("app.scheduler.scheduler") as mock_scheduler,
+        patch("app.http_client.close_clients", new_callable=AsyncMock),
+    ):
+        mock_settings.secret_key = "a-real-secret-key"
+        mock_settings.sentry_dsn = ""
+        mock_settings.azure_client_id = "cid"
+        mock_settings.azure_client_secret = "csecret"
+        mock_settings.azure_tenant_id = "tid"
+        mock_settings.acs_connection_string = ""
+        mock_settings.acs_webhook_secret = ""
+        yield {
+            "seed_api": mock_seed_api,
+            "seed_browser": mock_seed_browser,
+            "mark": mock_mark,
+            "deferred": mock_deferred,
+            "connector": mock_connector,
+            "configure": mock_configure,
+            "scheduler": mock_scheduler,
+        }
+
+
+class TestRunSchedulerFlagDefaultOn:
+    """RUN_SCHEDULER unset or "1" preserves today's single-process behavior:
+
+    seeds, APScheduler start/shutdown, and the deferred backfills all run.
+    """
+
+    def test_default_unset_runs_scheduler_and_seeds(self):
+        mock_app = MagicMock()
+        with no_testing_env(), run_scheduler_env(None), _lifespan_mocks() as mocks:
+            run_lifespan(mock_app)
+
+            mocks["seed_api"].assert_called_once()
+            mocks["seed_browser"].assert_called_once()
+            mocks["configure"].assert_called_once()
+            mocks["scheduler"].start.assert_called_once()
+            mocks["scheduler"].shutdown.assert_called_once_with(wait=True)
+            mocks["mark"].assert_called_once()
+            mocks["deferred"].assert_called_once()
+            # Connector status logging is NOT gated by RUN_SCHEDULER -- runs
+            # on every real (non-TESTING) boot regardless.
+            mocks["connector"].assert_called_once()
+
+    def test_explicit_run_scheduler_1_runs_scheduler_and_seeds(self):
+        mock_app = MagicMock()
+        with no_testing_env(), run_scheduler_env("1"), _lifespan_mocks() as mocks:
+            run_lifespan(mock_app)
+
+            mocks["seed_api"].assert_called_once()
+            mocks["seed_browser"].assert_called_once()
+            mocks["configure"].assert_called_once()
+            mocks["scheduler"].start.assert_called_once()
+            mocks["scheduler"].shutdown.assert_called_once_with(wait=True)
+            mocks["mark"].assert_called_once()
+            mocks["deferred"].assert_called_once()
+
+
+class TestRunSchedulerFlagOff:
+    """RUN_SCHEDULER=0 skips seeds, APScheduler start/shutdown, and the deferred
+    backfills entirely -- the `app` service's setting in docker-compose.yml, once the
+    scheduler moves to its own service."""
+
+    def test_zero_skips_scheduler_and_seeds(self):
+        mock_app = MagicMock()
+        with no_testing_env(), run_scheduler_env("0"), _lifespan_mocks() as mocks:
+            run_lifespan(mock_app)
+
+            mocks["seed_api"].assert_not_called()
+            mocks["seed_browser"].assert_not_called()
+            mocks["configure"].assert_not_called()
+            mocks["scheduler"].start.assert_not_called()
+            mocks["scheduler"].shutdown.assert_not_called()
+            mocks["mark"].assert_not_called()
+            mocks["deferred"].assert_not_called()
+            # Connector status logging is NOT gated by RUN_SCHEDULER -- still
+            # runs on the app process even with the scheduler disabled.
+            mocks["connector"].assert_called_once()
+
+    def test_zero_never_raises_on_shutdown(self):
+        """RUN_SCHEDULER=0 never imports `scheduler` during startup -- the shutdown
+        guard MUST be gated by the same flag rather than calling `scheduler.shutdown()`
+        unconditionally, which would NameError since the name was never bound in this
+        run of the lifespan.
+
+        A regression here would surface as an unhandled exception from run_lifespan(),
+        failing this test even without an explicit assertion below.
+        """
+        mock_app = MagicMock()
+        with no_testing_env(), run_scheduler_env("0"), _lifespan_mocks():
+            run_lifespan(mock_app)  # must not raise NameError on shutdown

--- a/tests/test_services_webhook.py
+++ b/tests/test_services_webhook.py
@@ -161,6 +161,23 @@ def _make_notification(
     }
 
 
+class _FakeReplayRedis:
+    """Minimal redis stand-in implementing the SET NX EX slice the webhook replay cache
+    uses (mirrors ``FakeRedis`` in tests/test_outreach_rate_limiter.py)."""
+
+    def __init__(self, *, fail: bool = False):
+        self.store: dict[str, str] = {}
+        self.fail = fail
+
+    def set(self, key: str, value: str, nx: bool = False, ex: int | None = None):
+        if self.fail:
+            raise RuntimeError("redis down")
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+
 def _make_message(
     msg_id: str = "msg-001",
     subject: str = "RE: RFQ LM317T",
@@ -1063,6 +1080,44 @@ class TestValidateNotifications:
         # Should be accepted again after expiry
         result2 = validate_notifications({"value": [notif.copy()]}, db_session)
         assert len(result2) == 1
+
+    def test_validate_replay_redis_rejects_duplicate(self, db_session, test_user, monkeypatch):
+        """Replay protection via the Redis SET NX EX path (shared across worker
+        processes) rejects a duplicate sub+resource within the window, without touching
+        the in-process fallback cache."""
+        fake_redis = _FakeReplayRedis()
+        monkeypatch.setattr("app.services.webhook_service._get_redis", lambda: fake_redis)
+
+        _make_subscription(db_session, test_user, sub_id="sub-val-redis", client_state="secret")
+        notif = _make_notification(
+            sub_id="sub-val-redis", client_state="secret", resource="Users('abc')/Messages('msg-redis')"
+        )
+
+        result1 = validate_notifications({"value": [notif.copy()]}, db_session)
+        assert len(result1) == 1
+
+        result2 = validate_notifications({"value": [notif.copy()]}, db_session)
+        assert result2 == []
+
+        # The Redis path handled it — the in-process fallback dict was never touched.
+        assert "sub-val-redis:Users('abc')/Messages('msg-redis')" not in _seen_notifications
+
+    def test_validate_replay_redis_error_falls_back_to_in_process(self, db_session, test_user, monkeypatch):
+        """A Redis SET error degrades to the in-process cache instead of failing open
+        (silently accepting every replay) or raising."""
+        fake_redis = _FakeReplayRedis(fail=True)
+        monkeypatch.setattr("app.services.webhook_service._get_redis", lambda: fake_redis)
+
+        _make_subscription(db_session, test_user, sub_id="sub-val-redis-err", client_state="secret")
+        notif = _make_notification(
+            sub_id="sub-val-redis-err", client_state="secret", resource="Users('abc')/Messages('msg-redis-err')"
+        )
+
+        result1 = validate_notifications({"value": [notif.copy()]}, db_session)
+        assert len(result1) == 1
+
+        result2 = validate_notifications({"value": [notif.copy()]}, db_session)
+        assert result2 == []
 
     def test_validate_timing_safe(self, db_session, test_user):
         """Verify that hmac.compare_digest is used for clientState comparison."""

--- a/tests/test_sse_broker_redis.py
+++ b/tests/test_sse_broker_redis.py
@@ -1,0 +1,244 @@
+"""tests/test_sse_broker_redis.py — Tests for the Redis-backed SSE broker fan-out.
+
+Covers the Redis pub/sub path added to app.services.sse_broker.SSEBroker:
+
+- channel namespacing / wire-payload serialization (pure unit tests)
+- the in-process fallback under TESTING=1 (the actual condition the whole suite runs
+  under) — reuses the shape of tests/test_sse_broker_coverage.py to prove nothing changed
+- listener cleanup (reader task cancelled, pubsub connection closed, channel entry
+  removed) on disconnect, driven against a hand-rolled fake pubsub — no fakeredis
+  dependency exists in this repo (checked: not in requirements.txt, not importable), so
+  the fake is scoped to exactly the surface _redis_reader calls (pubsub/subscribe/
+  listen/unsubscribe/aclose, publish)
+- a true two-instance cross-process check, gated on INTEGRATION_REDIS_URL — same
+  convention as tests/integration/test_redis_integration.py (conftest.py blanks
+  REDIS_URL for isolation, so a dedicated var carries the live server URL in CI)
+
+Called by: pytest
+Depends on: app.services.sse_broker, app.utils.json_helpers, tests.conftest
+"""
+
+import asyncio
+import os
+
+os.environ["TESTING"] = "1"
+
+from uuid import uuid4
+
+import pytest
+
+from app.services.sse_broker import SSEBroker, _redis_channel
+from app.utils import json_helpers as json
+from tests.conftest import engine  # noqa: F401
+
+INTEGRATION_REDIS_URL = os.environ.get("INTEGRATION_REDIS_URL") or ""
+
+
+# ── Unit: channel namespacing + serialization ──────────────────────────
+
+
+class TestRedisChannelNamespacing:
+    """_redis_channel() — the sse:{channel} prefix that keeps broker traffic out of the
+    rest of the Redis keyspace."""
+
+    def test_namespaces_with_sse_prefix(self):
+        assert _redis_channel("search:abc123") == "sse:search:abc123"
+
+    def test_distinct_per_channel_name(self):
+        assert _redis_channel("user:1") != _redis_channel("user:2")
+
+    def test_preserves_channel_name_verbatim_after_prefix(self):
+        assert _redis_channel("requisitions") == "sse:requisitions"
+
+
+class TestWirePayloadSerialization:
+    """The exact {'event', 'data'} shape publish() PUBLISHes must round-trip back to
+    what listen() yields — this is the contract _redis_reader relies on."""
+
+    def test_round_trips_through_json_helpers(self):
+        payload = json.dumps({"event": "sighting-updated", "data": '{"requirement_id": 7}'})
+        assert json.loads(payload) == {"event": "sighting-updated", "data": '{"requirement_id": 7}'}
+
+    def test_empty_data_round_trips(self):
+        payload = json.dumps({"event": "ping", "data": ""})
+        assert json.loads(payload) == {"event": "ping", "data": ""}
+
+
+# ── Fallback path: TESTING disables Redis, byte-identical in-process fan-out ──
+
+
+class TestFallbackPathUnderTesting:
+    """Reuses the shape of tests/test_sse_broker_coverage.py — confirms the Redis
+    addition changes nothing under TESTING=1, the condition the whole suite runs
+    under."""
+
+    async def test_get_redis_returns_none_and_disables_permanently(self):
+        b = SSEBroker()
+        assert await b._get_redis() is None
+        assert b._redis_disabled is True
+        # Second call must not re-probe — still None, still disabled.
+        assert await b._get_redis() is None
+
+    async def test_publish_falls_back_to_local_queues(self):
+        b = SSEBroker()
+        q = b.subscribe("fallback-chan")
+        await b.publish("fallback-chan", "evt", "payload")
+        assert q.get_nowait() == {"event": "evt", "data": "payload"}
+
+    async def test_listen_yields_without_a_redis_reader_task(self):
+        """Listen() under TESTING never creates a Redis reader task — publish() delivers
+        straight onto the local queue, exactly as before Redis support existed."""
+        b = SSEBroker()
+        received = []
+
+        async def _consumer():
+            async for msg in b.listen("fallback-listen"):
+                received.append(msg)
+                break
+
+        async def _producer():
+            await asyncio.sleep(0)
+            await b.publish("fallback-listen", "hello", "world")
+
+        await asyncio.gather(_consumer(), _producer())
+        assert received == [{"event": "hello", "data": "world"}]
+        assert len(b._channels["fallback-listen"]) == 0  # unsubscribed on exit
+
+
+# ── Cleanup: no leaked pubsub connection on listener disconnect ────────
+
+
+class _FakePubSub:
+    """Minimal stand-in for redis.asyncio.client.PubSub — just enough surface
+    (subscribe/listen/unsubscribe/aclose) for the reader-task lifecycle test below."""
+
+    def __init__(self, channel_queue: asyncio.Queue):
+        self._channel_queue = channel_queue
+        self.subscribed = False
+        self.unsubscribed = False
+        self.closed = False
+
+    async def subscribe(self, _channel):
+        self.subscribed = True
+
+    async def listen(self):
+        while True:
+            msg = await self._channel_queue.get()
+            yield msg
+
+    async def unsubscribe(self, _channel=None):
+        self.unsubscribed = True
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _FakeRedis:
+    """Minimal stand-in for redis.asyncio.Redis — .pubsub() is what _redis_reader calls;
+    .publish() feeds the same in-memory queue so publish()/listen() can be driven end-
+    to-end without a real server."""
+
+    def __init__(self):
+        self.channel_queue: asyncio.Queue = asyncio.Queue()
+        self.published: list[tuple[str, str]] = []
+        self.pubsubs: list[_FakePubSub] = []
+
+    def pubsub(self):
+        ps = _FakePubSub(self.channel_queue)
+        self.pubsubs.append(ps)
+        return ps
+
+    async def publish(self, channel: str, payload: str):
+        self.published.append((channel, payload))
+        await self.channel_queue.put({"type": "message", "channel": channel, "data": payload})
+
+    async def ping(self):
+        return True
+
+
+async def test_listen_cleanup_closes_pubsub_and_cancels_reader_on_disconnect():
+    """Listen()'s finally cancels the reader task and closes its pubsub — the leak the
+    Task 1 brief calls out explicitly."""
+    b = SSEBroker()
+    fake_redis = _FakeRedis()
+    b._redis_client = fake_redis  # short-circuit the probe — pretend Redis is live
+
+    gen = b.listen("cleanup-chan")
+    consume_task = asyncio.create_task(gen.__anext__())
+    await asyncio.sleep(0)  # let listen() run to `await q.get()`, starting the reader task
+
+    await fake_redis.publish(_redis_channel("cleanup-chan"), json.dumps({"event": "e", "data": "d"}))
+
+    msg = await asyncio.wait_for(consume_task, timeout=2)
+    assert msg == {"event": "e", "data": "d"}
+
+    assert len(fake_redis.pubsubs) == 1
+    fake_pubsub = fake_redis.pubsubs[0]
+    assert fake_pubsub.subscribed is True
+    assert fake_pubsub.closed is False  # still open while the listener is connected
+
+    await gen.aclose()  # simulates the SSE client disconnecting
+
+    assert fake_pubsub.unsubscribed is True
+    assert fake_pubsub.closed is True  # no leaked pubsub connection
+    assert len(b._channels["cleanup-chan"]) == 0  # local queue entry cleaned up too
+
+
+async def test_listen_reader_task_survives_unrelated_channel_noise():
+    """A message of type != 'message' (e.g. the subscribe confirmation redis-py itself
+    emits) must not be forwarded to the caller's queue."""
+    b = SSEBroker()
+    fake_redis = _FakeRedis()
+    b._redis_client = fake_redis
+
+    gen = b.listen("noise-chan")
+    consume_task = asyncio.create_task(gen.__anext__())
+    await asyncio.sleep(0)
+
+    await fake_redis.channel_queue.put({"type": "subscribe", "channel": "sse:noise-chan", "data": 1})
+    await fake_redis.publish(_redis_channel("noise-chan"), json.dumps({"event": "real", "data": "x"}))
+
+    msg = await asyncio.wait_for(consume_task, timeout=2)
+    assert msg == {"event": "real", "data": "x"}
+
+    await gen.aclose()
+
+
+# ── True cross-process check: two broker instances, one real Redis ─────
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not INTEGRATION_REDIS_URL,
+    reason="INTEGRATION_REDIS_URL not set — real two-instance Redis fan-out test skipped",
+)
+async def test_publish_on_one_instance_reaches_listener_on_another(monkeypatch):
+    """Two independent SSEBroker() instances (simulating two uvicorn workers), each with
+    its own lazy Redis client, sharing ONE real Redis: publish() on instance A must
+    reach listen() on instance B.
+
+    This is the actual cross-process guarantee Task 1 exists to add — the fake-pubsub
+    tests above only prove the reader-task lifecycle, not real Redis wire behavior. Runs
+    only against a real server via INTEGRATION_REDIS_URL (set by the CI "Redis
+    integration tests" step); everywhere else it's skipped, never flaky.
+    """
+    monkeypatch.delenv("TESTING", raising=False)
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "cache_backend", "redis", raising=False)
+    monkeypatch.setattr(settings, "redis_url", INTEGRATION_REDIS_URL, raising=False)
+
+    broker_a = SSEBroker()
+    broker_b = SSEBroker()
+    channel = f"itest:{uuid4().hex}"
+
+    gen = broker_b.listen(channel)
+    consume_task = asyncio.create_task(gen.__anext__())
+    await asyncio.sleep(0.2)  # let broker_b's reader task actually SUBSCRIBE on the wire
+
+    await broker_a.publish(channel, "cross-process", "payload")
+
+    msg = await asyncio.wait_for(consume_task, timeout=5)
+    assert msg == {"event": "cross-process", "data": "payload"}
+
+    await gen.aclose()

--- a/tests/test_sse_broker_redis.py
+++ b/tests/test_sse_broker_redis.py
@@ -10,6 +10,10 @@ Covers the Redis pub/sub path added to app.services.sse_broker.SSEBroker:
   dependency exists in this repo (checked: not in requirements.txt, not importable), so
   the fake is scoped to exactly the surface _redis_reader calls (pubsub/subscribe/
   listen/unsubscribe/aclose, publish)
+- self-healing: a mid-stream drop reconnects and resumes delivery instead of ending the
+  reader task; a listener started before Redis was reachable attaches once it recovers;
+  cancellation during the reconnect backoff sleep exits promptly; local (same-process)
+  delivery via publish()'s fallback keeps working for the whole outage window
 - a true two-instance cross-process check, gated on INTEGRATION_REDIS_URL — same
   convention as tests/integration/test_redis_integration.py (conftest.py blanks
   REDIS_URL for isolation, so a dedicated var carries the live server URL in CI)
@@ -19,7 +23,9 @@ Depends on: app.services.sse_broker, app.utils.json_helpers, tests.conftest
 """
 
 import asyncio
+import contextlib
 import os
+import time
 
 os.environ["TESTING"] = "1"
 
@@ -200,6 +206,200 @@ async def test_listen_reader_task_survives_unrelated_channel_noise():
 
     msg = await asyncio.wait_for(consume_task, timeout=2)
     assert msg == {"event": "real", "data": "x"}
+
+    await gen.aclose()
+
+
+# ── Self-healing: reconnect after a drop / late Redis recovery ─────────
+
+
+class _DropOncePubSub:
+    """Pubsub double whose FIRST generation delivers exactly one message, then raises a
+    simulated connection drop — exercising _redis_reader's reconnect path end-to-end.
+
+    Every later generation (post-reconnect) reads normally from the same shared queue.
+    ``ConnectionError`` is a real builtin subclassing ``OSError``, so it's caught by
+    _redis_reader's ``except (redis.RedisError, OSError)`` exactly like a genuine
+    redis-py connection error would be.
+    """
+
+    def __init__(self, fake_redis: "_FlakyFakeRedis", channel_queue: asyncio.Queue):
+        self._generation = fake_redis.subscribe_count
+        self._channel_queue = channel_queue
+        self.subscribed = False
+        self.closed = False
+
+    async def subscribe(self, _channel):
+        self.subscribed = True
+
+    async def listen(self):
+        if self._generation == 1:
+            msg = await self._channel_queue.get()
+            yield msg
+            raise ConnectionError("simulated mid-stream drop")
+        while True:
+            msg = await self._channel_queue.get()
+            yield msg
+
+    async def unsubscribe(self, _channel=None):
+        pass
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _FlakyFakeRedis:
+    """Fake whose pubsub drops the connection once (generation 1) then works normally
+    (generation 2+) — the "fails once then works" double the fix-round brief asked
+    for."""
+
+    def __init__(self):
+        self.channel_queue: asyncio.Queue = asyncio.Queue()
+        self.subscribe_count = 0
+
+    def pubsub(self):
+        self.subscribe_count += 1
+        return _DropOncePubSub(self, self.channel_queue)
+
+    async def publish(self, channel: str, payload: str):
+        await self.channel_queue.put({"type": "message", "channel": channel, "data": payload})
+
+
+async def test_reader_reconnects_after_mid_stream_drop_and_resumes_delivery(monkeypatch):
+    """Finding (a): a mid-stream RedisError/OSError must not end the reader task — it
+    must reconnect and resume relaying, instead of leaving the listener's queue silent
+    for the rest of the SSE connection."""
+    import app.services.sse_broker as sse_broker_module
+
+    monkeypatch.setattr(sse_broker_module, "_READER_BACKOFF_SCHEDULE_S", (0.01, 0.01, 0.01, 0.01))
+
+    b = SSEBroker()
+    fake_redis = _FlakyFakeRedis()
+
+    async def _fake_get_redis():
+        return fake_redis  # always "available" -- only the pubsub stream itself drops
+
+    b._get_redis = _fake_get_redis
+
+    gen = b.listen("flaky-chan")
+    received = []
+
+    async def _consume_two():
+        async for msg in gen:
+            received.append(msg)
+            if len(received) == 2:
+                return
+
+    consume_task = asyncio.create_task(_consume_two())
+    await asyncio.sleep(0)  # let listen() spawn the reader and subscribe (generation 1)
+
+    await fake_redis.publish("sse:flaky-chan", json.dumps({"event": "one", "data": "1"}))
+    # generation 1 delivers "one", then raises on its next read -- the simulated drop.
+    # The reader reconnects (generation 2) and "two" is only deliverable after that.
+    await fake_redis.publish("sse:flaky-chan", json.dumps({"event": "two", "data": "2"}))
+
+    await asyncio.wait_for(consume_task, timeout=3)
+    assert received == [{"event": "one", "data": "1"}, {"event": "two", "data": "2"}]
+    assert fake_redis.subscribe_count == 2  # one initial connect + one reconnect
+
+    await gen.aclose()
+
+
+async def test_listener_started_during_outage_attaches_after_recovery(monkeypatch):
+    """Finding (b): listen() must not evaluate _get_redis() only once at entry — a
+    listener that starts while Redis is down (no client yet) must still attach once
+    Redis recovers, instead of staying cross-process-deaf for the life of the
+    connection."""
+    import app.services.sse_broker as sse_broker_module
+
+    monkeypatch.setattr(sse_broker_module, "_READER_BACKOFF_SCHEDULE_S", (0.01, 0.01, 0.01, 0.01))
+
+    b = SSEBroker()
+    fake_redis = _FakeRedis()
+    calls = 0
+
+    async def _fake_get_redis():
+        nonlocal calls
+        calls += 1
+        # First few calls simulate the outage (no client yet); recovers after that.
+        return None if calls <= 2 else fake_redis
+
+    b._get_redis = _fake_get_redis
+
+    gen = b.listen("recovers-chan")
+    consume_task = asyncio.create_task(gen.__anext__())
+    await asyncio.sleep(0.1)  # let the reader retry through the simulated outage
+
+    await fake_redis.publish("sse:recovers-chan", json.dumps({"event": "e", "data": "d"}))
+
+    msg = await asyncio.wait_for(consume_task, timeout=3)
+    assert msg == {"event": "e", "data": "d"}
+    assert calls > 2  # it kept retrying instead of giving up after the first None
+
+    await gen.aclose()
+
+
+async def test_reader_cancellation_during_backoff_exits_promptly():
+    """A listener disconnecting while the reader is mid-backoff must not block cleanup —
+    asyncio.sleep responds to task cancellation immediately, so listen()'s finally never
+    waits out a pending backoff (uses the REAL 1s-first-step schedule, unpatched, so a
+    regression back to a blocking/uncancellable wait would show up as a slow test, not a
+    silent pass).
+
+    No message is ever delivered here (Redis is never available), so the listener's own
+    ``gen.__anext__()`` is permanently parked at ``await q.get()`` — cancelling that
+    *task* (not calling ``gen.aclose()``, which would race a still-pending anext()) is
+    what simulates the SSE request handler being torn down mid-connection; the
+    CancelledError it raises drives the exact same listen()-finally cleanup chain.
+    """
+    b = SSEBroker()
+
+    async def _fake_get_redis():
+        return None  # Redis never available -- reader stays parked in its backoff loop
+
+    b._get_redis = _fake_get_redis
+
+    gen = b.listen("never-connects-chan")
+    consume_task = asyncio.create_task(gen.__anext__())
+    await asyncio.sleep(0)  # let listen() spawn the reader; it's now sleeping its ~1s backoff
+
+    start = time.monotonic()
+    consume_task.cancel()  # simulates the SSE client disconnecting mid-backoff
+    with contextlib.suppress(asyncio.CancelledError):
+        await consume_task
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.5  # nowhere near the ~1s backoff -- cancellation was immediate
+
+
+async def test_publish_during_outage_reaches_local_listener_same_process():
+    """Local fallback must keep working for the whole outage window: publish() falls
+    back to _publish_local() when Redis is unavailable, and that write lands on the SAME
+    queue listen() reads from (subscribe() registers one queue regardless of Redis
+    status) — so a listener in THIS process is never silent during an outage. A listener
+    in a *different* worker process would still miss it (no Redis to relay through);
+    that loss is the accepted, now explicitly-scoped, remainder of the outage risk."""
+    b = SSEBroker()
+
+    async def _fake_get_redis():
+        return None  # Redis unavailable for the whole test
+
+    b._get_redis = _fake_get_redis
+
+    gen = b.listen("outage-chan")
+    received = []
+
+    async def _consumer():
+        async for msg in gen:
+            received.append(msg)
+            break
+
+    async def _producer():
+        await asyncio.sleep(0)
+        await b.publish("outage-chan", "still-here", "payload")
+
+    await asyncio.gather(_consumer(), _producer())
+    assert received == [{"event": "still-here", "data": "payload"}]
 
     await gen.aclose()
 


### PR DESCRIPTION
Phase 4 (do-all plan) infra stream. **Merges FIRST and deploys ALONE** — the other Phase-4 PRs hold until this deploy verifies.

## What

- **SSE over Redis pub/sub** (in-process fallback when Redis is absent): search streaming and notification streams now work across processes — the prerequisite for everything below. The reader self-heals with bounded backoff after Redis blips.
- **Graph webhook replay cache shared via Redis** (SET NX EX 300; per-process fallback preserved).
- **APScheduler moved to a dedicated container** behind `RUN_SCHEDULER` (default "1" = old behavior = instant rollback knob). App workers run no scheduler, no seeds, no deferred backfills. deploy.sh builds/recreates/rolls back the scheduler and enforces the exactly-one-scheduler invariant (patient 120s poll; the transition-deploy rollback refuses to recreate the old image under the new command — it stops everything loudly rather than risk two schedulers double-sending approval emails).
- **Migrations advisory-locked** (`docker-entrypoint-migrate.py`): N containers can race `alembic upgrade head` safely.
- **uvicorn `--workers 2`** with an env-tunable DB pool (5+5 per process; budget 70/100 documented in code).
- `/health` reports `"external (scheduler service)"` honestly on scheduler-free workers.

## Evidence

- Full suite in worktree: `24757 passed, 37 skipped, 0 FAILED` (the gate's one failure was a genuine this-branch env-doc gap, root-caused and fixed).
- 5 task reviews (3 fix rounds: SSE self-heal; rollback/alembic/resources/health; transition-rollback + patient invariant) + whole-branch final review with a step-by-step transition-deploy trace + re-reviewed fix wave.
- Known deferral (ledgered, pre-wipe fix required): the admin/agent seed check-then-insert race matters only on a freshly WIPED DB's first multi-worker boot — goes in the Phase-6 wipe runbook.

## Post-deploy verification (controller runs)

/health 200 · exactly one "APScheduler configured" (scheduler container), zero in app · 2 worker processes in app · SSE stream opens · `pg_stat_activity` count sane · an interval job observed firing · rollback knob intact (RUN_SCHEDULER default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkHRARudqRbahKpsFDmUQa